### PR TITLE
Rename `RID::get_rid()` => `get_id()` to match Godot

### DIFF
--- a/include/core/RID.hpp
+++ b/include/core/RID.hpp
@@ -15,7 +15,7 @@ public:
 
 	RID(Object *p);
 
-	int32_t get_rid() const;
+	int32_t get_id() const;
 
 	inline bool is_valid() const {
 		// is_valid() is not available in the C API...

--- a/src/core/RID.cpp
+++ b/src/core/RID.cpp
@@ -14,7 +14,7 @@ RID::RID(Object *p) {
 	godot::api->godot_rid_new_with_resource(&_godot_rid, (const godot_object *)p);
 }
 
-int32_t RID::get_rid() const {
+int32_t RID::get_id() const {
 	return godot::api->godot_rid_get_id(&_godot_rid);
 }
 


### PR DESCRIPTION
I think this was an oversight, it wasnt supposed to be called `get_rid`