### PR TITLE
Update copyright statement to 'Godot Engine contributors'

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2017-2020 GodotNativeTools
+Copyright (c) 2017-2021 Godot Engine contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Amd bump year to cover 2021.