### PR TITLE
Fix default value of `bits` misnaming resulting library

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -68,6 +68,17 @@ else:
         'platform=<platform>'
     )
 
+env = Environment(ENV = os.environ)
+
+is64 = sys.maxsize > 2**32
+if (
+    env['TARGET_ARCH'] == 'amd64' or
+    env['TARGET_ARCH'] == 'emt64' or
+    env['TARGET_ARCH'] == 'x86_64' or
+    env['TARGET_ARCH'] == 'arm64-v8a'
+):
+    is64 = True
+
 opts = Variables([], ARGUMENTS)
 opts.Add(EnumVariable(
     'platform',
@@ -79,8 +90,8 @@ opts.Add(EnumVariable(
 opts.Add(EnumVariable(
     'bits',
     'Target platform bits',
-    'default',
-    ('default', '32', '64')
+    '64' if is64 else '32',
+    ('32', '64')
 ))
 opts.Add(BoolVariable(
     'use_llvm',
@@ -145,21 +156,8 @@ opts.Add(
     os.environ.get("ANDROID_NDK_ROOT", None)
 )
 
-env = Environment(ENV = os.environ)
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
-
-is64 = sys.maxsize > 2**32
-if (
-    env['TARGET_ARCH'] == 'amd64' or
-    env['TARGET_ARCH'] == 'emt64' or
-    env['TARGET_ARCH'] == 'x86_64' or
-    env['TARGET_ARCH'] == 'arm64-v8a'
-):
-    is64 = True
-
-if env['bits'] == 'default':
-    env['bits'] = '64' if is64 else '32'
 
 # This makes sure to keep the session environment variables on Windows.
 # This way, you can run SCons in a Visual Studio 2017 prompt and it will find


### PR DESCRIPTION
Fixes https://github.com/GodotNativeTools/godot-cpp/issues/381

I went for a slightly different fix than mentionned in the issue:
now the default value of `bits` is dynamically chosen to be `32` or `64` based on auto-detection.

This fix is slightly compatibility breaking, as you won't be able to specify `bits = default`. Let me know if you prefer to preserve this ability.