### PR TITLE
Print a warning with unknown SCons variables to ease troubleshooting

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -147,6 +147,13 @@ opts.Add(BoolVariable("generate_template_get_node", "Generate a template version
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
 
+# Detect and print a warning listing unknown SCons variables to ease troubleshooting.
+unknown = opts.UnknownVariables()
+if unknown:
+    print("WARNING: Unknown SCons variables were passed and will be ignored:")
+    for item in unknown.items():
+        print("    " + item[0] + "=" + item[1])
+
 # This makes sure to keep the session environment variables on Windows.
 # This way, you can run SCons in a Visual Studio 2017 prompt and it will find
 # all the required tools


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55203.

## Preview

```
❯ scons example=no  
scons: Reading SConscript files ...
WARNING: Unknown SCons variables were passed and will be ignored:
    example=no
scons: done reading SConscript files.
scons: Building targets ...
```