### PR TITLE
Fix MacOS CI using an available runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
   macos:
     name: Build (macOS, Clang)
-    runs-on: macos-11.0
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
MacOS 11.0 seems to be unavailable at the moment: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software