### PR TITLE
Avoid crash in Variant constructor from nullptr Object*

### DIFF
--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -171,7 +171,12 @@ Variant::Variant(const godot::RID &v) {
 }
 
 Variant::Variant(const Object *v) {
-	from_type_constructor[OBJECT](ptr(), const_cast<GodotObject **>(&v->_owner));
+	if (v) {
+		from_type_constructor[OBJECT](ptr(), const_cast<GodotObject **>(&v->_owner));
+	} else {
+		GodotObject *nullobject = nullptr;
+		from_type_constructor[OBJECT](ptr(), &nullobject);
+	}
 }
 
 Variant::Variant(const Callable &v) {


### PR DESCRIPTION
I am not sure about what I am doing, but this at least avoids a crash in my case.

The crash used to happen when generating the docs, while I had one of my extension's class property referencing another class (extending Resource): 
```
ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "magica_voxel_data", PROPERTY_HINT_RESOURCE_TYPE, "MagicaVoxelData"), "set_magica_voxel_data", "get_magica_voxel_data");
```

I suppose this fix does not really fix the underlying problem, but it avoids a crash. Which is likely a first good step IMO.