### PR TITLE
Fix object_set_instance being wrongly called for built-in wrapped classes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -45,7 +45,7 @@ class Wrapped {
 	friend void postinitialize_handler(Wrapped *);
 
 protected:
-	virtual const char *_get_class() const = 0; // This is needed to retrieve the class name before the godot object has its _extension and _extension_instance members assigned.
+	virtual const char *_get_extension_class() const; // This is needed to retrieve the class name before the godot object has its _extension and _extension_instance members assigned.
 	virtual const GDNativeInstanceBindingCallbacks *_get_bindings_callbacks() const = 0;
 
 	void _postinitialize();
@@ -60,26 +60,13 @@ public:
 
 } // namespace godot
 
-#ifdef DEBUG_ENABLED
-#define CHECK_CLASS_CONSTRUCTOR(m_constructor, m_class)                                                      \
-	if (unlikely(!m_constructor)) {                                                                          \
-		ERR_PRINT_ONCE("Constructor for class " #m_class "not found. Likely wasn't registered in ClassDB."); \
-		return nullptr;                                                                                      \
-	} else                                                                                                   \
-		((void)0)
-#else
-#define CHECK_CLASS_CONSTRUCTOR(m_constructor, m_class)
-#endif
-
 #define GDCLASS(m_class, m_inherits)                                                                               \
 private:                                                                                                           \
 	void operator=(const m_class &p_rval) {}                                                                       \
 	friend class ClassDB;                                                                                          \
                                                                                                                    \
-	using SelfType = m_class;                                                                                      \
-                                                                                                                   \
 protected:                                                                                                         \
-	virtual const char *_get_class() const override {                                                              \
+	virtual const char *_get_extension_class() const override {                                                    \
 		return get_class_static();                                                                                 \
 	}                                                                                                              \
                                                                                                                    \
@@ -151,10 +138,6 @@ private:                                                                        
 	void operator=(const m_class &p_rval) {}                                                                       \
                                                                                                                    \
 protected:                                                                                                         \
-	virtual const char *_get_class() const override {                                                              \
-		return get_class_static();                                                                                 \
-	}                                                                                                              \
-                                                                                                                   \
 	virtual const GDNativeInstanceBindingCallbacks *_get_bindings_callbacks() const override {                     \
 		return &___binding_callbacks;                                                                              \
 	}                                                                                                              \

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -36,8 +36,15 @@
 
 namespace godot {
 
+const char *Wrapped::_get_extension_class() const {
+	return nullptr;
+}
+
 void Wrapped::_postinitialize() {
-	godot::internal::gdn_interface->object_set_instance(_owner, _get_class(), this);
+	const char *extension_class = _get_extension_class();
+	if (extension_class) {
+		godot::internal::gdn_interface->object_set_instance(_owner, extension_class, this);
+	}
 	godot::internal::gdn_interface->object_set_instance_binding(_owner, godot::internal::token, this, _get_bindings_callbacks());
 }
 


### PR DESCRIPTION
This used to cause errors to be printed out, such as:
```
Class 'Image' has no native extension.
Class 'ImageTexture' has no native extension.
...
```
This happened for all objects created from a Godot built-in class. In such cases, we are not supposed to set the `_extension` and `_extension_instance` properties of the associated Godot `Object`, which `object_set_instance` does.

For this, I renamed `_get_class` to `_get_extension_class`, which will return `nullptr` for all built-in classes, and the extension class name for extension-only classes.

Also, I remove `CHECK_CLASS_CONSTRUCTOR`, it is unused since my recent constructor rework.