### PR TITLE
CRASH_COND interrupts exec, return value not expected

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -208,7 +208,10 @@ typedef float real_t;
 	do {                                     \
 		if (unlikely(cond)) {                \
 			FATAL_PRINT(ERR_MSG_COND(cond)); \
-			return;                          \
+			GENERATE_TRAP();                 \
+		}                                    \
+		else {                               \
+			((void)0);                       \
 		}                                    \
 	} while (0)
 #endif


### PR DESCRIPTION
Made changes as directed in issure #521 . Please let me know if any further changes are required.