### PR TITLE
Add missing move_toward to Vector2 and Vector3

### DIFF
--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -178,6 +178,13 @@ struct Vector2 {
 
 	Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, real_t p_t) const;
 
+	Vector2 move_toward(const Vector2 &p_to, const real_t p_delta) const {
+		Vector2 v = *this;
+		Vector2 vd = p_to - v;
+		real_t len = vd.length();
+		return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	}
+
 	inline Vector2 slide(const Vector2 &p_vec) const {
 		return p_vec - *this * this->dot(p_vec);
 	}

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -167,6 +167,13 @@ struct Vector3 {
 
 	Vector3 cubic_interpolate(const Vector3 &b, const Vector3 &pre_a, const Vector3 &post_b, const real_t t) const;
 
+	Vector3 move_toward(const Vector3 &p_to, const real_t p_delta) const {
+		Vector3 v = *this;
+		Vector3 vd = p_to - v;
+		real_t len = vd.length();
+		return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	}
+
 	Vector3 bounce(const Vector3 &p_normal) const {
 		return -reflect(p_normal);
 	}


### PR DESCRIPTION
I'm not sure if the functions should be `inline` or not, and where they should go (in the hpp or in the cpp files), so let me know if there are issues.

Fixes #422 