### PR TITLE
Replaced static math functions in CameraMatrix by Math usage

### DIFF
--- a/include/core/CameraMatrix.hpp
+++ b/include/core/CameraMatrix.hpp
@@ -5,6 +5,7 @@
 #include "Plane.hpp"
 #include "Rect2.hpp"
 #include "Transform.hpp"
+#include "Math.hpp"
 
 #include <vector>
 
@@ -39,7 +40,7 @@ struct CameraMatrix {
 
 	static real_t get_fovy(real_t p_fovx, real_t p_aspect) {
 
-		return rad2deg(atan(p_aspect * tan(deg2rad(p_fovx) * 0.5)) * 2.0);
+		return Math::rad2deg(atan(p_aspect * tan(Math::deg2rad(p_fovx) * 0.5)) * 2.0);
 	}
 
 	static inline double deg2rad(double p_y) { return p_y * Math_PI / 180.0; }

--- a/include/core/CameraMatrix.hpp
+++ b/include/core/CameraMatrix.hpp
@@ -43,12 +43,6 @@ struct CameraMatrix {
 		return Math::rad2deg(atan(p_aspect * tan(Math::deg2rad(p_fovx) * 0.5)) * 2.0);
 	}
 
-	static inline double deg2rad(double p_y) { return p_y * Math_PI / 180.0; }
-	static inline float deg2rad(float p_y) { return p_y * Math_PI / 180.0; }
-
-	static inline double rad2deg(double p_y) { return p_y * 180.0 / Math_PI; }
-	static inline float rad2deg(float p_y) { return p_y * 180.0 / Math_PI; }
-
 	static inline double absd(double g) {
 
 		union {

--- a/src/core/CameraMatrix.cpp
+++ b/src/core/CameraMatrix.cpp
@@ -585,7 +585,7 @@ real_t CameraMatrix::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
+		return Math::rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -594,7 +594,7 @@ real_t CameraMatrix::get_fov() const {
 				matrix[15] + matrix[12]);
 		left_plane.normalize();
 
-		return rad2deg(acos(abs(left_plane.normal.x))) + rad2deg(acos(abs(right_plane.normal.x)));
+		return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
 	}
 }
 


### PR DESCRIPTION
Redundant math function definitions in CameraMatrix has been replaced by the ones in Math.hpp