### PR TITLE
Adding more info to method registration failure

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -199,7 +199,9 @@ MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, const char *p_name, M 
 
 	if (type.method_map.find(p_name) != type.method_map.end()) {
 		memdelete(bind);
-		ERR_FAIL_V_MSG(nullptr, "Binding duplicate method.");
+		char failmsg[1024];
+		sprintf(failmsg, "Binding duplicate method %s.%s.", type.name, p_name);
+		ERR_FAIL_V_MSG(nullptr, failmsg);
 	}
 
 	// register our method bind within our plugin

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -143,19 +143,28 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const M
 
 	if (type.method_map.find(method_name.name) != type.method_map.end()) {
 		memdelete(p_bind);
-		ERR_FAIL_V_MSG(nullptr, "Binding duplicate method.");
+
+		char failmsg[1024];
+		sprintf(failmsg, "Binding duplicate method %s.%s.", type.name, method_name.name);
+		ERR_FAIL_V_MSG(nullptr, failmsg);
 	}
 
 	if (type.virtual_methods.find(method_name.name) != type.virtual_methods.end()) {
 		memdelete(p_bind);
-		ERR_FAIL_V_MSG(nullptr, "Method already bound as virtual.");
+
+		char failmsg[1024];
+		sprintf(failmsg, "Method %s.%s already bound as virtual.", type.name, method_name.name);
+		ERR_FAIL_V_MSG(nullptr, failmsg);
 	}
 
 	p_bind->set_name(method_name.name);
 
 	if (method_name.args.size() > p_bind->get_argument_count()) {
 		memdelete(p_bind);
-		ERR_FAIL_V_MSG(nullptr, "Method definition has more arguments than the actual method.");
+
+		char failmsg[1024];
+		sprintf(failmsg, "Method %s.%s definition has more arguments than the actual method.", type.name, method_name.name);
+		ERR_FAIL_V_MSG(nullptr, failmsg);
 	}
 
 	p_bind->set_hint_flags(p_flags);

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -55,6 +55,9 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("return_extended_ref"), &Example::return_extended_ref);
 	ClassDB::bind_method(D_METHOD("extended_ref_checks"), &Example::extended_ref_checks);
 
+	// just testing errors, this should return an error in our logs!
+	ClassDB::bind_method(D_METHOD("simple_func"), &Example::simple_func);
+
 	{
 		MethodInfo mi;
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "some_argument"));


### PR DESCRIPTION
I ran into the problem of having some duplicate method registration but with adding a handful of new classes, the errors didn't tell me anything useful. So added that info in. 