### PR TITLE
Fixed Android build for older NDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin
 *.creator.user
 *.files
 *.includes
+
+# NDK temp toolchain
+tempchain


### PR DESCRIPTION
This PR fixes building for Android with NDK versions older than revision 19. Previously, the SConstruct file assumed that the NDK provided by the user was capable of in-place toolchain usage. Now, the SConstruct file will check for the `source.properties` file in the NDK folder, retrieve the revision number, and apply special cases depending on the NDK revision number.

This PR adds the following Scons options:
- `ndk_toolchain`: Ignores most Android options and uses the given standalone toolchain to compile.

There are a number of special cases depending on NDK revision number:
- When `ndk_version < 19`, SConstruct will construct a toolchain using `make_standalone_toolchain.py` under the directory `tempchain`. Constructed toolchains are separated and cached by NDK version, architecture, and API level (i.e. `tempchain/ndk16-armv7-18`).
- ~~When `ndk_version < 12`, SConstruct will use `make-standalone-toolchain.sh` instead (`make_standalone_toolchain.py` added in revision 12). Errors out on Windows.~~ Minimum `ndk_version` is now `17`
- When `ndk_toolchain` is defined with a pre-made standalone toolchain, SConstruct will skip toolchain construction and use `ndk_toolchain`.
- ~~If the toolchain does not contain clang scripts (gcc is used in older NDK revisions), SConstruct will attempt to use gcc instead.~~ Minimum `ndk_version` is now `17`

NOTE: ~~Constructed toolchains are not cleaned up by `scons -c`. I can add this functionality if requested.~~ Added.

This PR has been tested on Windows 10 64-bit, Lubuntu, and macOS High Sierra, with NDK revisions 10, 11, 16, and 20.