### PR TITLE
Change behavior of Math::sign to match Godot builtin.

### DIFF
--- a/include/core/Math.hpp
+++ b/include/core/Math.hpp
@@ -107,7 +107,7 @@ inline T max(T a, T b) {
 
 template <typename T>
 inline T sign(T x) {
-	return static_cast<T>(x < 0 ? -1 : 1);
+	return static_cast<T>(x < 0 ? -1 : (x > 0 ? 1 : 0));
 }
 
 inline double deg2rad(double p_y) {


### PR DESCRIPTION
Please note that this could be a breaking change for anybody reliant on the current behavior.

Fixes #551.