### PR TITLE
Stop including iostream in Variant.hpp (to produce slightly smaller binaries)

### DIFF
--- a/include/core/Godot.hpp
+++ b/include/core/Godot.hpp
@@ -17,6 +17,8 @@
 
 #include "GodotGlobal.hpp"
 
+#include <type_traits>
+
 namespace godot {
 namespace detail {
 

--- a/include/core/Variant.hpp
+++ b/include/core/Variant.hpp
@@ -20,7 +20,6 @@
 #include "Vector2.hpp"
 #include "Vector3.hpp"
 
-#include <iostream>
 
 namespace godot {
 

--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -7,7 +7,6 @@
 #include "GodotGlobal.hpp"
 #include "Object.hpp"
 
-#include <iostream>
 
 namespace godot {
 


### PR DESCRIPTION
Every source file that includes iostream leaves behind some code for it in the object file.
See this example:
test.cpp
```cpp
#include <iostream>
```
`clang -S -O3 -emit-llvm -o test.ll test.cpp`
```llvm
; ModuleID = 'test.cpp'
source_filename = "test.cpp"
target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
target triple = "x86_64-unknown-linux-gnu"

%"class.std::ios_base::Init" = type { i8 }

@_ZStL8__ioinit = internal global %"class.std::ios_base::Init" zeroinitializer, align 1
@__dso_handle = external hidden global i8
@llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @_GLOBAL__sub_I_test.cpp, i8* null }]

declare dso_local void @_ZNSt8ios_base4InitC1Ev(%"class.std::ios_base::Init"* nonnull dereferenceable(1)) unnamed_addr #0

; Function Attrs: nounwind
declare dso_local void @_ZNSt8ios_base4InitD1Ev(%"class.std::ios_base::Init"* nonnull dereferenceable(1)) unnamed_addr #1

; Function Attrs: nofree nounwind
declare dso_local i32 @__cxa_atexit(void (i8*)*, i8*, i8*) local_unnamed_addr #2

; Function Attrs: uwtable
define internal void @_GLOBAL__sub_I_test.cpp() #3 section ".text.startup" {
  tail call void @_ZNSt8ios_base4InitC1Ev(%"class.std::ios_base::Init"* nonnull dereferenceable(1) @_ZStL8__ioinit)
  %1 = tail call i32 @__cxa_atexit(void (i8*)* bitcast (void (%"class.std::ios_base::Init"*)* @_ZNSt8ios_base4InitD1Ev to void (i8*)*), i8* getelementptr inbounds (%"class.std::ios_base::Init", %"class.std::ios_base::Init"* @_ZStL8__ioinit, i64 0, i32 0), i8* nonnull @__dso_handle) #4
  ret void
}

attributes #0 = { "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
attributes #1 = { nounwind "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
attributes #2 = { nofree nounwind }
attributes #3 = { uwtable "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
attributes #4 = { nounwind }

!llvm.module.flags = !{!0}
!llvm.ident = !{!1}

!0 = !{i32 1, !"wchar_size", i32 4}
!1 = !{!"clang version 12.0.0 (Fedora 12.0.0-0.3.rc1.fc34)"}
```
(LLVM bitcode is used here for easier readability, but the code is also present later in the assembly and in the object file, even if nothing from iostream is referenced, like in this example or in the whole godot-cpp repository. GCC behaves similar. Every source/object file creates one more copy of the code.)

Note that this was tested on Linux with libstdc++, but I believe that the same size increase would likely happen with libc++ or msvcrt.

The type_traits include is added to Godot.hpp, because is_base_of is being used there, and it was previously included by iostream.

Note that this was tested on Linux with libstdc++, but I believe that the same size increase would likely happen with libc++ or msvcrt.