### PR TITLE
Added test case for returning doubles

### DIFF
--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -8,6 +8,8 @@ func _ready():
 	$Example.simple_func()
 	($Example as Example).simple_const_func() # Force use of ptrcall
 	prints("returned", $Example.return_something("some string"))
+	prints("return 1 + 2 = ", $Example.return_double(1, 2))
+	prints("return 1.5 + 2.0 = ", $Example.return_double(1.5, 2.0))
 	prints("returned const", $Example.return_something_const())
 	prints("returned ref", $Example.return_extended_ref())
 	var ref = ExampleRef.new()

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -50,10 +50,11 @@ void Example::_bind_methods() {
 	// Methods.
 	ClassDB::bind_method(D_METHOD("simple_func"), &Example::simple_func);
 	ClassDB::bind_method(D_METHOD("simple_const_func"), &Example::simple_const_func);
-	ClassDB::bind_method(D_METHOD("return_something"), &Example::return_something);
+	ClassDB::bind_method(D_METHOD("return_something", "base"), &Example::return_something);
+	ClassDB::bind_method(D_METHOD("return_double", "a", "b"), &Example::return_double);
 	ClassDB::bind_method(D_METHOD("return_something_const"), &Example::return_something_const);
 	ClassDB::bind_method(D_METHOD("return_extended_ref"), &Example::return_extended_ref);
-	ClassDB::bind_method(D_METHOD("extended_ref_checks"), &Example::extended_ref_checks);
+	ClassDB::bind_method(D_METHOD("extended_ref_checks", "ref"), &Example::extended_ref_checks);
 
 	{
 		MethodInfo mi;
@@ -93,6 +94,10 @@ void Example::simple_const_func() const {
 String Example::return_something(const String &base) {
 	UtilityFunctions::print("Return something called.");
 	return base;
+}
+
+double Example::return_double(double p_a, double p_b) {
+	return p_a + p_b;
 }
 
 Viewport *Example::return_something_const() const {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -74,6 +74,7 @@ public:
 	void simple_func();
 	void simple_const_func() const;
 	String return_something(const String &base);
+	double return_double(double p_a, double p_b);
 	Viewport *return_something_const() const;
 	ExampleRef *return_extended_ref() const;
 	Ref<ExampleRef> extended_ref_checks(Ref<ExampleRef> p_ref) const;


### PR DESCRIPTION
Added a test case for an issue I'm looking into, just raising a draft PR to show the code, hopefully will change this into a fix once I know :)

The method I'm testing is really simple:
```
double Example::return_double(double p_a, double p_b) {
	return p_a + p_b;
}
```

Added two test cases:
```
prints("return 1 + 2 = ", $Example.return_double(1, 2))
prints("return 1.5 + 2.0 = ", $Example.return_double(1.5, 2.0))
```

The output currently is:
```
return 1 + 2 =  0
return 1.5 + 2.0 =  3.5
```

Originally I thought something was going wrong in returning the value as we were getting values in a and b but on close inspection those values are rubbish. The problem seems to be related to converting integer values to doubles..