### PR TITLE
Revert comment in the middle of function pointer in Godot.hpp

### DIFF
--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -210,14 +210,17 @@ void register_tool_class() {
 typedef godot_variant (*__godot_wrapper_method)(godot_object *, void *, void *, int, godot_variant **);
 
 template <class T, class R, class... args>
-const char *___get_method_class_name(R (T::*/*p*/)(args... a)) {
+const char *___get_method_class_name(R (T::*p)(args... a)) {
 	static_assert(T::___CLASS_IS_SCRIPT, "This function must only be used on custom classes");
+	(void)p; // To avoid "unused parameter" warnings. `p` is required for template matching.
 	return T::___get_class_name();
 }
 
+// This second version is also required to match constant functions
 template <class T, class R, class... args>
-const char *___get_method_class_name(R (T::*/*p*/)(args... a) const) {
+const char *___get_method_class_name(R (T::*p)(args... a) const) {
 	static_assert(T::___CLASS_IS_SCRIPT, "This function must only be used on custom classes");
+	(void)p; // To avoid "unused parameter" warnings. `p` is required for template matching.
 	return T::___get_class_name();
 }
 


### PR DESCRIPTION
`p` is unused, but cannot be `/*commented*/` because it triggers different warnings again in user code. This parameter is required for template matching to work. It's a nasty syntax.

It might need a per-compiler macro of some sort prepended to the argument, but I have no idea how to approach this so for now I'll revert it.

Edit: changed to a `(void) p;`