### PR TITLE
Added missing constants to Vector2, Vector3, Basis and Quat

### DIFF
--- a/include/core/Basis.hpp
+++ b/include/core/Basis.hpp
@@ -13,6 +13,11 @@ class Quat;
 
 class Basis {
 private:
+	static const Basis IDENTITY;
+	static const Basis FLIP_X;
+	static const Basis FLIP_Y;
+	static const Basis FLIP_Z;
+
 	// This helper template is for mimicking the behavior difference between the engine
 	// and script interfaces that logically script sees matrices as column major, while
 	// the engine stores them in row major to efficiently take advantage of SIMD

--- a/include/core/Quat.hpp
+++ b/include/core/Quat.hpp
@@ -11,6 +11,8 @@ namespace godot {
 
 class Quat {
 public:
+	static const Quat IDENTITY;
+
 	real_t x, y, z, w;
 
 	real_t length_squared() const;

--- a/include/core/Transform.hpp
+++ b/include/core/Transform.hpp
@@ -10,6 +10,11 @@ namespace godot {
 
 class Transform {
 public:
+	static const Transform IDENTITY;
+	static const Transform FLIP_X;
+	static const Transform FLIP_Y;
+	static const Transform FLIP_Z;
+
 	Basis basis;
 	Vector3 origin;
 

--- a/include/core/Transform2D.hpp
+++ b/include/core/Transform2D.hpp
@@ -10,6 +10,10 @@ typedef Vector2 Size2;
 struct Rect2;
 
 struct Transform2D {
+	static const Transform2D IDENTITY;
+	static const Transform2D FLIP_X;
+	static const Transform2D FLIP_Y;
+
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
 	// M = (elements[0][0] elements[1][0])
 	//     (elements[0][1] elements[1][1])

--- a/include/core/Vector2.hpp
+++ b/include/core/Vector2.hpp
@@ -12,6 +12,21 @@ namespace godot {
 class String;
 
 struct Vector2 {
+	enum Axis {
+		AXIS_X = 0,
+		AXIS_Y,
+		AXIS_COUNT
+	};
+
+	static const Vector2 ZERO;
+	static const Vector2 ONE;
+	static const Vector2 INF;
+
+	// Coordinate system of the 2D engine
+	static const Vector2 LEFT;
+	static const Vector2 RIGHT;
+	static const Vector2 UP;
+	static const Vector2 DOWN;
 
 	union {
 		real_t x;

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -19,7 +19,20 @@ struct Vector3 {
 		AXIS_X,
 		AXIS_Y,
 		AXIS_Z,
+		AXIS_COUNT
 	};
+
+	static const Vector3 ZERO;
+	static const Vector3 ONE;
+	static const Vector3 INF;
+
+	// Coordinate system of the 3D engine
+	static const Vector3 LEFT;
+	static const Vector3 RIGHT;
+	static const Vector3 UP;
+	static const Vector3 DOWN;
+	static const Vector3 FORWARD;
+	static const Vector3 BACK;
 
 	union {
 		struct {

--- a/src/core/Basis.cpp
+++ b/src/core/Basis.cpp
@@ -7,6 +7,11 @@
 
 namespace godot {
 
+const Basis Basis::IDENTITY = Basis();
+const Basis Basis::FLIP_X = Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+const Basis Basis::FLIP_Y = Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
+const Basis Basis::FLIP_Z = Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
+
 Basis::Basis(const Vector3 &row0, const Vector3 &row1, const Vector3 &row2) {
 	elements[0] = row0;
 	elements[1] = row1;

--- a/src/core/Quat.cpp
+++ b/src/core/Quat.cpp
@@ -7,6 +7,8 @@
 
 namespace godot {
 
+const Quat Quat::IDENTITY = Quat();
+
 // set_euler_xyz expects a vector containing the Euler angles in the format
 // (ax,ay,az), where ax is the angle of rotation around x axis,
 // and similar for other axes.

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -9,6 +9,11 @@
 
 namespace godot {
 
+const Transform Transform::IDENTITY = Transform();
+const Transform Transform::FLIP_X = Transform(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
+const Transform Transform::FLIP_Y = Transform(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0);
+const Transform Transform::FLIP_Z = Transform(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
+
 Transform Transform::inverse_xform(const Transform &t) const {
 
 	Vector3 v = t.origin - origin;

--- a/src/core/Transform2D.cpp
+++ b/src/core/Transform2D.cpp
@@ -7,6 +7,10 @@
 
 namespace godot {
 
+const Transform2D Transform2D::IDENTITY;
+const Transform2D Transform2D::FLIP_X = Transform2D(-1, 0, 0, 1, 0, 0);
+const Transform2D Transform2D::FLIP_Y = Transform2D(1, 0, 0, -1, 0, 0);
+
 Transform2D::Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy) {
 
 	elements[0][0] = xx;

--- a/src/core/Vector2.cpp
+++ b/src/core/Vector2.cpp
@@ -6,6 +6,15 @@
 
 namespace godot {
 
+const Vector2 Vector2::ZERO;
+const Vector2 Vector2::ONE;
+const Vector2 Vector2::INF;
+
+const Vector2 Vector2::LEFT = Vector2(-1, 0);
+const Vector2 Vector2::RIGHT = Vector2(1, 0);
+const Vector2 Vector2::UP = Vector2(0, -1);
+const Vector2 Vector2::DOWN = Vector2(0, 1);
+
 bool Vector2::operator==(const Vector2 &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
 }

--- a/src/core/Vector3.cpp
+++ b/src/core/Vector3.cpp
@@ -8,6 +8,17 @@
 
 namespace godot {
 
+const Vector3 Vector3::ZERO = Vector3();
+const Vector3 Vector3::ONE = Vector3();
+const Vector3 Vector3::INF = Vector3(INFINITY, INFINITY, INFINITY);
+
+const Vector3 Vector3::LEFT = Vector3(-1, 0, 0);
+const Vector3 Vector3::RIGHT = Vector3(1, 0, 0);
+const Vector3 Vector3::UP = Vector3(0, 1, 0);
+const Vector3 Vector3::DOWN = Vector3(0, -1, 0);
+const Vector3 Vector3::FORWARD = Vector3(0, 0, -1);
+const Vector3 Vector3::BACK = Vector3(0, 0, 1);
+
 bool Vector3::operator<(const Vector3 &p_v) const {
 	if (x == p_v.x) {
 		if (y == p_v.y)


### PR DESCRIPTION
Adds missing constants like `Vector3_LEFT`, `Basis_IDENTITY` or `Vector2::AXIS_X`.
~~Some use an `_` because C++ did not allow me to place a constant inside the definition of the type of that constant.~~

Updated: now constants are declared in the classes, and defined in the cpp files. This is not exactly the same as a constexpr since the value is now defined inside the library with an actual address instead of being header-only and inline, but it's likely not a big deal.

Should fix https://github.com/godotengine/godot-cpp/issues/467