### PR TITLE
Add macOS ARM64 (Apple Silicon) support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,18 +128,18 @@ jobs:
 
       - name: Build godot-cpp
         run: |
-          scons target=release generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
+          scons target=release macos_arch=x86_64 generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2.2.3
         with:
           name: godot-cpp-macos-x86_64-release
-          path: bin/libgodot-cpp.osx.release.64.a
+          path: bin/libgodot-cpp.osx.release.x86_64.a
           if-no-files-found: error
 
       - name: Build test GDNative library
         run: |
-          scons target=release platform=osx bits=64 -j $(sysctl -n hw.logicalcpu) -C test
+          scons target=release platform=osx macos_arch=x86_64 -j $(sysctl -n hw.logicalcpu) -C test
 
       - name: Run test GDNative library
         run: |

--- a/SConstruct
+++ b/SConstruct
@@ -149,6 +149,12 @@ opts.Add(EnumVariable(
     'arm64',
     ['armv7', 'arm64', 'x86_64']
 ))
+opts.Add(EnumVariable(
+    'macos_arch',
+    'Target macOS architecture',
+    'universal',
+    ['universal', 'arm64', 'x86_64']
+))
 opts.Add(BoolVariable(
     'ios_simulator',
     'Target iOS Simulator',
@@ -217,14 +223,28 @@ elif env['platform'] == 'osx':
             'Only 64-bit builds are supported for the macOS target.'
         )
 
-    env.Append(CCFLAGS=['-std=c++14', '-arch', 'x86_64'])
+    if env['macos_arch'] == 'universal':
+        env.Append(CCFLAGS=['-std=c++14', '-arch', 'x86_64', '-arch', 'arm64'])
+    else:
+        env.Append(CCFLAGS=['-std=c++14', '-arch', env['macos_arch']])
 
     if env['macos_deployment_target'] != 'default':
         env.Append(CCFLAGS=['-mmacosx-version-min=' + env['macos_deployment_target']])
 
+    if env['macos_arch'] == 'universal':
+        env.Append(LINKFLAGS=[
+            '-arch',
+            'x86_64',
+            '-arch',
+            'arm64'
+        ])
+    else:
+        env.Append(LINKFLAGS=[
+            '-arch',
+            env['macos_arch']
+        ])
+
     env.Append(LINKFLAGS=[
-        '-arch',
-        'x86_64',
         '-framework',
         'Cocoa',
         '-Wl,-undefined,dynamic_lookup',
@@ -439,10 +459,12 @@ add_sources(sources, 'src/gen', 'cpp')
 arch_suffix = env['bits']
 if env['platform'] == 'android':
     arch_suffix = env['android_arch']
-if env['platform'] == 'ios':
+elif env['platform'] == 'ios':
     arch_suffix = env['ios_arch']
-if env['platform'] == 'javascript':
+elif env['platform'] == 'javascript':
     arch_suffix = 'wasm'
+elif env['platform'] == 'osx':
+    arch_suffix = env['macos_arch']
 
 library = env.StaticLibrary(
     target='bin/' + 'libgodot-cpp.{}.{}.{}{}'.format(

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -28,6 +28,7 @@ opts.Add(EnumVariable('bits', 'Target platform bits', '64', ('32', '64')))
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/', PathVariable.PathAccept))
 opts.Add(PathVariable('target_name', 'The library name.', 'libgdexample', PathVariable.PathAccept))
+opts.Add(EnumVariable('macos_arch', 'Target macOS architecture', 'universal', ['universal', 'arm64', 'x86_64']))
 
 # Local dependency paths, adapt them to your setup
 godot_headers_path = "../godot-headers/"
@@ -75,11 +76,15 @@ if env['platform'] == '':
 
 # Check our platform specifics
 if env['platform'] == "osx":
+    if env['macos_arch'] == 'universal':
+        env.Append(CCFLAGS=['-std=c++17', '-arch', 'x86_64', '-arch', 'arm64'])
+        env.Append(LINKFLAGS=['-arch', 'x86_64', '-arch', 'arm64'])
+    else:
+        env.Append(CCFLAGS=['-std=c++17', '-arch', env['macos_arch']])
+        env.Append(LINKFLAGS=['-arch', env['macos_arch']])
+
     env['target_path'] += 'osx/'
     cpp_library += '.osx'
-    env.Append(CCFLAGS=['-arch', 'x86_64'])
-    env.Append(CXXFLAGS=['-std=c++17'])
-    env.Append(LINKFLAGS=['-arch', 'x86_64'])
     if env['target'] in ('debug', 'd'):
         env.Append(CCFLAGS=['-g', '-O2'])
     else:
@@ -117,7 +122,10 @@ if env['target'] in ('debug', 'd'):
 else:
     cpp_library += '.release'
 
-cpp_library += '.' + str(bits)
+if env['platform'] == 'osx':
+    cpp_library += '.' + env['macos_arch']
+else:
+    cpp_library += '.' + str(bits)
 
 # make sure our binding library is properly includes
 env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])


### PR DESCRIPTION
Adds `macos_arch` option, default to universal x86_64 + arm64.

Note: CI is set to build for x86_64 since `macos-11.0` environment is not available.