### PR TITLE
Rework the way custom class instances are created from C++

### DIFF
--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -17,59 +17,118 @@
 
 #include "GodotGlobal.hpp"
 
-#include <GDNativeLibrary.hpp>
-#include <NativeScript.hpp>
-
 namespace godot {
+namespace detail {
 
-template <class T>
-T *as(const Object *obj) {
-	return (obj) ? (T *)godot::nativescript_api->godot_nativescript_get_userdata(obj->_owner) : nullptr;
-}
-
+// Godot classes are wrapped by heap-allocated instances mimicking them through the C API.
+// They all inherit `_Wrapped`.
 template <class T>
 T *get_wrapper(godot_object *obj) {
 	return (T *)godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, obj);
 }
 
-#define GODOT_CLASS(Name, Base)                                                                                                                     \
-                                                                                                                                                    \
-public:                                                                                                                                             \
-	inline static const char *___get_type_name() { return static_cast<const char *>(#Name); }                                                       \
-	enum { ___CLASS_IS_SCRIPT = 1,                                                                                                                  \
-	};                                                                                                                                              \
-	inline static Name *_new() {                                                                                                                    \
-		godot::NativeScript *script = godot::NativeScript::_new();                                                                                  \
-		script->set_library(godot::get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));                                             \
-		script->set_class_name(#Name);                                                                                                              \
-		Name *instance = godot::as<Name>(script->new_());                                                                                           \
-		return instance;                                                                                                                            \
-	}                                                                                                                                               \
-	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                                                                          \
-	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }                                                                     \
-	inline static const char *___get_base_type_name() { return Base::___get_class_name(); }                                                         \
-	inline static Object *___get_from_variant(godot::Variant a) { return (godot::Object *)godot::as<Name>(godot::Object::___get_from_variant(a)); } \
-                                                                                                                                                    \
+// Custom class instances are not obtainable by just casting the pointer to the base class they inherit,
+// partly because in Godot, scripts are not instances of the classes themselves, they are only attached to them.
+// Yet we want to "fake" it as if they were the same entity.
+template <class T>
+T *get_custom_class_instance(const Object *obj) {
+	return (obj) ? (T *)godot::nativescript_api->godot_nativescript_get_userdata(obj->_owner) : nullptr;
+}
+
+template <class T>
+inline T *create_custom_class_instance() {
+	// Usually, script instances hold a reference to their NativeScript resource.
+	// that resource is obtained from a `.gdns` file, which in turn exists because
+	// of the resource system of Godot. We can't cleanly hardcode that here,
+	// so the easiest for now (though not really clean) is to create new resource instances,
+	// individually attached to the script instances.
+
+	// We cannot use wrappers because of https://github.com/godotengine/godot/issues/39181
+	//	godot::NativeScript *script = godot::NativeScript::_new();
+	//	script->set_library(get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));
+	//	script->set_class_name(T::___get_type_name());
+
+	// So we use the C API directly.
+	static godot_class_constructor script_constructor = godot::api->godot_get_class_constructor("NativeScript");
+	static godot_method_bind *mb_set_library = godot::api->godot_method_bind_get_method("NativeScript", "set_library");
+	static godot_method_bind *mb_set_class_name = godot::api->godot_method_bind_get_method("NativeScript", "set_class_name");
+	godot_object *script = script_constructor();
+	{
+		const void *args[] = { godot::gdnlib };
+		godot::api->godot_method_bind_ptrcall(mb_set_library, script, args, nullptr);
+	}
+	{
+		const String class_name = T::___get_type_name();
+		const void *args[] = { &class_name };
+		godot::api->godot_method_bind_ptrcall(mb_set_class_name, script, args, nullptr);
+	}
+
+	// Now to instanciate T, we initially did this, however in case of Reference it returns a variant with refcount
+	// already initialized, which woud cause inconsistent behavior compared to other classes (we still have to return a pointer).
+	//Variant instance_variant = script->new_();
+	//T *instance = godot::get_custom_class_instance<T>(instance_variant);
+
+	// So we should do this instead, however while convenient, it uses unnecessary wrapper objects.
+	//	Object *base_obj = T::___new_godot_base();
+	//	base_obj->set_script(script);
+	//	return get_custom_class_instance<T>(base_obj);
+
+	// Again using the C API to do exactly what we have to do.
+	static godot_class_constructor base_constructor = godot::api->godot_get_class_constructor(T::___get_godot_base_class_name());
+	static godot_method_bind *mb_set_script = godot::api->godot_method_bind_get_method("Object", "set_script");
+	godot_object *base_obj = base_constructor();
+	{
+		const void *args[] = { script };
+		godot::api->godot_method_bind_ptrcall(mb_set_script, base_obj, args, nullptr);
+	}
+
+	return (T *)godot::nativescript_api->godot_nativescript_get_userdata(base_obj);
+}
+
+} // namespace detail
+
+// Used in the definition of a custom class where the base is a Godot class
+#define GODOT_CLASS(Name, Base)                                                             \
+                                                                                            \
+public:                                                                                     \
+	inline static const char *___get_type_name() { return #Name; }                          \
+	enum { ___CLASS_IS_SCRIPT = 1 };                                                        \
+	inline static const char *___get_godot_base_class_name() {                              \
+		return Base::___get_class_name();                                                   \
+	}                                                                                       \
+	inline static Name *_new() {                                                            \
+		return godot::detail::create_custom_class_instance<Name>();                         \
+	}                                                                                       \
+	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                   \
+	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); }              \
+	inline static const char *___get_base_type_name() { return Base::___get_class_name(); } \
+	inline static godot::Object *___get_from_variant(godot::Variant a) {                    \
+		return (godot::Object *)godot::detail::get_custom_class_instance<Name>(             \
+				godot::Object::___get_from_variant(a));                                     \
+	}                                                                                       \
+                                                                                            \
 private:
 
-#define GODOT_SUBCLASS(Name, Base)                                                                                                                  \
-                                                                                                                                                    \
-public:                                                                                                                                             \
-	inline static const char *___get_type_name() { return static_cast<const char *>(#Name); }                                                       \
-	enum { ___CLASS_IS_SCRIPT = 1,                                                                                                                  \
-	};                                                                                                                                              \
-	inline static Name *_new() {                                                                                                                    \
-		godot::NativeScript *script = godot::NativeScript::_new();                                                                                  \
-		script->set_library(godot::get_wrapper<godot::GDNativeLibrary>((godot_object *)godot::gdnlib));                                             \
-		script->set_class_name(#Name);                                                                                                              \
-		Name *instance = godot::as<Name>(script->new_());                                                                                           \
-		return instance;                                                                                                                            \
-	}                                                                                                                                               \
-	inline static size_t ___get_id() { return typeid(Name).hash_code(); };                                                                          \
-	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); };                                                                     \
-	inline static const char *___get_base_type_name() { return #Base; }                                                                             \
-	inline static Object *___get_from_variant(godot::Variant a) { return (godot::Object *)godot::as<Name>(godot::Object::___get_from_variant(a)); } \
-                                                                                                                                                    \
+// Used in the definition of a custom class where the base is another custom class
+#define GODOT_SUBCLASS(Name, Base)                                                         \
+                                                                                           \
+public:                                                                                    \
+	inline static const char *___get_type_name() { return #Name; }                         \
+	enum { ___CLASS_IS_SCRIPT = 1 };                                                       \
+	inline static const char *___get_godot_base_class_name() {                             \
+		return Base::___get_godot_base_class_name();                                       \
+	}                                                                                      \
+	inline static Name *_new() {                                                           \
+		return godot::detail::create_custom_class_instance<Name>();                        \
+	}                                                                                      \
+	inline static size_t ___get_id() { return typeid(Name).hash_code(); };                 \
+	inline static size_t ___get_base_id() { return typeid(Base).hash_code(); };            \
+	inline static const char *___get_base_type_name() { return Base::___get_type_name(); } \
+	inline static godot::Object *___get_from_variant(godot::Variant a) {                   \
+		return (godot::Object *)godot::detail::get_custom_class_instance<Name>(            \
+				godot::Object::___get_from_variant(a));                                    \
+	}                                                                                      \
+                                                                                           \
 private:
 
 template <class T>
@@ -316,7 +375,7 @@ void register_property(const char *name, P(T::*var), P default_value, godot_meth
 	usage = (godot_property_usage_flags)((int)usage | GODOT_PROPERTY_USAGE_SCRIPT_VARIABLE);
 
 	if (def_val.get_type() == Variant::OBJECT) {
-		Object *o = get_wrapper<Object>(def_val.operator godot_object *());
+		Object *o = detail::get_wrapper<Object>(def_val.operator godot_object *());
 		if (o && o->is_class("Resource")) {
 			hint = (godot_property_hint)((int)hint | GODOT_PROPERTY_HINT_RESOURCE_TYPE);
 			hint_string = o->get_class();
@@ -460,7 +519,7 @@ T *Object::cast_to(const Object *obj) {
 	}
 
 	if (godot::_TagDB::is_type_compatible(typeid(T).hash_code(), have_tag)) {
-		return (T::___CLASS_IS_SCRIPT) ? godot::as<T>(obj) : (T *)obj;
+		return (T::___CLASS_IS_SCRIPT) ? detail::get_custom_class_instance<T>(obj) : (T *)obj;
 	} else {
 		return nullptr;
 	}


### PR DESCRIPTION
This is a new take that can replace https://github.com/GodotNativeTools/godot-cpp/pull/401 and #346 (it goes a long way at this point).

Should fix #397, #343, #215, maybe also #362.
PR #350 is no longer needed, as well as https://github.com/godotengine/godot/pull/33532 and https://github.com/GodotNativeTools/godot_headers/pull/60, so it should also be easier to merge.
PR #346 might also be no longer needed, if it's about the same issue? Though I don't really understand the change it does.

To understand what's going on and why this is yet another PR, I wrote a summary here: https://github.com/godotengine/godot/pull/33532#issuecomment-636268406

This PR avoids the *original source* of the leak by directly creating the new instance, without going through reference initialization (which is then done by us down the road), so it behaves consistently like in engine and workarounds of the previous PRs should not be needed.

- Custom references no longer leak
- The script instance is created using `Object::set_script()` instead of `NativeScript::new()`, as is done in the D and Rust bindings (thanks @toasteater and @sheepandshepherd for the help).
- The use of `GDNativeLibrary` no longer causes a leak (worked around with C API, see https://github.com/godotengine/godot/issues/39181)
- Extracted code from `GODOT_CLASS` so it's not written twice
- Formatted a bit some long lines to fit in the width of Github review
- Wrapped related code in a `detail` namespace, as it's meant for internal use
- Added comments about what's going on (I can remove those about failed attempts if you think they aren't needed)
- Renamed `as()` to its true meaning (not 100% sure on that. I did this when looking at the only places it was used, please confirm)
- Fixed a few things which were forcing to wrap custom classes inside the `godot` namespace

Note: the only downside of `set_script` is that we can't have this fix and have constructor arguments at the same time (as proposed in https://github.com/GodotNativeTools/godot-cpp/issues/293). However constructor arguments were already not supported so this doesn't break any compatibility and should be investigated in a future PR (which could involve PR to Godot), as I think the fix has much higher priority.
