### PR TITLE
Fix: add missing toolchain elements for android

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -14,7 +14,7 @@ else:
 
 # Workaround for MinGW. See:
 # http://www.scons.org/wiki/LongCmdLinesOnWin32
-if (os.name=="nt"):
+if os.name == "nt":
     import subprocess
 
     def mySubProcess(cmdline,env):
@@ -371,8 +371,12 @@ elif env['platform'] == 'android':
     env['CC'] = toolchain + "/bin/clang"
     env['CXX'] = toolchain + "/bin/clang++"
     env['AR'] = toolchain + "/bin/" + arch_info['tool_path'] + "-ar"
+    env["AS"] = toolchain + "/bin/" + arch_info['tool_path'] + "-as"
+    env["LD"] = toolchain + "/bin/" + arch_info['tool_path'] + "-ld"
+    env["STRIP"] = toolchain + "/bin/" + arch_info['tool_path'] + "-strip"
+    env["RANLIB"] = toolchain + "/bin/" + arch_info['tool_path'] + "-ranlib"
 
-    env.Append(CCFLAGS=['--target=' + arch_info['target'] + env['android_api_level'], '-march=' + arch_info['march'], '-fPIC'])#, '-fPIE', '-fno-addrsig', '-Oz'])
+    env.Append(CCFLAGS=['--target=' + arch_info['target'] + env['android_api_level'], '-march=' + arch_info['march'], '-fPIC'])
     env.Append(CCFLAGS=arch_info['ccflags'])
 
 elif env["platform"] == "javascript":


### PR DESCRIPTION
This adds android toolchain components, according to [this documentation](https://developer.android.com/ndk/guides/other_build_systems).

Closed #330 in favor of this one.