### PR TITLE
Fix clang 11 build failure over Wabsolute-value

### DIFF
--- a/src/core/CameraMatrix.cpp
+++ b/src/core/CameraMatrix.cpp
@@ -561,7 +561,7 @@ real_t CameraMatrix::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
+		return Math::rad2deg(acos(std::abs(right_plane.normal.x))) * 2.0;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],
@@ -570,7 +570,7 @@ real_t CameraMatrix::get_fov() const {
 				matrix[15] + matrix[12]);
 		left_plane.normalize();
 
-		return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
+		return Math::rad2deg(acos(std::abs(left_plane.normal.x))) + Math::rad2deg(acos(std::abs(right_plane.normal.x)));
 	}
 }
 


### PR DESCRIPTION
Clang 11 fails to build godot-cpp over Wabsolute-value. Fixing to use `std::abs(float)`.

```
sam@sam:~/work/spacebandit/libgai$ clang-11 --version
Ubuntu clang version 11.0.0-2
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin


-- Version: 6.2.2
-- Build type: Release
-- CXX_STANDARD: 11
-- Required features: cxx_variadic_templates
-- Generating Bindings
-- Configuring done
-- Generating done
-- Build files have been written to: /home/sam/work/spacebandit/libgai/work
Consolidate compiler generated dependencies of target fmt
[  0%] Built target fmt
Consolidate compiler generated dependencies of target libgai-test
[  2%] Built target libgai-test
Consolidate compiler generated dependencies of target godot-cpp
[  2%] Building CXX object lib/godot-cpp/CMakeFiles/godot-cpp.dir/src/core/CameraMatrix.cpp.o
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:564:29: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                return Math::rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
                                          ^
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:564:29: note: use function 'std::abs' instead
                return Math::rad2deg(acos(abs(right_plane.normal.x))) * 2.0;
                                          ^~~
                                          std::abs
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:573:29: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
                                          ^
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:573:29: note: use function 'std::abs' instead
                return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
                                          ^~~
                                          std::abs
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:573:77: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
                                                                                          ^
/home/sam/work/spacebandit/libgai/lib/godot-cpp/src/core/CameraMatrix.cpp:573:77: note: use function 'std::abs' instead
                return Math::rad2deg(acos(abs(left_plane.normal.x))) + Math::rad2deg(acos(abs(right_plane.normal.x)));
                                                                                          ^~~
                                                                                          std::abs
3 errors generated.
gmake[2]: *** [lib/godot-cpp/CMakeFiles/godot-cpp.dir/build.make:3915: lib/godot-cpp/CMakeFiles/godot-cpp.dir/src/core/CameraMatrix.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:206: lib/godot-cpp/CMakeFiles/godot-cpp.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
/home/sam/work/spacebandit/app/custom_node/gai/libgai-linux

```