### PR TITLE
test: Setup for building both debug and release build

### DIFF
--- a/test/SConstruct
+++ b/test/SConstruct
@@ -2,10 +2,22 @@
 import os
 import sys
 
+# default values, adapt them to your setup
+default_library_name = "libgdexample"
+default_target_path = "demo/bin/"
+
+# Local dependency paths, adapt them to your setup
+cpp_bindings_path = "../"
+# cpp_bindings_path = "godot-cpp/"
+godot_headers_path = cpp_bindings_path + "godot-headers/"
+cpp_library = "libgodot-cpp"
+
 # Try to detect the host platform automatically.
 # This is used if no `platform` argument is passed
 if sys.platform.startswith("linux"):
     host_platform = "linux"
+elif sys.platform.startswith("freebsd"):
+    host_platform = "freebsd"
 elif sys.platform == "darwin":
     host_platform = "osx"
 elif sys.platform == "win32" or sys.platform == "msys":
@@ -18,20 +30,22 @@ env = Environment(ENV=os.environ)
 opts = Variables([], ARGUMENTS)
 
 # Define our options
-opts.Add(EnumVariable("target", "Compilation target", "debug", ["d", "debug", "r", "release"]))
-opts.Add(EnumVariable("platform", "Compilation platform", host_platform, ["", "windows", "x11", "linux", "osx"]))
+opts.Add(EnumVariable("target", "Compilation target", "debug", allowed_values=("debug", "release"), ignorecase=2))
 opts.Add(
-    EnumVariable("p", "Compilation target, alias for 'platform'", host_platform, ["", "windows", "x11", "linux", "osx"])
+    EnumVariable(
+        "platform",
+        "Compilation platform",
+        host_platform,
+        # We'll need to support these in due times
+        # allowed_values=("linux", "freebsd", "osx", "windows", "android", "ios", "javascript"),
+        allowed_values=("linux", "windows"),
+        ignorecase=2,
+    )
 )
 opts.Add(EnumVariable("bits", "Target platform bits", "64", ("32", "64")))
 opts.Add(BoolVariable("use_llvm", "Use the LLVM / Clang compiler", "no"))
-opts.Add(PathVariable("target_path", "The path where the lib is installed.", "demo/bin/", PathVariable.PathAccept))
-opts.Add(PathVariable("target_name", "The library name.", "libgdexample", PathVariable.PathAccept))
-
-# Local dependency paths, adapt them to your setup
-godot_headers_path = "../godot-headers/"
-cpp_bindings_path = "../"
-cpp_library = "libgodot-cpp"
+opts.Add(PathVariable("target_path", "The path where the lib is installed.", default_target_path, PathVariable.PathAccept))
+opts.Add(PathVariable("target_name", "The library name.", default_library_name, PathVariable.PathAccept))
 
 # only support 64 at this time..
 bits = 64
@@ -57,9 +71,6 @@ if env["use_llvm"]:
     env["CC"] = "clang"
     env["CXX"] = "clang++"
 
-if env["p"] != "":
-    env["platform"] = env["p"]
-
 if env["platform"] == "":
     print("No valid target platform selected.")
     quit()
@@ -82,23 +93,21 @@ if env["platform"] == "osx":
     env.Append(CCFLAGS=["-arch", "x86_64"])
     env.Append(CXXFLAGS=["-std=c++17"])
     env.Append(LINKFLAGS=["-arch", "x86_64"])
-    if env["target"] in ("debug", "d"):
+    if env["target"] == "debug":
         env.Append(CCFLAGS=["-g", "-O2"])
     else:
         env.Append(CCFLAGS=["-g", "-O3"])
 
 elif env["platform"] in ("x11", "linux"):
-    env["target_path"] += "x11/"
     cpp_library += ".linux"
     env.Append(CCFLAGS=["-fPIC"])
     env.Append(CXXFLAGS=["-std=c++17"])
-    if env["target"] in ("debug", "d"):
+    if env["target"] == "debug":
         env.Append(CCFLAGS=["-g3", "-Og"])
     else:
         env.Append(CCFLAGS=["-g", "-O3"])
 
 elif env["platform"] == "windows":
-    env["target_path"] += "win64/"
     cpp_library += ".windows"
     # This makes sure to keep the session environment variables on windows,
     # that way you can run scons in a vs 2017 prompt and it will find all the required tools
@@ -107,7 +116,7 @@ elif env["platform"] == "windows":
     env.Append(CPPDEFINES=["WIN32", "_WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS"])
     env.Append(CCFLAGS=["-W3", "-GR"])
     env.Append(CXXFLAGS=["-std:c++17"])
-    if env["target"] in ("debug", "d"):
+    if env["target"] == "debug":
         env.Append(CPPDEFINES=["_DEBUG"])
         env.Append(CCFLAGS=["-EHsc", "-MDd", "-ZI", "-FS"])
         env.Append(LINKFLAGS=["-DEBUG"])
@@ -118,12 +127,11 @@ elif env["platform"] == "windows":
     if not(env["use_llvm"]):
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
 
-if env["target"] in ("debug", "d"):
-    cpp_library += ".debug"
-else:
-    cpp_library += ".release"
+# determine our architecture suffix
+arch_suffix = str(bits)
 
-cpp_library += "." + str(bits)
+# suffix our godot-cpp library
+cpp_library += "." + env["target"] + "." + arch_suffix
 
 # make sure our binding library is properly includes
 env.Append(CPPPATH=[".", godot_headers_path, cpp_bindings_path + "include/", cpp_bindings_path + "gen/include/"])
@@ -134,6 +142,8 @@ env.Append(LIBS=[cpp_library])
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
-library = env.SharedLibrary(target=env["target_path"] + env["target_name"], source=sources)
+target_name = "{}.{}.{}.{}".format(env["target_name"], env["platform"], env["target"], arch_suffix)
+print(target_name)
+library = env.SharedLibrary(target=env["target_path"] + target_name, source=sources)
 
 Default(library)

--- a/test/demo/example.gdextension
+++ b/test/demo/example.gdextension
@@ -4,5 +4,7 @@ entry_symbol = "example_library_init"
 
 [libraries]
 
-linux.64 = "bin/x11/libgdexample.so"
-windows.64 = "bin/win64/libgdexample.dll"
+linux.64.debug = "bin/libgdexample.linux.debug.64.so"
+linux.64.release = "bin/libgdexample.linux.release.64.so"
+windows.64.debug = "bin/libgdexample.windows.debug.64.dll"
+windows.64.release = "bin/libgdexample.windows.release.64.dll"


### PR DESCRIPTION
I've changed the `SConstruct` file for the demo so that building release and debug builds now puts that in the name of the DLL. I also added platform and bits so that the naming is in line with `godot-cpp`.

This allows us to deploy both debug and release builds. I've updated the `.gdextension` file accordingly, it seems to be loading the correct one in the editor but I haven't check the export yet and that probably will need some upstream fixes.

Because the platform is now in the name of the dll I've removed the folders here, seemed overkill.

Finally I've moved a few things to the top of the file so that you can copy this `SConstruct` for your own project and edit two or three entries and it will work. I figured people would appreciate that especially if we continue building out our test to support more platforms.