### PR TITLE
Fix argument constness in String::begins_with, String::ends_with

### DIFF
--- a/include/core/String.hpp
+++ b/include/core/String.hpp
@@ -75,14 +75,14 @@ public:
 	CharString utf8() const;
 	CharString ascii(bool p_extended = false) const;
 
-	bool begins_with(String &s) const;
+	bool begins_with(const String &s) const;
 	bool begins_with_char_array(const char *p_char_array) const;
 	PoolStringArray bigrams() const;
 	String c_escape() const;
 	String c_unescape() const;
 	String capitalize() const;
 	bool empty() const;
-	bool ends_with(String &text) const;
+	bool ends_with(const String &text) const;
 	void erase(int position, int chars);
 	int find(String what, int from = 0) const;
 	int find_last(String what) const;

--- a/src/core/String.cpp
+++ b/src/core/String.cpp
@@ -192,7 +192,7 @@ String operator+(const wchar_t *a, const String &b) {
 	return String(a) + b;
 }
 
-bool String::begins_with(String &p_string) const {
+bool String::begins_with(const String &p_string) const {
 	return godot::api->godot_string_begins_with(&_godot_string, &p_string._godot_string);
 }
 
@@ -221,7 +221,7 @@ bool String::empty() const {
 	return godot::api->godot_string_empty(&_godot_string);
 }
 
-bool String::ends_with(String &p_string) const {
+bool String::ends_with(const String &p_string) const {
 	return godot::api->godot_string_ends_with(&_godot_string, &p_string._godot_string);
 }
 


### PR DESCRIPTION
`String::begins_with()` and `String::ends_with()` currently take a non-const `String&` argument. This looks like a mistake since the underlying C bindings expect const strings.

Currently this code does not compile since the string literal can't bind to a non-const reference:

```c++
String test;
test.ends_with("doesn't compile");
```