### PR TITLE
Add option to generate template version of Node::get_node

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -144,6 +144,11 @@ opts.Add(
     'Path to your Android NDK installation. By default, uses ANDROID_NDK_ROOT from your defined environment variables.',
     os.environ.get("ANDROID_NDK_ROOT", None)
 )
+opts.Add(BoolVariable(
+	'generate_template_get_node',
+	"Generate a template version of the Node class's get_node.",
+	False
+))
 
 env = Environment(ENV = os.environ)
 opts.Update(env)
@@ -362,7 +367,7 @@ if env['generate_bindings']:
     # Actually create the bindings here
     import binding_generator
 
-    binding_generator.generate_bindings(json_api_file)
+    binding_generator.generate_bindings(json_api_file, env['generate_template_get_node'])
 
 # Sources to compile
 sources = []

--- a/SConstruct
+++ b/SConstruct
@@ -147,7 +147,7 @@ opts.Add(
 opts.Add(BoolVariable(
 	'generate_template_get_node',
 	"Generate a template version of the Node class's get_node.",
-	False
+	True
 ))
 
 env = Environment(ENV = os.environ)

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -291,24 +291,22 @@ def generate_class_header(used_classes, c, use_template_get_node):
 
     source.append(vararg_templates)
 
-    if use_template_get_node:
+    if use_template_get_node and class_name == "Node":
         # Extra definition for template get_node that calls the renamed get_node_internal; has a default template parameter for backwards compatibility.
-        if class_name == "Node":
-            source.append("\ttemplate <class T = Node>")
-            source.append("\tT *get_node(const NodePath path) const {")
-            source.append("\t\treturn Object::cast_to<T>(get_node_internal(path));")
-            source.append("\t}")
+        source.append("\ttemplate <class T = Node>")
+        source.append("\tT *get_node(const NodePath path) const {")
+        source.append("\t\treturn Object::cast_to<T>(get_node_internal(path));")
+        source.append("\t}")
 
         source.append("};")
         source.append("")
 
         # ...And a specialized version so we don't unnecessarily cast when using the default.
-        if class_name == "Node":
-            source.append("template <>")
-            source.append("inline Node *Node::get_node<Node>(const NodePath path) const {")
-            source.append("\treturn get_node_internal(path);")
-            source.append("}")
-            source.append("")
+        source.append("template <>")
+        source.append("inline Node *Node::get_node<Node>(const NodePath path) const {")
+        source.append("\treturn get_node_internal(path);")
+        source.append("}")
+        source.append("")
     else:
         source.append("};")
         source.append("")


### PR DESCRIPTION
Some teammates and I have gotten a bit tired of having to use `cast_to` every time `get_node` is used, and while we've been using a macro to make it a bit less verbose, we wanted a more tidy solution. So I decided to try implementing a template version of `get_node` similar to the `GetNode` generic function that's in the C# API.

This allows the following to be written:
```cpp
Sprite* sprite = cast_to<Sprite>(get_node("Sprite")); // old
Sprite* sprite = get_node<Sprite>("Sprite"); // new
```

This is achieved in a similar way to how `Object::cast_to` is generated, by simply adding a new section in the bindings generator file. To get around name clashing, I also renamed the original `get_node` to `get_node_internal`, but it still calls "get_node" in the Godot bindings, so it should work the same way.

To ensure full backwards compatibility, the new `get_node` has a default template parameter so it will still cast to Node if used with no type. I also added a specialization for the Node version so it doesn't perform any unnecessary casts.

Also, because these changes might be undesirable for some, I made them optional; there's a new boolean scons parameter called `generate_template_get_node`, set to "no" by default, which will only cause these changes to occur when generating the bindings if it is set to "yes."