### PR TITLE
iOS arm64 simulator support.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -145,6 +145,11 @@ opts.Add(EnumVariable(
     'arm64',
     ['armv7', 'arm64', 'x86_64']
 ))
+opts.Add(BoolVariable(
+    'ios_simulator',
+    'Target iOS Simulator',
+    False
+))
 opts.Add(
     'IPHONEPATH',
     'Path to iPhone toolchain',
@@ -227,9 +232,10 @@ elif env['platform'] == 'osx':
         env.Append(CCFLAGS=['-O3'])
 
 elif env['platform'] == 'ios':
-    if env['ios_arch'] == 'x86_64':
+    if env['ios_simulator']:
         sdk_name = 'iphonesimulator'
         env.Append(CCFLAGS=['-mios-simulator-version-min=10.0'])
+        env['LIBSUFFIX'] = ".simulator" + env['LIBSUFFIX']
     else:
         sdk_name = 'iphoneos'
         env.Append(CCFLAGS=['-miphoneos-version-min=10.0'])


### PR DESCRIPTION
Added a `ios_simulator` flag for SConstruct which should allow building for arm64 simulator.