### PR TITLE
Generate bindings if they are not found

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -123,10 +123,12 @@ opts.Add(PathVariable(
     None,
     PathVariable.PathIsFile
 ))
-opts.Add(BoolVariable(
+opts.Add(EnumVariable(
     'generate_bindings',
     'Generate GDNative API bindings',
-    False
+    'auto',
+    allowed_values = ['yes', 'no', 'auto', 'true'],
+    ignorecase = 2
 ))
 opts.Add(EnumVariable(
     'android_arch',
@@ -387,7 +389,13 @@ if 'custom_api_file' in env:
 else:
     json_api_file = os.path.join(os.getcwd(), env['headers_dir'], 'api.json')
 
-if env['generate_bindings']:
+if env['generate_bindings'] == 'auto':
+    # Check if generated files exist
+    should_generate_bindings = not os.path.isfile(os.path.join(os.getcwd(), 'src', 'gen', 'Object.cpp'))
+else:
+    should_generate_bindings = env['generate_bindings'] in ['yes', 'true']
+
+if should_generate_bindings:
     # Actually create the bindings here
     import binding_generator
 


### PR DESCRIPTION
This PR adds a primitive check to figure out if bindings should be generated or not.
It checks if `src/gen/Object.cpp` exists. If it isn't found, then bindings will get generated.

The `generate_bindings` option is an enumeration that can be given the following values:
- `true`, or `yes`: will generate bindings
- `no`: will not generate bindings
- `auto`: will detect presence of bindings. This is now the default value, so less users will forget to do this step.

This check does not detect if bindings should be re-generated. So if you update the library with Git for example, you still have to tell it explicitely, or clear the generated folder before building.
