### PR TITLE
[OSX] Add OSX universal build support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
           if-no-files-found: error
 
   macos:
-    name: Build (macOS, Clang)
-    runs-on: macos-10.15
+    name: Build (macOS, Clang, universal / x86_64 + arm64)
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -116,41 +116,7 @@ jobs:
 
       - name: Build godot-cpp
         run: |
-          scons target=release generate_bindings=yes macos_arch=x86_64 -j $(sysctl -n hw.logicalcpu)
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: godot-cpp-macos-x86_64-release
-          path: bin/libgodot-cpp.osx.release.x86_64.a
-          if-no-files-found: error
-
-  macos-arm64:
-    name: Build (macOS, Clang, cross-compile arm64)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install scons
-
-      - name: Build godot-cpp
-        run: |
-          # The default SDK in github the actions environemnt seems to have problems compiling for arm64.
-          # Use the latest 11.x SDK.
-          SDK_BASE=/Library/Developer/CommandLineTools/SDKs
-          SDK_VER=$(ls $SDK_BASE | grep "MacOSX11." | sort -r | head -n1)
-          echo $SDK_BASE/$SDK_VER/
-          scons target=release generate_bindings=yes macos_arch=arm64 macos_deployment_target=10.15 macos_sdk_path="$SDK_BASE/$SDK_VER/" -j $(sysctl -n hw.logicalcpu)
+          scons target=release generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
 
   static-checks:
     name: Static Checks (clang-format)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,13 @@ jobs:
 
       - name: Build godot-cpp
         run: |
-          scons target=release generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
+          scons target=release generate_bindings=yes macos_arch=x86_64 -j $(sysctl -n hw.logicalcpu)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: godot-cpp-macos-x86_64-release
-          path: bin/libgodot-cpp.osx.release.64.a
+          path: bin/libgodot-cpp.osx.release.x86_64.a
           if-no-files-found: error
 
   macos-arm64:


### PR DESCRIPTION
This is more of the work by @bruvzg in #529 .
My other two PRs combined were not the same, as they did not add the possibility to create a `universal` binary (i.e. a library containing both x64 and arm64 binaries).

This PR adds it and make the universal build the default and the only one in CI.
I'm sorry for the big mess :disappointed: (I'll try to backport to the 3.3 branch once confrimed).