### PR TITLE
[WIP] Changes for type-checking

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -122,10 +122,10 @@ def generate_class_header(used_classes, c):
     source.append("public:")
     source.append("")
 
-    # ___get_class_name
-    source.append("\tstatic inline char *___get_class_name() { return (char *) \"" + strip_name(c["name"]) + "\"; }")
+    # __get_class_name
+    source.append("\tstatic inline char *__get_class_name() { return (char *) \"" + strip_name(c["name"]) + "\"; }")
 
-    source.append("\tstatic inline Object *___get_from_variant(Variant a) { return (Object *) a; }")
+    #source.append("\tstatic inline Object *__get_from_variant(Variant a) { return (Object *) a; }")
 
     enum_values = []
 

--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -1,6 +1,7 @@
 #ifndef DEFS_H
 #define DEFS_H
 
+#define GODOT_TYPE_CHECKS
 
 namespace godot {
 
@@ -61,6 +62,7 @@ enum Error {
 }
 
 #include <stdio.h>
+#include <malloc.h>
 
 typedef float real_t;
 

--- a/include/core/GodotScript.h
+++ b/include/core/GodotScript.h
@@ -1,0 +1,124 @@
+#ifndef GODOTSCRIPT_H
+#define GODOTSCRIPT_H
+
+#include <core/Variant.hpp>
+#include "Object.hpp"
+
+// Place this into GodotScript<T>-derivated classes
+#define GODOT_CLASS(Name)                                             \
+	public:                                                           \
+		inline static const char *__get_class_name() {                \
+			return static_cast<const char *>(#Name);                  \
+		}                                                             \
+		inline static size_t __get_base_typetag() {                   \
+			return 0;                                                 \
+		}                                                             \
+	private:
+
+// Place this into classes inheriting GodotScript<T>-derivated classes
+#define GODOT_SUBCLASS(Name, Base)                                    \
+	public:                                                           \
+		inline static const char *__get_class_name() {                \
+			return static_cast<const char *>(#Name);                  \
+		}                                                             \
+		inline static size_t __get_base_typetag() {                   \
+			return __get_type_tag<Base>();                            \
+		}                                                             \
+	private:
+
+namespace godot {
+
+
+// Typetags gives us a chance to verify the type of the NativeScript void* pointer.
+// TODO this must ideally be a GDNative feature, because exploiting Object meta is slow and annoying
+
+template <class T>
+inline size_t __get_typetag() {
+	// TODO For some reason static_cast doesn't work... maybe this should be reviewed
+	return (size_t)(&T::__get_class_name);
+}
+
+inline size_t __get_typetag(Object *obj) {
+	return obj->get_meta("&");
+}
+
+template <class T>
+inline void __add_typetag(Object *obj) {
+	obj->set_meta("&", __get_typetag<T>());
+}
+
+inline void __remove_typetag(Object *obj) {
+	obj->set_meta("&", Variant());
+}
+
+
+// Your custom C++ classes Godot will access should inherit this,
+// where T is the type of the Godot object you want to extend
+template<class T>
+class GodotScript {
+public:
+	T *owner;
+
+	// GodotScript() {}
+
+	void _init() {}
+
+	// Don't forget to call the base if you override this function.
+	// Also, don't register it
+	virtual void _notification(int p_what) {
+		if(p_what == Object::NOTIFICATION_PREDELETE) {
+			__remove_typetag(owner);
+		}
+	}
+
+	static const char *__get_base_class_name()
+	{
+		return T::__get_class_name();
+	}
+
+	static T *__instance_base() {
+		return new T;
+	}
+
+	static void _register_methods() {}
+};
+
+// Creates a new script the same way it would happen in Godot scripting:
+// The script is created and attached to a new object of the type it extends
+template <class T>
+T *__instance_script() {
+	// TODO use Godot allocator
+	auto *s = new T();
+	auto *b = T::__instance_base(); // made that function so we can rule out a template param
+	__add_typetag<T>(b);
+	s->owner = b;
+	s->_init();
+	return s;
+}
+
+// Called by the engine
+template <class T>
+T *__instance_script_on_existing_object(godot_object *p) {
+	// TODO use Godot allocator
+	T *s = new T();
+	*(godot_object **) &s->owner = p;
+	__add_typetag<T>(s->owner);
+	s->_init();
+	return s;
+}
+
+// Called by the engine
+template <class T>
+void __destroy_script(godot_object *p) {
+	// No need to check the type here, we should be able to trust the engine
+
+	// Argh we can't remove the typetag from here, the Object is being destroyed...
+	//__remove_typetag((Object*)p);
+
+	T *s = (T*)p;
+	delete s;
+}
+
+}
+
+#endif // GODOTSCRIPT_H

--- a/include/core/ObjectUtil.hpp
+++ b/include/core/ObjectUtil.hpp
@@ -1,0 +1,85 @@
+#ifndef GODOT_OBJECTUTIL_HPP
+#define GODOT_OBJECTUTIL_HPP
+
+#include "Traits.hpp"
+#include "GodotScript.h"
+#include "TagDB.hpp"
+
+namespace godot {
+
+// In Godot, script inheritance is seamless.
+// But using the C++ bindings, Godot objects and "script" classes are different (for now).
+// This utility unifies some functions in a non-intrusive way.
+
+// For GodotScript<T>-derivated classes
+template<typename T, typename = void>
+struct ObjectUtil {
+
+	static inline T *instance() {
+		return T::__instance_script();
+	}
+
+	template<class C>
+	static inline C *cast_to(T *obj) {
+		// TODO Ability to cast from a GodotScript to its base Godot class
+#ifdef GODOT_TYPE_CHECKS
+		// Note: it is currently possible to use dynamic_cast because GodotScript has a virtual function.
+		// However we can't count on this if it gets removed one day.
+		return dynamic_cast<C*>(obj);
+#else
+		return static_cast<C*>(obj);
+#endif
+	}
+
+	static T *get_from_variant(const Variant &a) {
+		Object *obj = (Object*)a;
+#ifdef GODOT_TYPE_CHECKS
+		if(obj == nullptr)
+			return nullptr;
+		size_t tag = __get_typetag(obj);
+		if(!_TagDB::is_tag_compatible(tag, __get_typetag<T>()))
+			return nullptr;
+#endif
+		return (T *) godot::nativescript_api->godot_nativescript_get_userdata(obj);
+	}
+};
+
+// For godot::Object-derivated classes
+template<typename T>
+struct ObjectUtil<T, typename enable_if<is_base_of<Object, T>::value>::type> {
+
+	static inline T *instance() {
+		return new T;
+	}
+
+	template<class C>
+	static inline C *cast_to(T *obj) {
+		// TODO Ability to cast from a Godot class to its extending GodotScript
+#ifdef GODOT_TYPE_CHECKS
+		if(obj == nullptr)
+			return nullptr;
+		if(T::__get_class_name == C::__get_class_name)
+			return (C*)obj;
+		if(obj->is_class(C::__get_class_name()))
+			return (C*)obj;
+		return nullptr;
+#else
+		return (C*)obj;
+#endif
+	}
+
+	static T *get_from_variant(const Variant &a) {
+		Object *obj = (Object*)a;
+#ifdef GODOT_TYPE_CHECKS
+		if(obj == nullptr)
+			return nullptr;
+		if(!obj->is_class(T::__get_class_name()))
+			return nullptr;
+#endif
+		return (T *) obj;
+	}
+};
+
+}
+
+#endif // GODOT_OBJECTUTIL_HPP

--- a/include/core/TagDB.hpp
+++ b/include/core/TagDB.hpp
@@ -1,0 +1,17 @@
+#ifndef GODOT_TAGDB_HPP
+#define GODOT_TAGDB_HPP
+
+#include <stdlib.h>
+
+namespace godot {
+namespace _TagDB {
+
+// Use this only on class registration. The DB must be read-only after that.
+void add(size_t p_tag, size_t p_base_tag = 0);
+
+bool is_tag_compatible(size_t p_tag, size_t p_dst_tag);
+
+}
+}
+
+#endif // GODOT_TAGDB_HPP

--- a/include/core/Traits.hpp
+++ b/include/core/Traits.hpp
@@ -1,0 +1,82 @@
+#ifndef GODOT_TRAITS_H
+#define GODOT_TRAITS_H
+
+#include "Variant.hpp"
+
+namespace godot {
+
+template<typename T>
+struct VariantTraits { };
+
+#define VARIANT_TRAITS(m_ctype, m_id)      \
+	template <>                            \
+	struct VariantTraits<m_ctype> {        \
+		static String str() {              \
+			return String(#m_ctype);       \
+		}                                  \
+		static int id() {                  \
+			return m_id;                   \
+		}                                  \
+	}
+
+VARIANT_TRAITS(bool, Variant::BOOL);
+VARIANT_TRAITS(int, Variant::INT);
+VARIANT_TRAITS(float, Variant::REAL);
+VARIANT_TRAITS(Vector2, Variant::VECTOR2);
+VARIANT_TRAITS(Vector3, Variant::VECTOR3);
+VARIANT_TRAITS(Color, Variant::COLOR);
+VARIANT_TRAITS(String, Variant::STRING);
+
+VARIANT_TRAITS(PoolByteArray, Variant::POOL_BYTE_ARRAY);
+VARIANT_TRAITS(PoolIntArray, Variant::POOL_INT_ARRAY);
+VARIANT_TRAITS(PoolRealArray, Variant::POOL_REAL_ARRAY);
+VARIANT_TRAITS(PoolVector2Array, Variant::POOL_VECTOR2_ARRAY);
+VARIANT_TRAITS(PoolVector3Array, Variant::POOL_VECTOR3_ARRAY);
+VARIANT_TRAITS(PoolColorArray, Variant::POOL_COLOR_ARRAY);
+VARIANT_TRAITS(PoolStringArray, Variant::POOL_STRING_ARRAY);
+
+VARIANT_TRAITS(Array, Variant::ARRAY);
+VARIANT_TRAITS(Dictionary, Variant::DICTIONARY);
+VARIANT_TRAITS(RID, Variant::_RID);
+VARIANT_TRAITS(NodePath, Variant::NODE_PATH);
+VARIANT_TRAITS(Rect2, Variant::RECT2);
+VARIANT_TRAITS(AABB, Variant::AABB);
+VARIANT_TRAITS(Transform2D, Variant::TRANSFORM2D);
+VARIANT_TRAITS(Transform, Variant::TRANSFORM);
+VARIANT_TRAITS(Basis, Variant::BASIS);
+VARIANT_TRAITS(Plane, Variant::PLANE);
+VARIANT_TRAITS(Quat, Variant::QUAT);
+
+
+template<bool C, typename T = void>
+struct enable_if {
+	typedef T type;
+};
+
+template<typename T>
+struct enable_if<false, T> { };
+
+template<typename, typename>
+struct is_same {
+	static bool const value = false;
+};
+
+template<typename A>
+struct is_same<A, A> {
+	static bool const value = true;
+};
+
+template<typename B, typename D>
+struct is_base_of {
+	static D * create_d();
+	// We exploit function overloading, these actually never get called
+	static char (& chk(B *))[1]; // Array of 1 function reference taking a B* and returning a char
+	static char (& chk(...))[2];
+	static bool const value = sizeof chk(create_d()) == sizeof(char) && // if D can be casted to B, sizeof will be 1
+							  !is_same<B    volatile const,
+									   void volatile const>::value; // B should not be void*
+};
+
+}
+
+#endif // GODOT_TRAITS_H

--- a/include/core/Variant.hpp
+++ b/include/core/Variant.hpp
@@ -20,8 +20,6 @@
 #include "Vector2.hpp"
 #include "Vector3.hpp"
 
-#include <iostream>
-
 namespace godot {
 
 class Dictionary;
@@ -49,7 +47,7 @@ public:
 		TRANSFORM2D,
 		PLANE,
 		QUAT,			// 10
-		RECT3, //sorry naming convention fail :( not like it's used often
+		AABB,
 		BASIS,
 		TRANSFORM,
 
@@ -154,7 +152,7 @@ public:
 	Variant(const Plane& p_plane);
 
 
-	Variant(const AABB& p_aabb);
+	Variant(const godot::AABB& p_aabb);
 
 	Variant(const Quat& p_quat);
 
@@ -215,7 +213,7 @@ public:
 	operator Rect2() const;
 	operator Vector3() const;
 	operator Plane() const;
-	operator AABB() const;
+	operator godot::AABB() const;
 	operator Quat() const;
 	operator Basis() const;
 	operator Transform() const;

--- a/src/core/GodotGlobal.cpp
+++ b/src/core/GodotGlobal.cpp
@@ -15,8 +15,6 @@ void Godot::print(const String& message)
 
 void Godot::print_warning(const String& description, const String& function, const String& file, int line)
 {
-	int len;
-
 	char * c_desc = description.alloc_c_string();
 	char * c_func = function.alloc_c_string();
 	char * c_file = file.alloc_c_string();
@@ -32,8 +30,6 @@ void Godot::print_warning(const String& description, const String& function, con
 
 void Godot::print_error(const String& description, const String& function, const String& file, int line)
 {
-	int len;
-
 	char * c_desc = description.alloc_c_string();
 	char * c_func = function.alloc_c_string();
 	char * c_file = file.alloc_c_string();

--- a/src/core/TagDB.cpp
+++ b/src/core/TagDB.cpp
@@ -1,0 +1,29 @@
+#include "TagDB.hpp"
+#include "Dictionary.hpp"
+
+#include <unordered_map>
+
+namespace godot {
+namespace _TagDB {
+
+// Can't use Godot Dictionary, Variant cannot contain size_t
+std::unordered_map<size_t, size_t> s_tag_to_parent;
+
+void add(size_t p_tag, size_t p_base_tag) {
+	s_tag_to_parent[p_tag] = p_base_tag;
+}
+
+bool is_tag_compatible(size_t p_tag, size_t p_dst_tag) {
+	if(p_tag == p_dst_tag)
+		return true;
+	while(true) {
+		size_t v = s_tag_to_parent[p_tag];
+		if(v == 0)
+			return false;
+		if(v == p_dst_tag)
+			return true;
+	}
+}
+
+}
+}

--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -6,8 +6,6 @@
 #include "CoreTypes.hpp"
 #include "GodotGlobal.hpp"
 
-#include <iostream>
-
 namespace godot {
 
 Variant::Variant()
@@ -99,7 +97,7 @@ Variant::Variant(const Plane& p_plane)
 }
 
 
-Variant::Variant(const AABB& p_aabb)
+Variant::Variant(const godot::AABB& p_aabb)
 {
 	godot::api->godot_variant_new_aabb(&_godot_variant, (godot_aabb *) &p_aabb);
 }
@@ -274,10 +272,10 @@ Variant::operator Plane() const
 	godot_plane s = godot::api->godot_variant_as_plane(&_godot_variant);
 	return *(Plane *) &s;
 }
-Variant::operator AABB() const
+Variant::operator godot::AABB() const
 {
 	godot_aabb s = godot::api->godot_variant_as_aabb(&_godot_variant);
-	return *(AABB *) &s;
+	return *(godot::AABB *) &s;
 }
 Variant::operator Quat() const
 {


### PR DESCRIPTION
- Allow to use Ref<T> on GodotScripts extending reference types
- Type checks on primitives for calls from Godot
- Type checks on Godot objects using is_class
- Type checks on GodotScripts using tags and dynamic_cast
- _notification() is now virtual due to the above, don't register it
- Added argument count check
- Rect3 Variant type renamed to AABB
- Files reorganized a bit

Also introduces usage of standard library because I couldn't use a Godot container for typetag inheritance lookup.

Important note:
This has been my work-in-progress so far, some parts are untested.
Also, `GodotScript<T>` could disappear in a future refactoring after we discussed it at GodotCon (@karroffel & @reduz) so this PR may become partially irrelevant and merged into a branch.