### PR TITLE
Populates incorrect constants for Vector2 and 3 types.

### DIFF
--- a/src/core/Vector2.cpp
+++ b/src/core/Vector2.cpp
@@ -6,9 +6,9 @@
 
 namespace godot {
 
-const Vector2 Vector2::ZERO;
-const Vector2 Vector2::ONE;
-const Vector2 Vector2::INF;
+const Vector2 Vector2::ZERO = Vector2();
+const Vector2 Vector2::ONE = Vector2(1, 1);
+const Vector2 Vector2::INF = Vector2(INFINITY, INFINITY);
 
 const Vector2 Vector2::LEFT = Vector2(-1, 0);
 const Vector2 Vector2::RIGHT = Vector2(1, 0);

--- a/src/core/Vector3.cpp
+++ b/src/core/Vector3.cpp
@@ -9,7 +9,7 @@
 namespace godot {
 
 const Vector3 Vector3::ZERO = Vector3();
-const Vector3 Vector3::ONE = Vector3();
+const Vector3 Vector3::ONE = Vector3(1, 1, 1);
 const Vector3 Vector3::INF = Vector3(INFINITY, INFINITY, INFINITY);
 
 const Vector3 Vector3::LEFT = Vector3(-1, 0, 0);


### PR DESCRIPTION
Fixes #549 by populating `Vector2::ONE`, `Vector2::INF`, and `Vector3::ONE`.