### PR TITLE
Implementing dictionary operators

### DIFF
--- a/src/variant/packed_arrays.cpp
+++ b/src/variant/packed_arrays.cpp
@@ -33,6 +33,7 @@
 #include <godot_cpp/godot.hpp>
 
 #include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/variant/packed_color_array.hpp>
 #include <godot_cpp/variant/packed_float32_array.hpp>
@@ -132,6 +133,16 @@ const Variant &Array::operator[](int p_index) const {
 
 Variant &Array::operator[](int p_index) {
 	Variant *var = (Variant *)internal::gdn_interface->array_operator_index((GDNativeTypePtr *)this, p_index);
+	return *var;
+}
+
+const Variant &Dictionary::operator[](const Variant &p_key) const {
+	const Variant *var = (const Variant *)internal::gdn_interface->dictionary_operator_index_const((GDNativeTypePtr *)this, (GDNativeVariantPtr)&p_key);
+	return *var;
+}
+
+Variant &Dictionary::operator[](const Variant &p_key) {
+	Variant *var = (Variant *)internal::gdn_interface->dictionary_operator_index((GDNativeTypePtr *)this, (GDNativeVariantPtr)&p_key);
 	return *var;
 }
 

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -13,7 +13,9 @@ func _ready():
 	var ref = ExampleRef.new()
 	prints("sending ref: ", ref.get_instance_id(), "returned ref: ", $Example.extended_ref_checks(ref).get_instance_id())
 	prints("vararg args", $Example.varargs_func("some", "arguments", "to", "test"))
+
 	prints("test array", $Example.test_array())
+	prints("test dictionary", $Example.test_dictionary())
 
 	# Use properties.
 	prints("custom position is", $Example.group_subgroup_custom_position)

--- a/test/demo/main.tscn
+++ b/test/demo/main.tscn
@@ -6,15 +6,12 @@
 script = ExtResource( "1_c326s" )
 
 [node name="Example" type="Example" parent="."]
-script = null
 
 [node name="Label" type="Label" parent="Example"]
 offset_left = 194.0
 offset_top = -2.0
 offset_right = 234.0
 offset_bottom = 21.0
-structured_text_bidi_override_options = []
-script = null
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -23,9 +20,6 @@ __meta__ = {
 offset_right = 79.0
 offset_bottom = 29.0
 text = "Click me!"
-script = null
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[connection signal="custom_signal" from="Example" to="." method="_on_Example_custom_signal"]

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -54,7 +54,9 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("return_something_const"), &Example::return_something_const);
 	ClassDB::bind_method(D_METHOD("return_extended_ref"), &Example::return_extended_ref);
 	ClassDB::bind_method(D_METHOD("extended_ref_checks"), &Example::extended_ref_checks);
+
 	ClassDB::bind_method(D_METHOD("test_array"), &Example::test_array);
+	ClassDB::bind_method(D_METHOD("test_dictionary"), &Example::test_dictionary);
 
 	{
 		MethodInfo mi;
@@ -143,6 +145,15 @@ Array Example::test_array() const {
 	arr[1] = Variant(2);
 
 	return arr;
+}
+
+Dictionary Example::test_dictionary() const {
+	Dictionary dict;
+
+	dict["hello"] = "world";
+	dict["foo"] = "bar";
+
+	return dict;
 }
 
 // Properties.

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -88,7 +88,9 @@ public:
 	Ref<ExampleRef> extended_ref_checks(Ref<ExampleRef> p_ref) const;
 	Variant varargs_func(const Variant **args, GDNativeInt arg_count, GDNativeCallError &error);
 	void emit_custom_signal(const String &name, int value);
+
 	Array test_array() const;
+	Dictionary test_dictionary() const;
 
 	// Property.
 	void set_custom_position(const Vector2 &pos);


### PR DESCRIPTION
Requires https://github.com/godotengine/godot/pull/55247

Implement accessing dictionary through index. The test case in our test project works but fails on returning the dictionary which is a different issue. The problem here is that `return dict` will do a swap with a temporary dictionary object. This object does not instance a Godot object and the error happens on trying to free this non-existent object. We can see in the log that the dictionary was returned correctly:
```
USER ERROR: Condition "!_p" is true.
   at: Dictionary::_unref (core\variant\dictionary.cpp:244) - Condition "!_p" is true.
test dictionary {foo:bar, hello:world}
```

CI will fail until `godot-headers` is updated.