### PR TITLE
Reset reference counter to fix memory leak

### DIFF
--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -43,10 +43,14 @@ public:                                                                         
 		script->set_library(godot::get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));                                             \
 		script->set_class_name(#Name);                                                                                                              \
 		Name *instance = godot::as<Name>(script->new_());                                                                                           \
+		godot::Reference *ref = (godot::Reference *)instance;                                                                                       \
+		if (ref) {                                                                                                                                  \
+			ref->reset_ref();                                                                                                                       \
+		}                                                                                                                                           \
 		return instance;                                                                                                                            \
 	}                                                                                                                                               \
-	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                                                                          \
-	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }                                                                     \
+	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                                                                           \
+	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }                                                                      \
 	inline static const char *___get_base_type_name() { return Base::___get_class_name(); }                                                         \
 	inline static Object *___get_from_variant(godot::Variant a) { return (godot::Object *)godot::as<Name>(godot::Object::___get_from_variant(a)); } \
                                                                                                                                                     \


### PR DESCRIPTION
This needs to be merged after https://github.com/GodotNativeTools/godot_headers/pull/60 is merged.
This is part of the fix for GodotNativeTools/godot-cpp#215.