### PR TITLE
Fixed cmake source file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,23 +141,45 @@ else()
 endif()
 
 message(STATUS "Generating Bindings")
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_CUSTOM_API_FILE}\", ${GENERATE_BINDING_PARAMETERS})"
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_CUSTOM_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", headers=True)"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	RESULT_VARIABLE GENERATION_RESULT
-	OUTPUT_VARIABLE GENERATION_OUTPUT)
-message(STATUS ${GENERATION_RESULT} ${GENERATION_OUTPUT})
+	RESULT_VARIABLE HEADERS_FILE_LIST_RESULT
+	OUTPUT_VARIABLE HEADERS_FILE_LIST
+)
+set(HEADERS_FILE_LIST ${HEADERS_FILE_LIST})
+
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_CUSTOM_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", sources=True)"
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	RESULT_VARIABLE SOURCES_FILE_LIST_RESULT
+	OUTPUT_VARIABLE SOURCES_FILE_LIST
+)
+set(SOURCES_FILE_LIST ${SOURCES_FILE_LIST})
+
+add_custom_command(OUTPUT ${HEADERS_FILE_LIST} ${SOURCES_FILE_LIST}
+		COMMAND "${PYTHON_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_CUSTOM_API_FILE}\", \"${GENERATE_BINDING_PARAMETERS}\", \"${CMAKE_CURRENT_BINARY_DIR}\")"
+		VERBATIM
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		MAIN_DEPENDENCY ${GODOT_CUSTOM_API_FILE}
+		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/binding_generator.py
+		COMMENT Generating Bindings
+)
 
 # Get Sources
 file(GLOB_RECURSE SOURCES src/*.c**)
 file(GLOB_RECURSE HEADERS include/*.h**)
 
 # Define our godot-cpp library
-add_library(${PROJECT_NAME} ${SOURCES} ${HEADERS})
+add_library(${PROJECT_NAME}
+		${SOURCES}
+		${SOURCES_FILE_LIST}
+		${HEADERS}
+		${HEADERS_FILE_LIST}
+)
 target_include_directories(${PROJECT_NAME}
 	PUBLIC
 	include
 	include/core
-	include/gen
+	${CMAKE_CURRENT_BINARY_DIR}/include/gen/
 )
 
 # Put godot headers as SYSTEM PUBLIC to exclude warnings from irrelevant headers


### PR DESCRIPTION
This is a resubmission of an old Pull Request that stagnated (because of some mysterious Travis error):
https://github.com/GodotNativeTools/godot-cpp/pull/368

The code was rebased to the latest master

----

I needed to fix the file generation in the `CMakeLists.txt` for my own project.

The file generation currently regenerates sources and headers every time any `CMakeLists.txt` is modified and it takes a long time to recompile. With my modification the generation happens only when necessary.

Another thing I needed to modify is that the generation of any intermediate file should go into the build folder, not into the source folder. For this I needed to modify the `binding_generator.py`.

If you need me to modify/improve anything of this pull request don't hesitate to ask. 