### PR TITLE
Add C conversion constructors and fix new leak

### DIFF
--- a/include/core/Array.hpp
+++ b/include/core/Array.hpp
@@ -57,6 +57,11 @@ class Object;
 class Array {
 	godot_array _godot_array;
 
+	friend class Variant;
+	inline explicit Array(const godot_array &other) {
+		_godot_array = other;
+	}
+
 public:
 	Array();
 	Array(const Array &other);

--- a/include/core/Dictionary.hpp
+++ b/include/core/Dictionary.hpp
@@ -12,6 +12,11 @@ namespace godot {
 class Dictionary {
 	godot_dictionary _godot_dictionary;
 
+	friend Variant::operator Dictionary() const;
+	inline explicit Dictionary(const godot_dictionary &other) {
+		_godot_dictionary = other;
+	}
+
 public:
 	Dictionary();
 	Dictionary(const Dictionary &other);

--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -261,14 +261,12 @@ Variant::operator RID() const {
 }
 
 Variant::operator Dictionary() const {
-	Dictionary ret;
-	*(godot_dictionary *)&ret = godot::api->godot_variant_as_dictionary(&_godot_variant);
+	Dictionary ret(godot::api->godot_variant_as_dictionary(&_godot_variant));
 	return ret;
 }
 
 Variant::operator Array() const {
-	Array ret;
-	*(godot_array *)&ret = godot::api->godot_variant_as_array(&_godot_variant);
+	Array ret(godot::api->godot_variant_as_array(&_godot_variant));
 	return ret;
 }
 


### PR DESCRIPTION
#355 fixed a leak caused by copy constructors. However, for Array and Dictionary, the fix now calls default constructors that allocate memory for an empty array/dictionary, again resulting in a leak. The other types fixed by #355 aren't affected - their default constructors do nothing.

The only way I can think of to convert a `godot_array` to a `godot::Array` *without* calling either constructor is to add a new `Array(godot_array a)` constructor to do the conversion. This way is clean and safe, but exposes part of the C API to C++. If we want to avoid that, maybe we can find a better way.