### PR TITLE
Dont carry MSVC stuff to MinGW builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -284,8 +284,13 @@ elif env['platform'] == 'windows':
             env['AR'] = "i686-w64-mingw32-ar"
             env['RANLIB'] = "i686-w64-mingw32-ranlib"
             env['LINK'] = "i686-w64-mingw32-g++"
+    
     elif host_platform == 'windows' and env['use_mingw']:
-        env = env.Clone(tools=['mingw'])
+        # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.
+        env = Environment(ENV = os.environ, tools=["mingw"])
+        opts.Update(env)
+        #env = env.Clone(tools=['mingw'])
+
         env["SPAWN"] = mySpawn
 
     # Native or cross-compilation using MinGW
@@ -301,7 +306,11 @@ elif env['platform'] == 'windows':
 
 elif env['platform'] == 'android':
     if host_platform == 'windows':
-        env = env.Clone(tools=['mingw'])
+        # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.
+        env = Environment(ENV = os.environ, tools=["mingw"])
+        opts.Update(env)
+        #env = env.Clone(tools=['mingw'])
+
         env["SPAWN"] = mySpawn
 
     # Verify NDK root


### PR DESCRIPTION
This should fix MinGW builds on the CI: https://github.com/Zylann/cpp_bindings/runs/1802898864?check_suite_focus=true
Also should likely fix #361, see https://github.com/godotengine/godot-cpp/issues/361#issuecomment-607516261

~~Mac OS is still lost in limbo.~~
Mac OS needs to use a different runner: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software