### PR TITLE
add per-class overloads of `new` and `delete`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -202,12 +202,6 @@ def generate_class_header(used_classes, c, use_template_get_node):
         if name not in enum_values:
             source.append("\tconst static int " + name + " = " + str(c["constants"][name]) + ";")
 
-
-    if c["instanciable"]:
-        source.append("")
-        source.append("")
-        source.append("\tstatic " + class_name + " *_new();")
-
     source.append("\n\t// methods")
 
 
@@ -294,6 +288,16 @@ def generate_class_header(used_classes, c, use_template_get_node):
 
 
         source.append("\t" + method_signature + ";")
+
+    if c["instanciable"]:
+        source.append("")
+        source.append("\t// object lifetime management")
+        source.append("")
+        source.append("\tstatic " + class_name + " *_new();")
+        source.append("\tinline static void *operator new(size_t _size) { return (void *) " + class_name + "::_new(); }")
+        source.append("\tinline static void operator delete(void *obj) { ((" + class_name + " *)obj)->free(); }")
+        source.append("")
+        source.append("")
 
     source.append(vararg_templates)
 

--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -112,6 +112,8 @@ public:                                                                         
 	inline static Name *_new() {                                                             \
 		return godot::detail::create_custom_class_instance<Name>();                          \
 	}                                                                                        \
+	inline static void *operator new(size_t _size) { return (void *)Name::_new(); }          \
+	inline static void operator delete(void *obj) { ((Name *)obj)->free(); }                 \
 	inline static size_t ___get_id() { return typeid(Name).hash_code(); }                    \
 	inline static size_t ___get_base_id() { return Base::___get_id(); }                      \
 	inline static const char *___get_base_class_name() { return Base::___get_class_name(); } \
@@ -150,7 +152,8 @@ struct _ArgCast<Variant> {
 
 template <class T>
 void *_godot_class_instance_func(godot_object *p, void * /*method_data*/) {
-	T *d = new T();
+	void *buf = godot::api->godot_alloc(sizeof(T));
+	T *d = new (buf) T();
 	d->_owner = p;
 	d->_type_tag = typeid(T).hash_code();
 	d->_init();
@@ -160,7 +163,8 @@ void *_godot_class_instance_func(godot_object *p, void * /*method_data*/) {
 template <class T>
 void _godot_class_destroy_func(godot_object * /*p*/, void * /*method_data*/, void *data) {
 	T *d = (T *)data;
-	delete d;
+	d.~T();
+	godot::api->godot_free(data);
 }
 
 template <class T>


### PR DESCRIPTION
This should allow the common `new` and `delete` operators to
be used, as is often the case in C++ code bases, instead of
the Godot specific `::_new` and `->free()` methods.