### PR TITLE
Fix default library filename generation in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG "${BUILD_PATH}")
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE "${BUILD_PATH}")
 
 # Default build type is Debug in the SConstruct
-if(CMAKE_BUILD_TYPE STREQUAL "")
+if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 	set(CMAKE_BUILD_TYPE Debug)
 endif()
 
@@ -66,10 +66,12 @@ if(FLOAT_TYPE EQUAL 64)
 	set(FLOAT_TYPE_FLAG "double" CACHE STRING "")
 endif(FLOAT_TYPE EQUAL 64)
 
-set(BITS 32)
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(BITS 64)
-endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+if(NOT DEFINED BITS)
+	set(BITS 32)
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(BITS 64)
+	endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+endif()
 
 # Input from user for godot headers and the api file
 set(GODOT_HEADERS_DIR "godot-headers" CACHE STRING "")


### PR DESCRIPTION
The repository's CMakeLists.txt file was not reliably giving a library file of the name structure `godot-cpp.<platform>.<build_type>.<system_bits>`. Tested on Windows using MSVC and CMake v3.19, which gave me the mysterious file: `godot-cpp.windows..32.lib`, which is missing the `build_type` entirely and detected 32-bit despite being on a 64-bit machine.

While I'm unsure why `CMAKE_SIZEOF_VOID_P` was resolving as 4 on my 64-bit machine, I figured it would be nice to be able to explicitly specify the architecture like you can in the SConstruct file (with `bits=64`). Additionally, the statement `CMAKE_BUILD_TYPE STREQUAL ""` evaluates to false when `CMAKE_BUILD_TYPE` is not defined.

With both of these updates, you should be able to replicate (using an out-of-source build on Windows as an example):

```sh
mkdir build
# Default build: godot-cpp.windows.debug.32.lib
cmake build
# Explicitly set: godot-cpp.windows.release.64.lib
cmake -DCMAKE_BUILD_TYPE=Release -DBITS=64 build
```
