### PR TITLE
Fixed crash when called methods return nullptr.

### DIFF
--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -48,6 +48,9 @@ O *_call_native_mb_ret_obj(const GDNativeMethodBindPtr mb, void *instance, const
 	GodotObject *ret = nullptr;
 	std::array<const GDNativeTypePtr, sizeof...(Args)> mb_args = { { (const GDNativeTypePtr)args... } };
 	internal::gdn_interface->object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
+	if (ret == nullptr) {
+		return nullptr;
+	}
 	return reinterpret_cast<O *>(internal::gdn_interface->object_get_instance_binding(ret, internal::token, &O::___binding_callbacks));
 }
 


### PR DESCRIPTION
The returned value "ret" may be nullptr in which case the code would crash because `object_get_instance_binding` can't be called on nullptr input.

This should be very easy to reproduce, I encountered it pretty much any time I called a method that returned `Ref<Something>`. E.g.:

```
Ref<GeometryInstance3D> instance;
instance.instantiate();
instance.get_mesh();    // Crash because no mesh was set for the instance and the returned value was nullptr.
```