### PR TITLE
[3.x] [OSX] Add universal build support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
 
   macos:
     name: Build (macOS, Clang)
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -133,44 +133,17 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: godot-cpp-macos-x86_64-release
+          name: godot-cpp-macos-universal-release
           path: bin/libgodot-cpp.osx.release.64.a
           if-no-files-found: error
 
       - name: Build test GDNative library
         run: |
-          scons target=release platform=osx bits=64 -j $(sysctl -n hw.logicalcpu) -C test
+          scons target=release platform=osx bits=64 macos_arch=universal -j $(sysctl -n hw.logicalcpu) -C test
 
       - name: Run test GDNative library
         run: |
           ./Godot.app/Contents/MacOS/Godot --path test -s script.gd
-
-  macos-arm64:
-    name: Build (macOS, Clang, cross-compile arm64)
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install scons
-
-      - name: Build godot-cpp
-        run: |
-          # The default SDK in github the actions environemnt seems to have problems compiling for arm64.
-          # Use the latest 11.x SDK.
-          SDK_BASE=/Library/Developer/CommandLineTools/SDKs
-          SDK_VER=$(ls $SDK_BASE | grep "MacOSX11." | sort -r | head -n1)
-          echo $SDK_BASE/$SDK_VER/
-          scons target=release generate_bindings=yes macos_arch=arm64 macos_deployment_target=10.15 macos_sdk_path="$SDK_BASE/$SDK_VER/" -j $(sysctl -n hw.logicalcpu)
 
   static-checks:
     name: Static Checks (clang-format)

--- a/SConstruct
+++ b/SConstruct
@@ -151,8 +151,8 @@ opts.Add(
 opts.Add(EnumVariable(
     'macos_arch',
     'Target macOS architecture',
-    'x86_64',
-    ['x86_64', 'arm64']
+    'universal',
+    ['universal', 'x86_64', 'arm64']
 ))
 opts.Add(EnumVariable(
     'ios_arch',
@@ -228,7 +228,14 @@ elif env['platform'] == 'osx':
             'Only 64-bit builds are supported for the macOS target.'
         )
 
-    env.Append(CCFLAGS=['-std=c++14', '-arch', env['macos_arch']])
+    if env["macos_arch"] == "universal":
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-arch", "arm64"])
+    else:
+        env.Append(LINKFLAGS=["-arch", env["macos_arch"]])
+        env.Append(CCFLAGS=["-arch", env["macos_arch"]])
+
+    env.Append(CCFLAGS=['-std=c++14'])
 
     if env['macos_deployment_target'] != 'default':
         env.Append(CCFLAGS=['-mmacosx-version-min=' + env['macos_deployment_target']])
@@ -239,8 +246,6 @@ elif env['platform'] == 'osx':
         env.Append(LINKFLAGS=['-isysroot', env['macos_sdk_path']])
 
     env.Append(LINKFLAGS=[
-        '-arch',
-        env['macos_arch'],
         '-framework',
         'Cocoa',
         '-Wl,-undefined,dynamic_lookup',
@@ -472,8 +477,8 @@ if env['platform'] == 'android':
 elif env['platform'] == 'ios':
     arch_suffix = env['ios_arch']
 elif env['platform'] == 'osx':
-    if env['macos_arch'] != 'x86_64':
-         arch_suffix = env['macos_arch']
+    if env['macos_arch'] != 'universal':
+        arch_suffix = env['macos_arch']
 elif env['platform'] == 'javascript':
     arch_suffix = 'wasm'
 


### PR DESCRIPTION
`3.x` port of #634 .

Small differences:
- Default arch is still `x86_64`, binary suffix is kept as `.64`  for compatibility(?).
- The `x86_64` build is kept in CI (as it works with the `test`, and I'm not sure it's safe to update the `gdnlib` in this branch).