### PR TITLE
Escape parameters named `enum`.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -881,6 +881,7 @@ def is_primitive(name):
 def escape_cpp(name):
     escapes = {
         "class":    "_class",
+        "enum":     "_enum",
         "char":     "_char",
         "short":    "_short",
         "bool":     "_bool",


### PR DESCRIPTION
Prefix parameters named `enum` with an underscore like all the other reserved keywords.