### PR TITLE
Travis: Use SCons 3.1.2 on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ install:
     fi
 
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.0.5/scons-local-3.0.5.zip;
-      unzip scons-local-3.0.5.zip;
+      curl -LO https://downloads.sourceforge.net/project/scons/scons-local/3.1.2/scons-local-3.1.2.zip;
+      unzip scons-local-3.1.2.zip;
     fi
 
 script:


### PR DESCRIPTION
Could likely use `pip` instead of relying on unreliable SourceForge, but it's a good first step anyway.