### PR TITLE
CMake project now uses find_package(Python) rather than hardcoded python string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,9 @@ endif()
 
 # Generate source from the bindings file
 message(STATUS "Generating Bindings")
-execute_process(COMMAND "python" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_CUSTOM_API_FILE}\")"
+find_package (Python COMPONENTS Interpreter)
+
+execute_process(COMMAND "${Python_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_CUSTOM_API_FILE}\", True)"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	RESULT_VARIABLE GENERATION_RESULT
 	OUTPUT_VARIABLE GENERATION_OUTPUT)

--- a/src/core/CameraMatrix.cpp
+++ b/src/core/CameraMatrix.cpp
@@ -585,7 +585,7 @@ real_t CameraMatrix::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
+		return Math::rad2deg(acos(std::abs(right_plane.normal.x))) * 2.0;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -594,7 +594,7 @@ real_t CameraMatrix::get_fov() const {
 				matrix[15] + matrix[12]);
 		left_plane.normalize();
 
-		return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
+		return Math::rad2deg(acos(std::abs(left_plane.normal.x))) + Math::rad2deg(acos(std::abs(right_plane.normal.x)));
 	}
 }
 


### PR DESCRIPTION
Came across the same issue here: https://github.com/godotengine/godot-cpp/issues/491

Also removing implicit cast caused by use of C math that was breaking clang-11 build.