### PR TITLE
Fix dangling pointer in custom Reference _new

### DIFF
--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -42,11 +42,15 @@ public:                                                                         
 		godot::NativeScript *script = godot::NativeScript::_new();                                                                                  \
 		script->set_library(godot::get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));                                             \
 		script->set_class_name(#Name);                                                                                                              \
-		Name *instance = godot::as<Name>(script->new_());                                                                                           \
+		Variant instance_variant = script->new_();                                                                                                  \
+		Reference *instance_ref = Object::cast_to<Reference>(Object::___get_from_variant(instance_variant));                                        \
+		if (instance_ref)                                                                                                                           \
+			instance_ref->reference();                                                                                                              \
+		Name *instance = godot::as<Name>(instance_variant);                                                                                         \
 		return instance;                                                                                                                            \
 	}                                                                                                                                               \
-	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                                                                          \
-	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }                                                                     \
+	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                                                                           \
+	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }                                                                      \
 	inline static const char *___get_base_type_name() { return Base::___get_class_name(); }                                                         \
 	inline static Object *___get_from_variant(godot::Variant a) { return (godot::Object *)godot::as<Name>(godot::Object::___get_from_variant(a)); } \
                                                                                                                                                     \
@@ -62,7 +66,11 @@ public:                                                                         
 		godot::NativeScript *script = godot::NativeScript::_new();                                                                                  \
 		script->set_library(godot::get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));                                             \
 		script->set_class_name(#Name);                                                                                                              \
-		Name *instance = godot::as<Name>(script->new_());                                                                                           \
+		Variant instance_variant = script->new_();                                                                                                  \
+		Reference *instance_ref = Object::cast_to<Reference>(Object::___get_from_variant(instance_variant));                                        \
+		if (instance_ref)                                                                                                                           \
+			instance_ref->reference();                                                                                                              \
+		Name *instance = godot::as<Name>(instance_variant);                                                                                         \
 		return instance;                                                                                                                            \
 	}                                                                                                                                               \
 	inline static size_t ___get_id() { return typeid(Name).hash_code(); };                                                                          \


### PR DESCRIPTION
GODOT_CLASS's `_new()` frees the pointer it's supposed to return:
```cpp
Name *instance = godot::as<Name>(script->new_());
//                │               │
//                │               └─> returns Variant: ref-count is 1
//                └─> returns Name*: ref-count drops to 0 when the Variant is destroyed
```
This PR inserts a `reference()` after the `NativeScript::new_()` call.

It does the same thing as #346, only at the location actually causing the dangling pointer, rather than in `NativeScript::new_()`. That function already works correctly, returning with a ref-count of 1.

Fixes #343 and #397 

As discussed in #215, #346, and [this comment](https://github.com/GodotNativeTools/godot-cpp/issues/215#issuecomment-549093551), there's now a memory leak of the returned Reference because `Ref(T *)` increases its ref-count to 2. Another fix such as #350 will be needed in addition to this.