### PR TITLE
Fix long / Variant conversion for javascript platform

### DIFF
--- a/include/core/Variant.hpp
+++ b/include/core/Variant.hpp
@@ -20,6 +20,7 @@
 #include "Vector2.hpp"
 #include "Vector3.hpp"
 
+#include <climits>
 #include <iostream>
 
 namespace godot {
@@ -140,9 +141,18 @@ public:
 
 	inline Variant(unsigned char p_char) :
 			Variant((unsigned int)p_char) {}
+
 	Variant(int64_t p_char);
 
 	Variant(uint64_t p_char);
+
+#if LONG_MAX == INT_MAX
+	inline Variant(signed long p_long) :
+			Variant((signed int)p_long) {}
+
+	inline Variant(unsigned long p_long) :
+			Variant((unsigned int)p_long) {}
+#endif
 
 	Variant(float p_float);
 
@@ -209,6 +219,10 @@ public:
 	operator unsigned char() const;
 	operator int64_t() const;
 	operator uint64_t() const;
+#if LONG_MAX == INT_MAX
+	operator signed long() const;
+	operator unsigned long() const;
+#endif
 
 	operator wchar_t() const;
 

--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -7,6 +7,7 @@
 #include "GodotGlobal.hpp"
 #include "Object.hpp"
 
+#include <climits>
 #include <iostream>
 
 namespace godot {
@@ -192,6 +193,14 @@ Variant::operator int64_t() const {
 Variant::operator uint64_t() const {
 	return godot::api->godot_variant_as_uint(&_godot_variant);
 }
+#if LONG_MAX == INT_MAX
+Variant::operator signed long() const {
+	return godot::api->godot_variant_as_int(&_godot_variant);
+}
+Variant::operator unsigned long() const {
+	return godot::api->godot_variant_as_uint(&_godot_variant);
+}
+#endif
 
 Variant::operator wchar_t() const {
 	return godot::api->godot_variant_as_int(&_godot_variant);


### PR DESCRIPTION
I was getting errors about ambiguous conversions from size_t to Variant when building code to wasm. I think this should be fine for all platforms, but I was only able to test these three: linux x86-64, mingw-w64, and emscripten.