### PR TITLE
Require at least Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ else()
 endif()
 
 # Generate source from the bindings file
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 if(GENERATE_TEMPLATE_GET_NODE)
 	set(GENERATE_BINDING_PARAMETERS "True")
 else()


### PR DESCRIPTION
If CMake finds additional copies of python on a system it may choose python 2. This change ensures that at least python 3 is chosen.