### PR TITLE
Add missing Vector3::operator Vector3i definition

### DIFF
--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -151,6 +151,7 @@ public:
 	real_t aspect() const { return width / height; }
 
 	operator String() const;
+	operator Vector2i() const;
 
 	inline Vector2() {}
 	inline Vector2(real_t p_x, real_t p_y) {

--- a/src/variant/vector2.cpp
+++ b/src/variant/vector2.cpp
@@ -31,11 +31,16 @@
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/vector2.hpp>
+#include <godot_cpp/variant/vector2i.hpp>
 
 namespace godot {
 
 Vector2::operator String() const {
 	return String::num(x, 5) + ", " + String::num(y, 5);
+}
+
+Vector2::operator Vector2i() const {
+	return Vector2i(x, y);
 }
 
 real_t Vector2::angle() const {

--- a/src/variant/vector3.cpp
+++ b/src/variant/vector3.cpp
@@ -31,6 +31,7 @@
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/basis.hpp>
 #include <godot_cpp/variant/vector3.hpp>
+#include <godot_cpp/variant/vector3i.hpp>
 
 namespace godot {
 
@@ -119,6 +120,10 @@ bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 
 Vector3::operator String() const {
 	return (String::num(x, 5) + ", " + String::num(y, 5) + ", " + String::num(z, 5));
+}
+
+Vector3::operator Vector3i() const {
+	return Vector3i(x, y, z);
 }
 
 } // namespace godot


### PR DESCRIPTION
The definition is simply missing.