### PR TITLE
Fix JavaScript library suffix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs/*
 *.os
 *.so
 *.obj
+*.bc
 *.pyc
 *.dblite
 *.pdb

--- a/SConstruct
+++ b/SConstruct
@@ -397,7 +397,7 @@ elif env["platform"] == "javascript":
     # Program() output consists of multiple files, so specify suffixes manually at builder.
     env["PROGSUFFIX"] = ""
     env["LIBPREFIX"] = "lib"
-    env["LIBSUFFIX"] = ".bc"
+    env["LIBSUFFIX"] = ".a"
     env["LIBPREFIXES"] = ["$LIBPREFIX"]
     env["LIBSUFFIXES"] = ["$LIBSUFFIX"]
     env.Replace(SHLINKFLAGS='$LINKFLAGS')


### PR DESCRIPTION
Related to godotengine/godot#48320 for recent emscripten support.

EDIT: Also add byte-code files to `.gitignore`