### PR TITLE
Add get_rotation_quat() and is_equal_approx() functions

### DIFF
--- a/include/core/Basis.hpp
+++ b/include/core/Basis.hpp
@@ -347,6 +347,8 @@ public:
 
 	Basis rotated(const Vector3 &p_axis, real_t p_phi) const;
 
+	Quat get_rotation_quat() const;
+
 	void scale(const Vector3 &p_scale);
 
 	Basis scaled(const Vector3 &p_scale) const;
@@ -367,6 +369,8 @@ public:
 	real_t tdotx(const Vector3 &v) const;
 	real_t tdoty(const Vector3 &v) const;
 	real_t tdotz(const Vector3 &v) const;
+
+	bool is_equal_approx(const Basis &p_basis) const;
 
 	bool operator==(const Basis &p_matrix) const;
 

--- a/include/core/Vector3.hpp
+++ b/include/core/Vector3.hpp
@@ -249,6 +249,8 @@ struct Vector3 {
 		return std::abs(length_squared() - 1.f) < 0.00001f;
 	}
 
+	bool is_equal_approx(const Vector3 &p_v) const;
+
 	Basis outer(const Vector3 &b) const;
 
 	int max_axis() const;

--- a/src/core/Basis.cpp
+++ b/src/core/Basis.cpp
@@ -310,6 +310,10 @@ real_t Basis::tdotz(const Vector3 &v) const {
 	return elements[0][2] * v[0] + elements[1][2] * v[1] + elements[2][2] * v[2];
 }
 
+bool Basis::is_equal_approx(const Basis &p_basis) const {
+	return elements[0].is_equal_approx(p_basis.elements[0]) && elements[1].is_equal_approx(p_basis.elements[1]) && elements[2].is_equal_approx(p_basis.elements[2]);
+}
+
 bool Basis::operator==(const Basis &p_matrix) const {
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
@@ -641,6 +645,19 @@ Basis::Basis(const Vector3 &p_axis, real_t p_phi) {
 	elements[2][0] = p_axis.z * p_axis.x * (1.0 - cosine) - p_axis.y * sine;
 	elements[2][1] = p_axis.y * p_axis.z * (1.0 - cosine) + p_axis.x * sine;
 	elements[2][2] = axis_sq.z + cosine * (1.0 - axis_sq.z);
+}
+
+Quat Basis::get_rotation_quat() const {
+	// Assumes that the matrix can be decomposed into a proper rotation and scaling matrix as M = R.S,
+	// and returns the Quaternion corresponding to the rotation part, complementing get_scale().
+	// See the comment in get_scale() for further information.
+	Basis m = orthonormalized();
+	real_t det = m.determinant();
+	if (det < 0) {
+		// Ensure that the determinant is 1, such that result is a proper rotation matrix which can be represented by Euler angles.
+		m.scale(Vector3(-1, -1, -1));
+	}
+	return m.operator Quat();
 }
 
 Basis::operator Quat() const {

--- a/src/core/Vector3.cpp
+++ b/src/core/Vector3.cpp
@@ -84,6 +84,10 @@ void Vector3::snap(real_t p_val) {
 	z = Math::stepify(z, p_val);
 }
 
+bool Vector3::is_equal_approx(const Vector3 &p_v) const {
+	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z);
+}
+
 Vector3::operator String() const {
 	return String::num(x) + ", " + String::num(y) + ", " + String::num(z);
 }


### PR DESCRIPTION
Adds `get_rotation_quat()` and `is_equal_approx()` functions to the `Basis` class to ensure it matches the Godot API. Also adds an `is_equal_approx()` function to `Vector3`. All the newly added methods have implementations similar to the ones in the Godot core.

Closes #532