### PR TITLE
Allow SConstruct to be used as a subsidiary SConstruct for a parent project

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -430,8 +430,8 @@ env.Append(
     CPPPATH=[
         ".",
         env["headers_dir"],
-        "#include",
-        "#gen/include",
+        "include",
+        "gen/include",
     ]
 )
 
@@ -478,3 +478,4 @@ library = env.StaticLibrary(
     source=sources,
 )
 Default(library)
+Return('library')


### PR DESCRIPTION
Removing the `#` from the `CPPPATH` allows `godot-cpp`'s `SConstruct` file to be built as a child of a game project. 

With the `#` prefix [scons would look for these folders relative to my main `SConstruct` file](https://www.scons.org/doc/HTML/scons-man.html#cv-CPPPATH) (which is an incorrect behavior) as opposed to `godot-cpp`'s `SConstruct` file (which would be the correct behavior).

This allows the game project to be built with a single `scons` command rather than having to build `godot-cpp` manually first. `Return()`-ing the File Node that scons has built also eases the use of the built static lib.

With this change I can do this in my project's SConstruct file:
```
libGodotCpp = SConscript('lib/godot-cpp/SConstruct')
print(libGodotCpp) 

# [...] build the rest of my project as usual, and godot-cpp will be automatically be built with it
```

Unfortunately I couldn't get `env["headers_dir"]` to function as a workaround for all this as I'd need to fill it with 2 values (a path to the `include` folder and a path to the `gen/include` folder) at the same time.