### PR TITLE
CI: Disable test build to prepare for 4.0 extensions merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -qqq build-essential pkg-config
           python -m pip install scons
-          curl -LO https://downloads.tuxfamily.org/godotengine/3.3.3/Godot_v3.3.3-stable_linux_server.64.zip
-          unzip Godot_v3.3.3-stable_linux_server.64.zip
 
       - name: Build godot-cpp
         run: |
@@ -34,14 +32,6 @@ jobs:
           name: godot-cpp-linux-glibc2.27-x86_64-release
           path: bin/libgodot-cpp.linux.release.64.a
           if-no-files-found: error
-
-      - name: Build test GDNative library
-        run: |
-          scons target=release platform=linux bits=64 -j $(nproc) -C test
-
-      - name: Run test GDNative library
-        run: |
-          ./Godot_v3.3.3-stable_linux_server.64 --path test -s script.gd
 
   windows-msvc:
     name: Build (Windows, MSVC)
@@ -123,8 +113,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install scons
-          curl -LO https://downloads.tuxfamily.org/godotengine/3.3.3/Godot_v3.3.3-stable_osx.universal.zip
-          unzip Godot_v3.3.3-stable_osx.universal.zip
 
       - name: Build godot-cpp
         run: |
@@ -136,14 +124,6 @@ jobs:
           name: godot-cpp-macos-x86_64-release
           path: bin/libgodot-cpp.osx.release.64.a
           if-no-files-found: error
-
-      - name: Build test GDNative library
-        run: |
-          scons target=release platform=osx bits=64 -j $(sysctl -n hw.logicalcpu) -C test
-
-      - name: Run test GDNative library
-        run: |
-          ./Godot.app/Contents/MacOS/Godot --path test -s script.gd
 
   macos-arm64:
     name: Build (macOS, Clang, cross-compile arm64)


### PR DESCRIPTION
It can't pass and fixing it in the heavily WIP extensions implementation
would be a hassle, it's better to readd tests once things are working.