### PR TITLE
bindgen: Properly escape NodePath in default args

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -308,7 +308,7 @@ def generate_class_header(used_classes, c, use_template_get_node):
                     return "Rect2" + default_value
                 if _type == "Variant":
                     return "Variant()" if default_value == "Null" else default_value
-                if _type == "String":
+                if _type == "String" or _type == "NodePath":
                     return "\"" + default_value + "\""
                 if _type == "RID":
                     return "RID()"


### PR DESCRIPTION
Fixes build error with `3.x` headers due to a default argument being an empty NodePath (`""`).

Before:
```
include/gen/SoftBody.hpp
109:    void set_point_pinned(const int64_t point_index, const bool pinned, const NodePath attachment_path = );
```

After:
```
include/gen/SoftBody.hpp
109:    void set_point_pinned(const int64_t point_index, const bool pinned, const NodePath attachment_path = "");
```