### PR TITLE
Synced windows compile definitions with scons configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,11 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC
 	$<$<CONFIG:Debug>:DEBUG_ENABLED>
 	$<$<CONFIG:Debug>:DEBUG_METHODS_ENABLED>
 )
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	target_compile_definitions(${PROJECT_NAME} PUBLIC TYPED_METHOD_BIND)
+endif()
+
 target_include_directories(${PROJECT_NAME} PUBLIC
 	include
 	${CMAKE_CURRENT_BINARY_DIR}/gen/include


### PR DESCRIPTION
In [df9164b9bd7b4505a9918212e39451b75a38a7d7](https://github.com/godotengine/godot-cpp/commit/df9164b9bd7b4505a9918212e39451b75a38a7d7) TYPED_METHOD_BIND definition was added to scons project configuration. 

Without it windows method binding fail on compilation