### PR TITLE
[WIP] Adding UWP support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -80,6 +80,47 @@ elif target_platform == 'osx':
     env.Append(CCFLAGS = [ '-g','-O3', '-std=c++14', '-arch', 'x86_64' ])
     env.Append(LINKFLAGS = [ '-arch', 'x86_64', '-framework', 'Cocoa', '-Wl,-undefined,dynamic_lookup' ])
 
+elif target_platform == 'uwp':
+    # blatently stolen from godot uwp platform, I have no idea what half of this does...
+    vc_base_path = os.environ['VCTOOLSINSTALLDIR'] if "VCTOOLSINSTALLDIR" in os.environ else os.environ['VCINSTALLDIR']
+
+    if target == "debug":
+        env.Append(CCFLAGS=['/Zi', '/DDEBUG_ENABLED', '/DDEBUG_MEMORY_ENABLED'])
+        env.Append(CPPFLAGS=['/MDd'])
+        env.Append(LINKFLAGS=['/DEBUG'])
+    else:
+        env.Append(CPPFLAGS=['/O2', '/GL'])
+        env.Append(CPPFLAGS=['/MD'])
+        env.Append(LINKFLAGS=['/LTCG'])
+
+    if (target_arch == '32'):
+        env.Append(LINKFLAGS=['/MACHINE:X86'])
+    else:
+        env.Append(LINKFLAGS=['/MACHINE:X64'])
+
+    env.Append(CPPPATH=['#platform/uwp', '#drivers/windows'])
+    env.Append(CCFLAGS=['/DUWP_ENABLED', '/DWINDOWS_ENABLED', '/DTYPED_METHOD_BIND'])
+    env.Append(CCFLAGS=['/DGLES_ENABLED', '/DGL_GLEXT_PROTOTYPES', '/DEGL_EGLEXT_PROTOTYPES', '/DANGLE_ENABLED'])
+    winver = "0x0602" # Windows 8 is the minimum target for UWP build
+    env.Append(CCFLAGS=['/DWINVER=%s' % winver, '/D_WIN32_WINNT=%s' % winver])
+
+    env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/store/references'])
+    env.Append(CPPFLAGS=['/AI', vc_base_path + 'lib/x86/store/references'])
+
+    env.Append(CCFLAGS='/FS /MP /GS /wd"4453" /wd"28204" /wd"4291" /Zc:wchar_t /Gm- /fp:precise /D "_UNICODE" /D "UNICODE" /D "WINAPI_FAMILY=WINAPI_FAMILY_APP" /errorReport:prompt /WX- /Zc:forScope /Gd /EHsc /nologo'.split())
+    env.Append(CXXFLAGS='/ZW /FS'.split())
+    env.Append(CCFLAGS=['/AI', vc_base_path + '\\vcpackages', '/AI', os.environ['WINDOWSSDKDIR'] + '\\References\\CommonConfiguration\\Neutral'])
+
+    env.Append(LINKFLAGS=['/MANIFEST:NO', '/NXCOMPAT', '/DYNAMICBASE', '/WINMD', '/APPCONTAINER', '/ERRORREPORT:PROMPT', '/NOLOGO', '/TLBID:1', '/NODEFAULTLIB:"kernel32.lib"', '/NODEFAULTLIB:"ole32.lib"'])
+
+    LIBS = [
+        'WindowsApp',
+        'mincore',
+    ]
+    env.Append(LINKFLAGS=[p + ".lib" for p in LIBS])
+
+    result_name += '.uwp.' + target_arch
+
 
 env.Append(CPPPATH=['.', godot_headers, 'include', 'include/core'])
 


### PR DESCRIPTION
Working on UWP support for this as well, it compiles but can't test because I'm unable to get Godot 3.0.3 RC3 to actually export the DLL and thats the only way to run UWP apps.

Also VC really doesn't like compiling this as a static library with a bunch of the switches in here, and I think a few switches should only be in compiling the final DLL not in here, but as I mostly copied this from the UWP platform in Godot I'm not sure if all the switches make sense. Microsoft really assumes you just use their IDE.

I've got similar changes for our tutorial ready to go once we can confirm this actually works. 