### PR TITLE
change suffix ‘.os’ to ‘.so’

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ Once you've compiled the GDNative C++ bindings (see above), you can compile the 
 
 ```bash
 cd SimpleLibrary
-clang -fPIC -o src/init.os -c src/init.cpp -g -O3 -std=c++14 -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Igodot-cpp/godot_headers
-clang -o bin/libtest.so -shared src/init.os -Lgodot-cpp/bin -l<name of the godot-cpp>
+clang -fPIC -o src/init.so -c src/init.cpp -g -O3 -std=c++14 -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Igodot-cpp/godot_headers
+clang -o bin/libtest.so -shared src/init.so -Lgodot-cpp/bin -l<name of the godot-cpp>
 ```
 
 You'll need to replace `<name of the godot-cpp>` with the file that was created in [**Compiling the cpp bindings library**](#compiling-the-cpp-bindings-library).
@@ -256,8 +256,8 @@ submit a pull request :slightly_smiling_face:
 
 ```bash
 cd SimpleLibrary
-aarch64-linux-android29-clang -fPIC -o src/init.os -c src/init.cpp -g -O3 -std=c++14 -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Igodot-cpp/godot_headers
-aarch64-linux-android29-clang -o bin/libtest.so -shared src/init.os -Lgodot-cpp/bin -l<name of the godot-cpp>
+aarch64-linux-android29-clang -fPIC -o src/init.so -c src/init.cpp -g -O3 -std=c++14 -Igodot-cpp/include -Igodot-cpp/include/core -Igodot-cpp/include/gen -Igodot-cpp/godot_headers
+aarch64-linux-android29-clang -o bin/libtest.so -shared src/init.so -Lgodot-cpp/bin -l<name of the godot-cpp>
 ```
 
 You'll need to replace `<name of the godot-cpp>` with the file that was created in [**Compiling the cpp bindings library**](#compiling-the-cpp-bindings-library). The command above targets `arm64v8`. To target `armv7`, use `armv7a-linux-androideabi29-clang` instead of `aarch64-linux-android29-clang`.


### PR DESCRIPTION
Maybe this is a convention I don’t know about, but it seems like the `.os` suffixes in in the build instructions for Linux and Android should be `.so` instead.