### PR TITLE
Remove extraneous Error enum values that were removed in Godot 3.0

### DIFF
--- a/include/core/Defs.hpp
+++ b/include/core/Defs.hpp
@@ -53,8 +53,6 @@ enum class Error {
 	ERR_HELP, ///< user requested help!!
 	ERR_BUG, ///< a bug in the software certainly happened, due to a double check failing or unexpected behavior.
 	ERR_PRINTER_ON_FIRE, /// the parallel port printer is engulfed in flames
-	ERR_OMFG_THIS_IS_VERY_VERY_BAD, ///< shit happens, has never been used, though
-	ERR_WTF = ERR_OMFG_THIS_IS_VERY_VERY_BAD ///< short version of the above
 };
 
 } // namespace godot


### PR DESCRIPTION
These values were removed by https://github.com/godotengine/godot/pull/14000.