### PR TITLE
Fix Vector's Bounce Reflect

### DIFF
--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -180,8 +180,8 @@ struct Vector2 {
 		return -reflect(p_normal);
 	}
 
-	inline Vector2 reflect(const Vector2 &p_vec) const {
-		return p_vec - *this * this->dot(p_vec) * 2.0;
+	inline Vector2 reflect(const Vector2 &p_normal) const {
+		return -(*this -p_normal * this->dot(p_normal) * 2.0);
 	}
 
 	inline real_t angle() const {

--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -181,7 +181,7 @@ struct Vector2 {
 	}
 
 	inline Vector2 reflect(const Vector2 &p_normal) const {
-		return -(*this -p_normal * this->dot(p_normal) * 2.0);
+		return -(*this - p_normal * this->dot(p_normal) * 2.0);
 	}
 
 	inline real_t angle() const {

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -238,8 +238,8 @@ struct Vector3 {
 		return v;
 	}
 
-	inline Vector3 reflect(const Vector3 &by) const {
-		return by - *this * this->dot(by) * 2.f;
+	inline Vector3 reflect(const Vector3 &p_normal) const {
+		return -(*this - p_normal  * this->dot(p_normal) * 2.f);
 	}
 
 	inline Vector3 rotated(const Vector3 &axis, const real_t phi) const {

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -239,7 +239,7 @@ struct Vector3 {
 	}
 
 	inline Vector3 reflect(const Vector3 &p_normal) const {
-		return -(*this - p_normal  * this->dot(p_normal) * 2.f);
+		return -(*this - p_normal * this->dot(p_normal) * 2.0);
 	}
 
 	inline Vector3 rotated(const Vector3 &axis, const real_t phi) const {


### PR DESCRIPTION
Fixes Vector 2 and 3 bounce and reflect methods to match gdscript


```c++
//C++
Vector3 v = Vector3(0.003606, -0.081427, -0.045547);
Vector3 n = Vector3(0, -1, 0);
Vector3 b = v.bounce(n);
Vector3 r = v.reflect(n);

Vector2 v2 = Vector2(0.003606, -0.081427);
Vector2 n2 = Vector2(0, -1);
Vector2 b2 = v2.bounce(n2);
Vector2 r2 = v2.reflect(n2);

Godot::print("V3Bounce");
Godot::print(b);

Godot::print("V3Reflect");
Godot::print(r);

Godot::print("V2Bounce");
Godot::print(b2);

Godot::print("V2Reflect");
Godot::print(r2);

```
```GDScript
#GDScript
var v = Vector3(0.003606, -0.081427, -0.045547)
var n = Vector3(0, -1, 0)

var b = v.bounce(n)
var r = v.reflect(n)

print("V3Bounce")
print(b)
print("V3Reflect")
print(r)

var v2 = Vector2(0.003606, -0.081427)
var n2 = Vector2(0, -1)

var b2 = v2.bounce(n2)
var r2 = v2.reflect(n2)

print("V2Bounce")
print(b2)
print("V2Reflect")
print(r2)
```

will print 



```
c++
V3Bounce
0.003606, 0.081427, -0.045547
V3Reflect
-0.003606, -0.081427, 0.045547
V2Bounce
0.003606, 0.081427
V2Reflect
-0.003606, -0.081427


gdscript
V3Bounce
(0.003606, 0.081427, -0.045547)
V3Reflect
(-0.003606, -0.081427, 0.045547)
V2Bounce
(0.003606, 0.081427)
V2Reflect
(-0.003606, -0.081427)
```

I used the math fix from
Co-Authored-By: Bruno Campos <brunocu@msn.com>