### PR TITLE
Add DEBUG_ENABLED CPPDEFINES

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -160,7 +160,10 @@ if (
 
 if env['bits'] == 'default':
     env['bits'] = '64' if is64 else '32'
-
+    
+if env['target'] == 'debug':
+    env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+    
 # This makes sure to keep the session environment variables on Windows.
 # This way, you can run SCons in a Visual Studio 2017 prompt and it will find
 # all the required tools


### PR DESCRIPTION
GodotProfiling.hpp requires the DEBUG_ENABLED define to work. However this is not defined anywhere. So I added it to the Scons script to have it defined in debug builds.