### PR TITLE
Fix alloca.h error in Defs.h

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -62,8 +62,10 @@ enum class Error {
 #include <GodotGlobal.hpp>
 
 // alloca() is non-standard. When using MSVC, it's in malloc.h.
-#if defined(__linux__) || defined(__APPLE__) || defined(__MINGW32__)
+#if defined(__linux__) || defined(__APPLE__)
 #include <alloca.h>
+#else
+#include <malloc.h>
 #endif
 
 typedef float real_t;


### PR DESCRIPTION
MinGW was previously trying to include `alloca.h`, which was causing compilation to fail on both Windows and Linux. This should stop that from happening. (Fixes #414)