### PR TITLE
String constructor that accepts len

### DIFF
--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -37,6 +37,7 @@ class String {
 public:
 	String();
 	String(const char *contents);
+	String(const char *contents, int len);
 	String(const wchar_t *contents);
 	String(const wchar_t c);
 	String(const String &other);

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -61,6 +61,11 @@ String::String(const char *contents) {
 	godot::api->godot_string_parse_utf8(&_godot_string, contents);
 }
 
+String::String(const char *contents, int len) {
+    godot::api->godot_string_new(&_godot_string);
+    godot::api->godot_string_parse_utf8_with_len(&_godot_string, contents, len);
+}
+
 String::String(const wchar_t *contents) {
 	godot::api->godot_string_new_with_wide_string(&_godot_string, contents, wcslen(contents));
 }


### PR DESCRIPTION
Currently, there is no way to create strings by passing ptr + length, and you are forced to use the null terminator approach no matter what. This fix is written primarily by @Zylann, I just created a PR.