### PR TITLE
Fix CMake generation on Windows

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import json
 import os
-from pathlib import PosixPath
+from pathlib import Path
 
 # Convenience function for using template get_node
 def correct_method_name(method_list):
@@ -19,23 +19,23 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
     end = ';'
     with open(api_filepath) as api_file:
         classes = json.load(api_file)
-    include_gen_folder = PosixPath(output_dir) / 'include' / 'gen'
-    source_gen_folder = PosixPath(output_dir) / 'src' / 'gen'
+    include_gen_folder = Path(output_dir) / 'include' / 'gen'
+    source_gen_folder = Path(output_dir) / 'src' / 'gen'
     for _class in classes:
         header_filename = include_gen_folder / (strip_name(_class["name"]) + ".hpp")
         source_filename = source_gen_folder / (strip_name(_class["name"]) + ".cpp")
         if headers:
-            print(str(header_filename), end=end)
+            print(str(header_filename.as_posix()), end=end)
         if sources:
-            print(str(source_filename), end=end)
+            print(str(source_filename.as_posix()), end=end)
     icall_header_filename = include_gen_folder / '__icalls.hpp'
     register_types_filename = source_gen_folder / '__register_types.cpp'
     init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
     if headers:
-        print(str(icall_header_filename), end=end)
+        print(str(icall_header_filename.as_posix()), end=end)
     if sources:
-        print(str(register_types_filename), end=end)
-        print(str(init_method_bindings_filename), end=end)
+        print(str(register_types_filename.as_posix()), end=end)
+        print(str(init_method_bindings_filename.as_posix()), end=end)
 
 
 def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
@@ -44,8 +44,8 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
         classes = json.load(api_file)
 
     icalls = set()
-    include_gen_folder = PosixPath(output_dir) / 'include' / 'gen'
-    source_gen_folder = PosixPath(output_dir) / 'src' / 'gen'
+    include_gen_folder = Path(output_dir) / 'include' / 'gen'
+    source_gen_folder = Path(output_dir) / 'src' / 'gen'
 
     try:
         include_gen_folder.mkdir(parents=True, exist_ok=True)

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import json
 import os
+import errno
 from pathlib import Path
 
 # Convenience function for using template get_node
@@ -48,14 +49,20 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
     source_gen_folder = Path(output_dir) / 'src' / 'gen'
 
     try:
-        include_gen_folder.mkdir(parents=True, exist_ok=True)
+        include_gen_folder.mkdir(parents=True)
     except os.error as e:
-        exit(1)
+        if e.errno == errno.EEXIST:
+            print(str(source_gen_folder) + ": " + os.strerror(e.errno))
+        else:
+            exit(1)
 
     try:
-        source_gen_folder.mkdir(parents=True, exist_ok=True)
+        source_gen_folder.mkdir(parents=True)
     except os.error as e:
-        exit(1)
+        if e.errno == errno.EEXIST:
+            print(str(source_gen_folder) + ": " + os.strerror(e.errno))
+        else:
+            exit(1)
 
     for c in classes:
         # print(c['name'])
@@ -68,23 +75,23 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
         impl = generate_class_implementation(icalls, used_classes, c, use_template_get_node)
 
         header_filename = include_gen_folder / (strip_name(c["name"]) + ".hpp")
-        with open(header_filename, "w+") as header_file:
+        with header_filename.open("w+") as header_file:
             header_file.write(header)
 
         source_filename = source_gen_folder / (strip_name(c["name"]) + ".cpp")
-        with open(source_filename, "w+") as source_file:
+        with source_filename.open("w+") as source_file:
             source_file.write(impl)
 
     icall_header_filename = include_gen_folder / '__icalls.hpp'
-    with open(icall_header_filename, "w+") as icall_header_file:
+    with icall_header_filename.open("w+") as icall_header_file:
         icall_header_file.write(generate_icall_header(icalls))
 
     register_types_filename = source_gen_folder / '__register_types.cpp'
-    with open(register_types_filename, "w+") as register_types_file:
+    with register_types_filename.open("w+") as register_types_file:
         register_types_file.write(generate_type_registry(classes))
 
     init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
-    with open(init_method_bindings_filename, "w+") as init_method_bindings_file:
+    with init_method_bindings_filename.open("w+") as init_method_bindings_file:
         init_method_bindings_file.write(generate_init_method_bindings(classes))
 
 

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import json
 import os
-import errno
+from pathlib import PosixPath
 
 # Convenience function for using template get_node
 def correct_method_name(method_list):
@@ -19,23 +19,23 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
     end = ';'
     with open(api_filepath) as api_file:
         classes = json.load(api_file)
-    include_gen_folder = os.path.join(output_dir, 'include', 'gen')
-    source_gen_folder = os.path.join(output_dir, 'src', 'gen')
+    include_gen_folder = PosixPath(output_dir) / 'include' / 'gen'
+    source_gen_folder = PosixPath(output_dir) / 'src' / 'gen'
     for _class in classes:
-        header_filename = os.path.join(include_gen_folder, strip_name(_class["name"]) + ".hpp")
-        source_filename = os.path.join(source_gen_folder, strip_name(_class["name"]) + ".cpp")
+        header_filename = include_gen_folder / (strip_name(_class["name"]) + ".hpp")
+        source_filename = source_gen_folder / (strip_name(_class["name"]) + ".cpp")
         if headers:
-            print(header_filename.replace("\\", "/"), end=end)
+            print(str(header_filename), end=end)
         if sources:
-            print(source_filename.replace("\\", "/"), end=end)
-    icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
-    register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
-    init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
+            print(str(source_filename), end=end)
+    icall_header_filename = include_gen_folder / '__icalls.hpp'
+    register_types_filename = source_gen_folder / '__register_types.cpp'
+    init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
     if headers:
-        print(icall_header_filename.replace("\\", "/"), end=end)
+        print(str(icall_header_filename), end=end)
     if sources:
-        print(register_types_filename.replace("\\", "/"), end=end)
-        print(init_method_bindings_filename.replace("\\", "/"), end=end)
+        print(str(register_types_filename), end=end)
+        print(str(init_method_bindings_filename), end=end)
 
 
 def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
@@ -44,22 +44,18 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
         classes = json.load(api_file)
 
     icalls = set()
-    include_gen_folder = os.path.join(output_dir, 'include', 'gen')
-    source_gen_folder = os.path.join(output_dir, 'src', 'gen')
+    include_gen_folder = PosixPath(output_dir) / 'include' / 'gen'
+    source_gen_folder = PosixPath(output_dir) / 'src' / 'gen'
+
     try:
-        os.makedirs(include_gen_folder)
+        include_gen_folder.mkdir(parents=True, exist_ok=True)
     except os.error as e:
-        if e.errno == errno.EEXIST:
-            print(include_gen_folder + ": " + os.strerror(e.errno))
-        else:
-            exit(1)
+        exit(1)
+
     try:
-        os.makedirs(source_gen_folder)
+        source_gen_folder.mkdir(parents=True, exist_ok=True)
     except os.error as e:
-        if e.errno == errno.EEXIST:
-            print(source_gen_folder + ": " + os.strerror(e.errno))
-        else:
-            exit(1)
+        exit(1)
 
     for c in classes:
         # print(c['name'])
@@ -71,23 +67,23 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
 
         impl = generate_class_implementation(icalls, used_classes, c, use_template_get_node)
 
-        header_filename = os.path.join(include_gen_folder, strip_name(c["name"]) + ".hpp")
+        header_filename = include_gen_folder / (strip_name(c["name"]) + ".hpp")
         with open(header_filename, "w+") as header_file:
             header_file.write(header)
 
-        source_filename = os.path.join(source_gen_folder, strip_name(c["name"]) + ".cpp")
+        source_filename = source_gen_folder / (strip_name(c["name"]) + ".cpp")
         with open(source_filename, "w+") as source_file:
             source_file.write(impl)
 
-    icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
+    icall_header_filename = include_gen_folder / '__icalls.hpp'
     with open(icall_header_filename, "w+") as icall_header_file:
         icall_header_file.write(generate_icall_header(icalls))
 
-    register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
+    register_types_filename = source_gen_folder / '__register_types.cpp'
     with open(register_types_filename, "w+") as register_types_file:
         register_types_file.write(generate_type_registry(classes))
 
-    init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
+    init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
     with open(init_method_bindings_filename, "w+") as init_method_bindings_file:
         init_method_bindings_file.write(generate_init_method_bindings(classes))
 

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -25,17 +25,17 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
         header_filename = os.path.join(include_gen_folder, strip_name(_class["name"]) + ".hpp")
         source_filename = os.path.join(source_gen_folder, strip_name(_class["name"]) + ".cpp")
         if headers:
-            print(header_filename, end=end)
+            print(header_filename.replace("\\", "/"), end=end)
         if sources:
-            print(source_filename, end=end)
+            print(source_filename.replace("\\", "/"), end=end)
     icall_header_filename = os.path.join(include_gen_folder, '__icalls.hpp')
     register_types_filename = os.path.join(source_gen_folder, '__register_types.cpp')
     init_method_bindings_filename = os.path.join(source_gen_folder, '__init_method_bindings.cpp')
     if headers:
-        print(icall_header_filename, end=end)
+        print(icall_header_filename.replace("\\", "/"), end=end)
     if sources:
-        print(register_types_filename, end=end)
-        print(init_method_bindings_filename, end=end)
+        print(register_types_filename.replace("\\", "/"), end=end)
+        print(init_method_bindings_filename.replace("\\", "/"), end=end)
 
 
 def generate_bindings(api_filepath, use_template_get_node, output_dir="."):


### PR DESCRIPTION
On Windows, paths are mixed by os.path.join with different slash directions. This should generally be fine but when using the print function we print "C:\\\\mypath/myfile.cpp" as "C:\\mypath/myfile.cpp" which is unescaped on the backward slash. To fix this I propose to replace "\\\\" with "/" just before printing it out for CMake usage. I would suggest using pathlib but it is not included by default on python versions <= 3.3 which may still be an issue.