### PR TITLE
Call Variant destructor in operator= to prevent a memory leak

### DIFF
--- a/src/core/Variant.cpp
+++ b/src/core/Variant.cpp
@@ -188,6 +188,7 @@ Variant::Variant(const PoolColorArray &p_color_array) {
 }
 
 Variant &Variant::operator=(const Variant &v) {
+	godot::api->godot_variant_destroy(&_godot_variant);
 	godot::api->godot_variant_new_copy(&_godot_variant, &v._godot_variant);
 	return *this;
 }


### PR DESCRIPTION
This is to prevent memory leaks in the present implementation of Variant operator= in GDNative (see #647, #643)

*Bugsquad edit:*
- Fixes #643
- Fixes #647