### PR TITLE
Fixing reference return

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -186,6 +186,14 @@ public:
 		r.reference = nullptr;
 	}
 
+	template <class T_Other>
+	Ref(Ref<T_Other> &&p_other) {
+		// Should just be able to swap these...
+		T *swap = (T *)p_other.reference;
+		p_other.reference = (T_Other *)reference;
+		reference = swap;
+	}
+
 	Ref(T *p_reference) {
 		if (p_reference) {
 			ref_pointer(p_reference);

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -9,9 +9,12 @@ func _ready():
 	($Example as Example).simple_const_func() # Force use of ptrcall
 	prints("returned", $Example.return_something("some string"))
 	prints("returned const", $Example.return_something_const())
-	prints("returned ref", $Example.return_extended_ref())
+
+	prints("returned example ref object: ", $Example.return_extended_ref())
+
 	var ref = ExampleRef.new()
 	prints("sending ref: ", ref.get_instance_id(), "returned ref: ", $Example.extended_ref_checks(ref).get_instance_id())
+
 	prints("vararg args", $Example.varargs_func("some", "arguments", "to", "test"))
 
 	prints("test array", $Example.test_array())

--- a/test/demo/main.tscn
+++ b/test/demo/main.tscn
@@ -1,17 +1,25 @@
-[gd_scene load_steps=2 format=3 uid="uid://dmx2xuigcpvt4"]
+[gd_scene load_steps=3 format=3 uid="uid://dmx2xuigcpvt4"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_c326s"]
+
+[sub_resource type="ExampleRef" id="ExampleRef_gveeo"]
+value = 5
 
 [node name="Node" type="Node"]
 script = ExtResource( "1_c326s" )
 
 [node name="Example" type="Example" parent="."]
+ref_obj = SubResource( "ExampleRef_gveeo" )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Label" type="Label" parent="Example"]
 offset_left = 194.0
 offset_top = -2.0
 offset_right = 234.0
 offset_bottom = 21.0
+theme_override_font_sizes/font_size = 16
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -39,21 +39,30 @@
 
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/global_constants.hpp>
+#include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/classes/viewport.hpp>
 
 #include <godot_cpp/core/binder_common.hpp>
 
 using namespace godot;
 
-class ExampleRef : public RefCounted {
-	GDCLASS(ExampleRef, RefCounted);
+class ExampleRef : public Resource {
+	GDCLASS(ExampleRef, Resource);
+
+private:
+	static uint64_t instance_count; // just so we can test if this comes back to 0 at the end of our test
+
+	int64_t value;
 
 protected:
-	static void _bind_methods() {}
+	static void _bind_methods();
 
 public:
 	ExampleRef();
 	~ExampleRef();
+
+	void set_value(int64_t p_value);
+	int64_t get_value() const;
 };
 
 class Example : public Control {
@@ -64,6 +73,7 @@ protected:
 
 private:
 	Vector2 custom_position;
+	Ref<ExampleRef> ref_obj;
 
 public:
 	// Constants.
@@ -84,7 +94,7 @@ public:
 	void simple_const_func() const;
 	String return_something(const String &base);
 	Viewport *return_something_const() const;
-	ExampleRef *return_extended_ref() const;
+	Ref<ExampleRef> return_extended_ref() const;
 	Ref<ExampleRef> extended_ref_checks(Ref<ExampleRef> p_ref) const;
 	Variant varargs_func(const Variant **args, GDNativeInt arg_count, GDNativeCallError &error);
 	void emit_custom_signal(const String &name, int value);
@@ -95,6 +105,9 @@ public:
 	// Property.
 	void set_custom_position(const Vector2 &pos);
 	Vector2 get_custom_position() const;
+
+	void set_ref_obj(const Ref<ExampleRef> p_ref);
+	Ref<ExampleRef> get_ref_obj() const;
 
 	// Virtual function override (no need to bind manually).
 	virtual bool _has_point(const Vector2 &point) const override;


### PR DESCRIPTION
Investigating various issues around using reference, adding use cases to the test project to test them and fixing them.

Note, things are currently broken on the Godot side until https://github.com/godotengine/godot/pull/55282 is merged.
You can work around that issue by commenting out the print statements in the constructors of Example and ExampleRef.