### PR TITLE
Use default destructor for Object

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -965,7 +965,7 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
         result.append("\ttemplate<class T>")
         result.append("\tstatic T *cast_to(Object *p_object);")
 
-        result.append("\tvirtual ~Object() {};")
+        result.append("\tvirtual ~Object() = default;")
     elif use_template_get_node and class_name == "Node":
         result.append("\ttemplate<class T>")
         result.append(


### PR DESCRIPTION
Minor style improvement, follows up #27. Was suggested by @vnen.