### PR TITLE
Add `ptr()` / `ptrw()` to the arrays, add missing `String` methods, add missing `CharString` method implementations.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -246,7 +246,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
     result.append(f"\tstatic constexpr size_t {snake_class_name}_SIZE = {size};")
     result.append(f"\tuint8_t opaque[{snake_class_name}_SIZE] = {{}};")
     result.append(
-        f"\t_FORCE_INLINE_ GDNativeTypePtr ptr() const {{ return const_cast<uint8_t (*)[{snake_class_name}_SIZE]>(&opaque); }}"
+        f"\t_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const {{ return const_cast<uint8_t (*)[{snake_class_name}_SIZE]>(&opaque); }}"
     )
 
     result.append("")
@@ -378,6 +378,10 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
 
     # Special cases.
     if class_name == "String":
+        result.append("\tstatic String utf8(const char *from, int len = -1);")
+        result.append("\tvoid parse_utf8(const char *from, int len = -1);")
+        result.append("\tstatic String utf16(const char16_t *from, int len = -1);")
+        result.append("\tvoid parse_utf16(const char16_t *from, int len = -1);")
         result.append("\tCharString utf8() const;")
         result.append("\tCharString ascii() const;")
         result.append("\tChar16String utf16() const;")
@@ -426,6 +430,8 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
         result.append("bool operator!=(const char32_t *p_str) const;")
         result.append(f"\tconst char32_t &operator[](int p_index) const;")
         result.append(f"\tchar32_t &operator[](int p_index);")
+        result.append(f"\tconst char32_t *ptr() const;")
+        result.append(f"\tchar32_t *ptrw();")
 
     if class_name == "Array":
         result.append("\ttemplate <class... Args>")
@@ -443,6 +449,8 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
             return_type = "float"
         result.append(f"\tconst " + return_type + f" &operator[](int p_index) const;")
         result.append(f"\t" + return_type + f" &operator[](int p_index);")
+        result.append(f"\tconst " + return_type + f" *ptr() const;")
+        result.append(f"\t" + return_type + f" *ptrw();")
 
     if class_name == "Array":
         result.append(f"\tconst Variant &operator[](int p_index) const;")

--- a/include/godot_cpp/variant/aabb.hpp
+++ b/include/godot_cpp/variant/aabb.hpp
@@ -44,9 +44,11 @@
 namespace godot {
 
 class AABB {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Vector3 position;
 	Vector3 size;
 
@@ -73,8 +75,8 @@ public:
 	inline bool encloses(const AABB &p_aabb) const; /// p_aabb is completely inside this
 
 	AABB merge(const AABB &p_with) const;
-	void merge_with(const AABB &p_aabb); ///merge with another AABB
-	AABB intersection(const AABB &p_aabb) const; ///get box where two intersect, empty if no intersection occurs
+	void merge_with(const AABB &p_aabb); /// merge with another AABB
+	AABB intersection(const AABB &p_aabb) const; /// get box where two intersect, empty if no intersection occurs
 	bool intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector3 *r_clip = nullptr, Vector3 *r_normal = nullptr) const;
 	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *r_clip = nullptr, Vector3 *r_normal = nullptr) const;
 	inline bool smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t t0, real_t t1) const;

--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -38,9 +38,11 @@
 namespace godot {
 
 class Basis {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Vector3 elements[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),

--- a/include/godot_cpp/variant/char_string.hpp
+++ b/include/godot_cpp/variant/char_string.hpp
@@ -48,6 +48,9 @@ public:
 	int length() const;
 	const char *get_data() const;
 
+	CharString(CharString &&p_str);
+	void operator=(CharString &&p_str);
+	CharString() {}
 	~CharString();
 };
 
@@ -63,6 +66,9 @@ public:
 	int length() const;
 	const char16_t *get_data() const;
 
+	Char16String(Char16String &&p_str);
+	void operator=(Char16String &&p_str);
+	Char16String() {}
 	~Char16String();
 };
 
@@ -78,6 +84,9 @@ public:
 	int length() const;
 	const char32_t *get_data() const;
 
+	Char32String(Char32String &&p_str);
+	void operator=(Char32String &&p_str);
+	Char32String() {}
 	~Char32String();
 };
 
@@ -93,6 +102,9 @@ public:
 	int length() const;
 	const wchar_t *get_data() const;
 
+	CharWideString(CharWideString &&p_str);
+	void operator=(CharWideString &&p_str);
+	CharWideString() {}
 	~CharWideString();
 };
 

--- a/include/godot_cpp/variant/color.hpp
+++ b/include/godot_cpp/variant/color.hpp
@@ -38,9 +38,11 @@ namespace godot {
 class String;
 
 class Color {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	union {
 		struct {
 			float r;
@@ -198,7 +200,7 @@ public:
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_a);
 	static Color from_rgbe9995(uint32_t p_rgbe);
 
-	inline bool operator<(const Color &p_color) const; //used in set keys
+	inline bool operator<(const Color &p_color) const; // used in set keys
 	operator String() const;
 
 	// For the binder.

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -38,14 +38,16 @@
 namespace godot {
 
 class Plane {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Vector3 normal;
 	real_t d = 0;
 
 	void set_normal(const Vector3 &p_normal);
-	inline Vector3 get_normal() const { return normal; }; ///Point is coplanar, CMP_EPSILON for precision
+	inline Vector3 get_normal() const { return normal; }; /// Point is coplanar, CMP_EPSILON for precision
 
 	void normalize();
 	Plane normalized() const;

--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -37,9 +37,11 @@
 namespace godot {
 
 class Quaternion {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	union {
 		struct {
 			real_t x;

--- a/include/godot_cpp/variant/rect2.hpp
+++ b/include/godot_cpp/variant/rect2.hpp
@@ -40,9 +40,11 @@ namespace godot {
 class Transform2D;
 
 class Rect2 {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Point2 position;
 	Size2 size;
 
@@ -161,7 +163,7 @@ public:
 		new_rect.size.x = Math::max(p_rect.position.x + p_rect.size.x, position.x + size.x);
 		new_rect.size.y = Math::max(p_rect.position.y + p_rect.size.y, position.y + size.y);
 
-		new_rect.size = new_rect.size - new_rect.position; //make relative again
+		new_rect.size = new_rect.size - new_rect.position; // make relative again
 
 		return new_rect;
 	}
@@ -225,7 +227,7 @@ public:
 		return r;
 	}
 
-	inline void expand_to(const Vector2 &p_vector) { //in place function for speed
+	inline void expand_to(const Vector2 &p_vector) { // in place function for speed
 
 		Vector2 begin = position;
 		Vector2 end = position + size;
@@ -279,7 +281,7 @@ public:
 				continue;
 			}
 
-			//check inside
+			// check inside
 			Vector2 tg = r.orthogonal();
 			float s = tg.dot(center) - tg.dot(a);
 			if (s < 0.0) {
@@ -288,7 +290,7 @@ public:
 				side_minus++;
 			}
 
-			//check ray box
+			// check ray box
 			r /= l;
 			Vector2 ir((real_t)1.0 / r.x, (real_t)1.0 / r.y);
 
@@ -309,7 +311,7 @@ public:
 		}
 
 		if (side_plus * side_minus == 0) {
-			return true; //all inside
+			return true; // all inside
 		} else {
 			return false;
 		}

--- a/include/godot_cpp/variant/rect2i.hpp
+++ b/include/godot_cpp/variant/rect2i.hpp
@@ -37,9 +37,11 @@
 namespace godot {
 
 class Rect2i {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Point2i position;
 	Size2i size;
 
@@ -107,7 +109,7 @@ public:
 		new_rect.size.x = Math::max(p_rect.position.x + p_rect.size.x, position.x + size.x);
 		new_rect.size.y = Math::max(p_rect.position.y + p_rect.size.y, position.y + size.y);
 
-		new_rect.size = new_rect.size - new_rect.position; //make relative again
+		new_rect.size = new_rect.size - new_rect.position; // make relative again
 
 		return new_rect;
 	}

--- a/include/godot_cpp/variant/transform2d.hpp
+++ b/include/godot_cpp/variant/transform2d.hpp
@@ -40,9 +40,11 @@
 namespace godot {
 
 class Transform2D {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
 	// M = (elements[0][0] elements[1][0])
 	//     (elements[0][1] elements[1][1])

--- a/include/godot_cpp/variant/transform3d.hpp
+++ b/include/godot_cpp/variant/transform3d.hpp
@@ -40,9 +40,11 @@
 namespace godot {
 
 class Transform3D {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	Basis basis;
 	Vector3 origin;
 

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -45,7 +45,7 @@ namespace godot {
 class Variant {
 	uint8_t opaque[GODOT_CPP_VARIANT_SIZE]{ 0 };
 
-	_FORCE_INLINE_ GDNativeVariantPtr ptr() const { return const_cast<uint8_t(*)[GODOT_CPP_VARIANT_SIZE]>(&opaque); }
+	_FORCE_INLINE_ GDNativeVariantPtr _native_ptr() const { return const_cast<uint8_t(*)[GODOT_CPP_VARIANT_SIZE]>(&opaque); }
 
 	friend class GDExtensionBinding;
 	friend class MethodBind;

--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -39,9 +39,11 @@ namespace godot {
 class Vector2i;
 
 class Vector2 {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -38,9 +38,11 @@
 namespace godot {
 
 class Vector2i {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -40,9 +40,11 @@ class Basis;
 class Vector3i;
 
 class Vector3 {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -37,9 +37,11 @@
 namespace godot {
 
 class Vector3i {
-public:
-	_FORCE_INLINE_ GDNativeTypePtr ptr() const { return (void *)this; }
+	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
 
+	friend class Variant;
+
+public:
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/src/core/method_bind.cpp
+++ b/src/core/method_bind.cpp
@@ -103,7 +103,7 @@ void MethodBind::bind_call(void *p_method_userdata, GDExtensionClassInstancePtr 
 	Variant ret = bind->call(p_instance, p_args, p_argument_count, *r_error);
 	// This assumes the return value is an empty Variant, so it doesn't need to call the destructor first.
 	// Since only NativeExtensionMethodBind calls this from the Godot side, it should always be the case.
-	internal::gdn_interface->variant_new_copy(r_return, ret.ptr());
+	internal::gdn_interface->variant_new_copy(r_return, ret._native_ptr());
 }
 
 void MethodBind::bind_ptrcall(void *p_method_userdata, GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_return) {

--- a/src/variant/char_string.cpp
+++ b/src/variant/char_string.cpp
@@ -39,61 +39,157 @@
 
 namespace godot {
 
+int CharString::length() const {
+	return _length;
+}
+
 const char *CharString::get_data() const {
 	return _data;
+}
+
+CharString::CharString(CharString &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
+}
+
+void CharString::operator=(CharString &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
 }
 
 CharString::CharString(const char *str, int length) :
 		_data(str), _length(length) {}
 
 CharString::~CharString() {
-	memdelete_arr(_data);
+	if (_data != nullptr) {
+		memdelete_arr(_data);
+	}
+}
+
+int Char16String::length() const {
+	return _length;
+}
+
+const char16_t *Char16String::get_data() const {
+	return _data;
+}
+
+Char16String::Char16String(Char16String &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
+}
+
+void Char16String::operator=(Char16String &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
 }
 
 Char16String::Char16String(const char16_t *str, int length) :
 		_data(str), _length(length) {}
 
 Char16String::~Char16String() {
-	memdelete_arr(_data);
+	if (_data != nullptr) {
+		memdelete_arr(_data);
+	}
+}
+
+int Char32String::length() const {
+	return _length;
+}
+
+const char32_t *Char32String::get_data() const {
+	return _data;
+}
+
+Char32String::Char32String(Char32String &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
+}
+
+void Char32String::operator=(Char32String &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
 }
 
 Char32String::Char32String(const char32_t *str, int length) :
 		_data(str), _length(length) {}
 
 Char32String::~Char32String() {
-	memdelete_arr(_data);
+	if (_data != nullptr) {
+		memdelete_arr(_data);
+	}
+}
+
+int CharWideString::length() const {
+	return _length;
+}
+
+const wchar_t *CharWideString::get_data() const {
+	return _data;
+}
+
+CharWideString::CharWideString(CharWideString &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
+}
+
+void CharWideString::operator=(CharWideString &&p_str) {
+	SWAP(_length, p_str._length);
+	SWAP(_data, p_str._data);
 }
 
 CharWideString::CharWideString(const wchar_t *str, int length) :
 		_data(str), _length(length) {}
 
 CharWideString::~CharWideString() {
-	memdelete_arr(_data);
+	if (_data != nullptr) {
+		memdelete_arr(_data);
+	}
 }
 
 // Custom String functions that are not part of bound API.
 // It's easier to have them written in C++ directly than in a Python script that generates them.
 
 String::String(const char *from) {
-	internal::gdn_interface->string_new_with_utf8_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_latin1_chars(_native_ptr(), from);
 }
 
 String::String(const wchar_t *from) {
-	internal::gdn_interface->string_new_with_wide_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_wide_chars(_native_ptr(), from);
 }
 
 String::String(const char16_t *from) {
-	internal::gdn_interface->string_new_with_utf16_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_utf16_chars(_native_ptr(), from);
 }
 
 String::String(const char32_t *from) {
-	internal::gdn_interface->string_new_with_utf32_chars(ptr(), from);
+	internal::gdn_interface->string_new_with_utf32_chars(_native_ptr(), from);
+}
+
+String String::utf8(const char *from, int len) {
+	String ret;
+	ret.parse_utf8(from, len);
+	return ret;
+}
+
+void String::parse_utf8(const char *from, int len) {
+	internal::gdn_interface->string_new_with_utf8_chars_and_len(_native_ptr(), from, len);
+}
+
+String String::utf16(const char16_t *from, int len) {
+	String ret;
+	ret.parse_utf16(from, len);
+	return ret;
+}
+
+void String::parse_utf16(const char16_t *from, int len) {
+	internal::gdn_interface->string_new_with_utf16_chars_and_len(_native_ptr(), from, len);
 }
 
 CharString String::utf8() const {
-	int size = internal::gdn_interface->string_to_utf8_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf8_chars(_native_ptr(), nullptr, 0);
 	char *cstr = memnew_arr(char, size + 1);
-	internal::gdn_interface->string_to_utf8_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf8_chars(_native_ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -101,9 +197,9 @@ CharString String::utf8() const {
 }
 
 CharString String::ascii() const {
-	int size = internal::gdn_interface->string_to_latin1_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_latin1_chars(_native_ptr(), nullptr, 0);
 	char *cstr = memnew_arr(char, size + 1);
-	internal::gdn_interface->string_to_latin1_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_latin1_chars(_native_ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -111,9 +207,9 @@ CharString String::ascii() const {
 }
 
 Char16String String::utf16() const {
-	int size = internal::gdn_interface->string_to_utf16_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf16_chars(_native_ptr(), nullptr, 0);
 	char16_t *cstr = memnew_arr(char16_t, size + 1);
-	internal::gdn_interface->string_to_utf16_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf16_chars(_native_ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -121,9 +217,9 @@ Char16String String::utf16() const {
 }
 
 Char32String String::utf32() const {
-	int size = internal::gdn_interface->string_to_utf32_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_utf32_chars(_native_ptr(), nullptr, 0);
 	char32_t *cstr = memnew_arr(char32_t, size + 1);
-	internal::gdn_interface->string_to_utf32_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_utf32_chars(_native_ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -131,9 +227,9 @@ Char32String String::utf32() const {
 }
 
 CharWideString String::wide_string() const {
-	int size = internal::gdn_interface->string_to_wide_chars(ptr(), nullptr, 0);
+	int size = internal::gdn_interface->string_to_wide_chars(_native_ptr(), nullptr, 0);
 	wchar_t *cstr = memnew_arr(wchar_t, size + 1);
-	internal::gdn_interface->string_to_wide_chars(ptr(), cstr, size + 1);
+	internal::gdn_interface->string_to_wide_chars(_native_ptr(), cstr, size + 1);
 
 	cstr[size] = '\0';
 
@@ -198,6 +294,14 @@ const char32_t &String::operator[](int p_index) const {
 
 char32_t &String::operator[](int p_index) {
 	return *internal::gdn_interface->string_operator_index((GDNativeStringPtr)this, p_index);
+}
+
+const char32_t *String::ptr() const {
+	return internal::gdn_interface->string_operator_index_const((GDNativeStringPtr)this, 0);
+}
+
+char32_t *String::ptrw() {
+	return internal::gdn_interface->string_operator_index((GDNativeStringPtr)this, 0);
 }
 
 bool operator==(const char *p_chr, const String &p_str) {

--- a/src/variant/packed_arrays.cpp
+++ b/src/variant/packed_arrays.cpp
@@ -54,6 +54,14 @@ uint8_t &PackedByteArray::operator[](int p_index) {
 	return *internal::gdn_interface->packed_byte_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
+const uint8_t *PackedByteArray::ptr() const {
+	return internal::gdn_interface->packed_byte_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+uint8_t *PackedByteArray::ptrw() {
+	return internal::gdn_interface->packed_byte_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const Color &PackedColorArray::operator[](int p_index) const {
 	const Color *color = (const Color *)internal::gdn_interface->packed_color_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *color;
@@ -64,12 +72,28 @@ Color &PackedColorArray::operator[](int p_index) {
 	return *color;
 }
 
+const Color *PackedColorArray::ptr() const {
+	return (const Color *)internal::gdn_interface->packed_color_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+Color *PackedColorArray::ptrw() {
+	return (Color *)internal::gdn_interface->packed_color_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const float &PackedFloat32Array::operator[](int p_index) const {
 	return *internal::gdn_interface->packed_float32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 float &PackedFloat32Array::operator[](int p_index) {
 	return *internal::gdn_interface->packed_float32_array_operator_index((GDNativeTypePtr *)this, p_index);
+}
+
+const float *PackedFloat32Array::ptr() const {
+	return internal::gdn_interface->packed_float32_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+float *PackedFloat32Array::ptrw() {
+	return internal::gdn_interface->packed_float32_array_operator_index((GDNativeTypePtr *)this, 0);
 }
 
 const double &PackedFloat64Array::operator[](int p_index) const {
@@ -80,6 +104,14 @@ double &PackedFloat64Array::operator[](int p_index) {
 	return *internal::gdn_interface->packed_float64_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
+const double *PackedFloat64Array::ptr() const {
+	return internal::gdn_interface->packed_float64_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+double *PackedFloat64Array::ptrw() {
+	return internal::gdn_interface->packed_float64_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const int32_t &PackedInt32Array::operator[](int p_index) const {
 	return *internal::gdn_interface->packed_int32_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
@@ -88,12 +120,28 @@ int32_t &PackedInt32Array::operator[](int p_index) {
 	return *internal::gdn_interface->packed_int32_array_operator_index((GDNativeTypePtr *)this, p_index);
 }
 
+const int32_t *PackedInt32Array::ptr() const {
+	return internal::gdn_interface->packed_int32_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+int32_t *PackedInt32Array::ptrw() {
+	return internal::gdn_interface->packed_int32_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const int64_t &PackedInt64Array::operator[](int p_index) const {
 	return *internal::gdn_interface->packed_int64_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 }
 
 int64_t &PackedInt64Array::operator[](int p_index) {
 	return *internal::gdn_interface->packed_int64_array_operator_index((GDNativeTypePtr *)this, p_index);
+}
+
+const int64_t *PackedInt64Array::ptr() const {
+	return internal::gdn_interface->packed_int64_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+int64_t *PackedInt64Array::ptrw() {
+	return internal::gdn_interface->packed_int64_array_operator_index((GDNativeTypePtr *)this, 0);
 }
 
 const String &PackedStringArray::operator[](int p_index) const {
@@ -106,6 +154,14 @@ String &PackedStringArray::operator[](int p_index) {
 	return *string;
 }
 
+const String *PackedStringArray::ptr() const {
+	return (const String *)internal::gdn_interface->packed_string_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+String *PackedStringArray::ptrw() {
+	return (String *)internal::gdn_interface->packed_string_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const Vector2 &PackedVector2Array::operator[](int p_index) const {
 	const Vector2 *vec = (const Vector2 *)internal::gdn_interface->packed_vector2_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *vec;
@@ -116,6 +172,14 @@ Vector2 &PackedVector2Array::operator[](int p_index) {
 	return *vec;
 }
 
+const Vector2 *PackedVector2Array::ptr() const {
+	return (const Vector2 *)internal::gdn_interface->packed_vector2_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+Vector2 *PackedVector2Array::ptrw() {
+	return (Vector2 *)internal::gdn_interface->packed_vector2_array_operator_index((GDNativeTypePtr *)this, 0);
+}
+
 const Vector3 &PackedVector3Array::operator[](int p_index) const {
 	const Vector3 *vec = (const Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index_const((GDNativeTypePtr *)this, p_index);
 	return *vec;
@@ -124,6 +188,14 @@ const Vector3 &PackedVector3Array::operator[](int p_index) const {
 Vector3 &PackedVector3Array::operator[](int p_index) {
 	Vector3 *vec = (Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index((GDNativeTypePtr *)this, p_index);
 	return *vec;
+}
+
+const Vector3 *PackedVector3Array::ptr() const {
+	return (const Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index_const((GDNativeTypePtr *)this, 0);
+}
+
+Vector3 *PackedVector3Array::ptrw() {
+	return (Vector3 *)internal::gdn_interface->packed_vector3_array_operator_index((GDNativeTypePtr *)this, 0);
 }
 
 const Variant &Array::operator[](int p_index) const {

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -69,15 +69,15 @@ void Variant::init_bindings() {
 }
 
 Variant::Variant() {
-	internal::gdn_interface->variant_new_nil(ptr());
+	internal::gdn_interface->variant_new_nil(_native_ptr());
 }
 
 Variant::Variant(const GDNativeVariantPtr native_ptr) {
-	internal::gdn_interface->variant_new_copy(ptr(), native_ptr);
+	internal::gdn_interface->variant_new_copy(_native_ptr(), native_ptr);
 }
 
 Variant::Variant(const Variant &other) {
-	internal::gdn_interface->variant_new_copy(ptr(), other.ptr());
+	internal::gdn_interface->variant_new_copy(_native_ptr(), other._native_ptr());
 }
 
 Variant::Variant(Variant &&other) {
@@ -87,163 +87,163 @@ Variant::Variant(Variant &&other) {
 Variant::Variant(bool v) {
 	GDNativeBool encoded;
 	PtrToArg<bool>::encode(v, &encoded);
-	from_type_constructor[BOOL](ptr(), &encoded);
+	from_type_constructor[BOOL](_native_ptr(), &encoded);
 }
 
 Variant::Variant(int64_t v) {
 	GDNativeInt encoded;
 	PtrToArg<int64_t>::encode(v, &encoded);
-	from_type_constructor[INT](ptr(), &encoded);
+	from_type_constructor[INT](_native_ptr(), &encoded);
 }
 
 Variant::Variant(double v) {
 	double encoded;
 	PtrToArg<double>::encode(v, &encoded);
-	from_type_constructor[FLOAT](ptr(), &encoded);
+	from_type_constructor[FLOAT](_native_ptr(), &encoded);
 }
 
 Variant::Variant(const String &v) {
-	from_type_constructor[STRING](ptr(), v.ptr());
+	from_type_constructor[STRING](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Vector2 &v) {
-	from_type_constructor[VECTOR2](ptr(), v.ptr());
+	from_type_constructor[VECTOR2](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Vector2i &v) {
-	from_type_constructor[VECTOR2I](ptr(), v.ptr());
+	from_type_constructor[VECTOR2I](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Rect2 &v) {
-	from_type_constructor[RECT2](ptr(), v.ptr());
+	from_type_constructor[RECT2](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Rect2i &v) {
-	from_type_constructor[RECT2I](ptr(), v.ptr());
+	from_type_constructor[RECT2I](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Vector3 &v) {
-	from_type_constructor[VECTOR3](ptr(), v.ptr());
+	from_type_constructor[VECTOR3](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Vector3i &v) {
-	from_type_constructor[VECTOR3I](ptr(), v.ptr());
+	from_type_constructor[VECTOR3I](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Transform2D &v) {
-	from_type_constructor[TRANSFORM2D](ptr(), v.ptr());
+	from_type_constructor[TRANSFORM2D](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Plane &v) {
-	from_type_constructor[PLANE](ptr(), v.ptr());
+	from_type_constructor[PLANE](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Quaternion &v) {
-	from_type_constructor[QUATERNION](ptr(), v.ptr());
+	from_type_constructor[QUATERNION](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const godot::AABB &v) {
-	from_type_constructor[AABB](ptr(), v.ptr());
+	from_type_constructor[AABB](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Basis &v) {
-	from_type_constructor[BASIS](ptr(), v.ptr());
+	from_type_constructor[BASIS](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Transform3D &v) {
-	from_type_constructor[TRANSFORM3D](ptr(), v.ptr());
+	from_type_constructor[TRANSFORM3D](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Color &v) {
-	from_type_constructor[COLOR](ptr(), v.ptr());
+	from_type_constructor[COLOR](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const StringName &v) {
-	from_type_constructor[STRING_NAME](ptr(), v.ptr());
+	from_type_constructor[STRING_NAME](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const NodePath &v) {
-	from_type_constructor[NODE_PATH](ptr(), v.ptr());
+	from_type_constructor[NODE_PATH](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const godot::RID &v) {
-	from_type_constructor[RID](ptr(), v.ptr());
+	from_type_constructor[RID](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Object *v) {
 	if (v) {
-		from_type_constructor[OBJECT](ptr(), const_cast<GodotObject **>(&v->_owner));
+		from_type_constructor[OBJECT](_native_ptr(), const_cast<GodotObject **>(&v->_owner));
 	} else {
 		GodotObject *nullobject = nullptr;
-		from_type_constructor[OBJECT](ptr(), &nullobject);
+		from_type_constructor[OBJECT](_native_ptr(), &nullobject);
 	}
 }
 
 Variant::Variant(const Callable &v) {
-	from_type_constructor[CALLABLE](ptr(), v.ptr());
+	from_type_constructor[CALLABLE](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Signal &v) {
-	from_type_constructor[SIGNAL](ptr(), v.ptr());
+	from_type_constructor[SIGNAL](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Dictionary &v) {
-	from_type_constructor[DICTIONARY](ptr(), v.ptr());
+	from_type_constructor[DICTIONARY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const Array &v) {
-	from_type_constructor[ARRAY](ptr(), v.ptr());
+	from_type_constructor[ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedByteArray &v) {
-	from_type_constructor[PACKED_BYTE_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_BYTE_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedInt32Array &v) {
-	from_type_constructor[PACKED_INT32_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_INT32_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedInt64Array &v) {
-	from_type_constructor[PACKED_INT64_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_INT64_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedFloat32Array &v) {
-	from_type_constructor[PACKED_FLOAT32_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_FLOAT32_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedFloat64Array &v) {
-	from_type_constructor[PACKED_FLOAT64_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_FLOAT64_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedStringArray &v) {
-	from_type_constructor[PACKED_STRING_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_STRING_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedVector2Array &v) {
-	from_type_constructor[PACKED_VECTOR2_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_VECTOR2_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedVector3Array &v) {
-	from_type_constructor[PACKED_VECTOR3_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_VECTOR3_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::Variant(const PackedColorArray &v) {
-	from_type_constructor[PACKED_COLOR_ARRAY](ptr(), v.ptr());
+	from_type_constructor[PACKED_COLOR_ARRAY](_native_ptr(), v._native_ptr());
 }
 
 Variant::~Variant() {
-	internal::gdn_interface->variant_destroy(ptr());
+	internal::gdn_interface->variant_destroy(_native_ptr());
 }
 
 Variant::operator bool() const {
 	GDNativeBool result;
-	to_type_constructor[BOOL](&result, ptr());
+	to_type_constructor[BOOL](&result, _native_ptr());
 	return PtrToArg<bool>::convert(&result);
 }
 
 Variant::operator int64_t() const {
 	GDNativeInt result;
-	to_type_constructor[INT](&result, ptr());
+	to_type_constructor[INT](&result, _native_ptr());
 	return PtrToArg<int64_t>::convert(&result);
 }
 
@@ -261,7 +261,7 @@ Variant::operator uint32_t() const {
 
 Variant::operator double() const {
 	double result;
-	to_type_constructor[FLOAT](&result, ptr());
+	to_type_constructor[FLOAT](&result, _native_ptr());
 	return PtrToArg<double>::convert(&result);
 }
 
@@ -271,109 +271,109 @@ Variant::operator float() const {
 
 Variant::operator String() const {
 	String result;
-	to_type_constructor[STRING](result.ptr(), ptr());
+	to_type_constructor[STRING](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Vector2() const {
 	Vector2 result;
-	to_type_constructor[VECTOR2](result.ptr(), ptr());
+	to_type_constructor[VECTOR2](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Vector2i() const {
 	Vector2i result;
-	to_type_constructor[VECTOR2I](result.ptr(), ptr());
+	to_type_constructor[VECTOR2I](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Rect2() const {
 	Rect2 result;
-	to_type_constructor[RECT2](result.ptr(), ptr());
+	to_type_constructor[RECT2](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Rect2i() const {
 	Rect2i result;
-	to_type_constructor[RECT2I](result.ptr(), ptr());
+	to_type_constructor[RECT2I](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Vector3() const {
 	Vector3 result;
-	to_type_constructor[VECTOR3](result.ptr(), ptr());
+	to_type_constructor[VECTOR3](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Vector3i() const {
 	Vector3i result;
-	to_type_constructor[VECTOR3I](result.ptr(), ptr());
+	to_type_constructor[VECTOR3I](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Transform2D() const {
 	Transform2D result;
-	to_type_constructor[TRANSFORM2D](result.ptr(), ptr());
+	to_type_constructor[TRANSFORM2D](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Plane() const {
 	Plane result;
-	to_type_constructor[PLANE](result.ptr(), ptr());
+	to_type_constructor[PLANE](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Quaternion() const {
 	Quaternion result;
-	to_type_constructor[QUATERNION](result.ptr(), ptr());
+	to_type_constructor[QUATERNION](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator godot::AABB() const {
 	godot::AABB result;
-	to_type_constructor[AABB](result.ptr(), ptr());
+	to_type_constructor[AABB](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Basis() const {
 	Basis result;
-	to_type_constructor[BASIS](result.ptr(), ptr());
+	to_type_constructor[BASIS](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Transform3D() const {
 	Transform3D result;
-	to_type_constructor[TRANSFORM3D](result.ptr(), ptr());
+	to_type_constructor[TRANSFORM3D](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Color() const {
 	Color result;
-	to_type_constructor[COLOR](result.ptr(), ptr());
+	to_type_constructor[COLOR](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator StringName() const {
 	StringName result;
-	to_type_constructor[STRING_NAME](result.ptr(), ptr());
+	to_type_constructor[STRING_NAME](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator NodePath() const {
 	NodePath result;
-	to_type_constructor[NODE_PATH](result.ptr(), ptr());
+	to_type_constructor[NODE_PATH](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator godot::RID() const {
 	godot::RID result;
-	to_type_constructor[RID](result.ptr(), ptr());
+	to_type_constructor[RID](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Object *() const {
 	GodotObject *obj;
-	to_type_constructor[OBJECT](&obj, ptr());
+	to_type_constructor[OBJECT](&obj, _native_ptr());
 	if (obj == nullptr) {
 		return nullptr;
 	}
@@ -382,85 +382,85 @@ Variant::operator Object *() const {
 
 Variant::operator Callable() const {
 	Callable result;
-	to_type_constructor[CALLABLE](result.ptr(), ptr());
+	to_type_constructor[CALLABLE](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Signal() const {
 	Signal result;
-	to_type_constructor[SIGNAL](result.ptr(), ptr());
+	to_type_constructor[SIGNAL](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Dictionary() const {
 	Dictionary result;
-	to_type_constructor[DICTIONARY](result.ptr(), ptr());
+	to_type_constructor[DICTIONARY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator Array() const {
 	Array result;
-	to_type_constructor[ARRAY](result.ptr(), ptr());
+	to_type_constructor[ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedByteArray() const {
 	PackedByteArray result;
-	to_type_constructor[PACKED_BYTE_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_BYTE_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedInt32Array() const {
 	PackedInt32Array result;
-	to_type_constructor[PACKED_INT32_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_INT32_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedInt64Array() const {
 	PackedInt64Array result;
-	to_type_constructor[PACKED_INT64_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_INT64_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedFloat32Array() const {
 	PackedFloat32Array result;
-	to_type_constructor[PACKED_FLOAT32_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_FLOAT32_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedFloat64Array() const {
 	PackedFloat64Array result;
-	to_type_constructor[PACKED_FLOAT64_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_FLOAT64_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedStringArray() const {
 	PackedStringArray result;
-	to_type_constructor[PACKED_STRING_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_STRING_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedVector2Array() const {
 	PackedVector2Array result;
-	to_type_constructor[PACKED_VECTOR2_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_VECTOR2_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedVector3Array() const {
 	PackedVector3Array result;
-	to_type_constructor[PACKED_VECTOR3_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_VECTOR3_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant::operator PackedColorArray() const {
 	PackedColorArray result;
-	to_type_constructor[PACKED_COLOR_ARRAY](result.ptr(), ptr());
+	to_type_constructor[PACKED_COLOR_ARRAY](result._native_ptr(), _native_ptr());
 	return result;
 }
 
 Variant &Variant::operator=(const Variant &other) {
 	clear();
-	internal::gdn_interface->variant_new_copy(ptr(), other.ptr());
+	internal::gdn_interface->variant_new_copy(_native_ptr(), other._native_ptr());
 	return *this;
 }
 
@@ -500,22 +500,22 @@ bool Variant::operator<(const Variant &other) const {
 }
 
 void Variant::call(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDNativeCallError &r_error) {
-	internal::gdn_interface->variant_call(ptr(), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
+	internal::gdn_interface->variant_call(_native_ptr(), method._native_ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret._native_ptr(), &r_error);
 }
 
 void Variant::call_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDNativeCallError &r_error) {
-	internal::gdn_interface->variant_call_static(static_cast<GDNativeVariantType>(type), method.ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret.ptr(), &r_error);
+	internal::gdn_interface->variant_call_static(static_cast<GDNativeVariantType>(type), method._native_ptr(), reinterpret_cast<const GDNativeVariantPtr *>(const_cast<Variant **>(args)), argcount, r_ret._native_ptr(), &r_error);
 }
 
 void Variant::evaluate(const Operator &op, const Variant &a, const Variant &b, Variant &r_ret, bool &r_valid) {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_evaluate(static_cast<GDNativeVariantOperator>(op), a.ptr(), b.ptr(), r_ret.ptr(), &valid);
+	internal::gdn_interface->variant_evaluate(static_cast<GDNativeVariantOperator>(op), a._native_ptr(), b._native_ptr(), r_ret._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 void Variant::set(const Variant &key, const Variant &value, bool *r_valid) {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_set(ptr(), key.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set(_native_ptr(), key._native_ptr(), value._native_ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -523,27 +523,27 @@ void Variant::set(const Variant &key, const Variant &value, bool *r_valid) {
 
 void Variant::set_named(const StringName &name, const Variant &value, bool &r_valid) {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_set_named(ptr(), name.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set_named(_native_ptr(), name._native_ptr(), value._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 void Variant::set_indexed(int64_t index, const Variant &value, bool &r_valid, bool &r_oob) {
 	GDNativeBool valid, oob;
-	internal::gdn_interface->variant_set_indexed(ptr(), index, value.ptr(), &valid, &oob);
+	internal::gdn_interface->variant_set_indexed(_native_ptr(), index, value._native_ptr(), &valid, &oob);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	r_oob = PtrToArg<bool>::convert(&oob);
 }
 
 void Variant::set_keyed(const Variant &key, const Variant &value, bool &r_valid) {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_set_keyed(ptr(), key.ptr(), value.ptr(), &valid);
+	internal::gdn_interface->variant_set_keyed(_native_ptr(), key._native_ptr(), value._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 }
 
 Variant Variant::get(const Variant &key, bool *r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::gdn_interface->variant_get(ptr(), key.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get(_native_ptr(), key._native_ptr(), result._native_ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -553,7 +553,7 @@ Variant Variant::get(const Variant &key, bool *r_valid) const {
 Variant Variant::get_named(const StringName &name, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::gdn_interface->variant_get_named(ptr(), name.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get_named(_native_ptr(), name._native_ptr(), result._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
@@ -562,7 +562,7 @@ Variant Variant::get_indexed(int64_t index, bool &r_valid, bool &r_oob) const {
 	Variant result;
 	GDNativeBool valid;
 	GDNativeBool oob;
-	internal::gdn_interface->variant_get_indexed(ptr(), index, result.ptr(), &valid, &oob);
+	internal::gdn_interface->variant_get_indexed(_native_ptr(), index, result._native_ptr(), &valid, &oob);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	r_oob = PtrToArg<bool>::convert(&oob);
 	return result;
@@ -571,7 +571,7 @@ Variant Variant::get_indexed(int64_t index, bool &r_valid, bool &r_oob) const {
 Variant Variant::get_keyed(const Variant &key, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::gdn_interface->variant_get_keyed(ptr(), key.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_get_keyed(_native_ptr(), key._native_ptr(), result._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
@@ -588,36 +588,36 @@ bool Variant::in(const Variant &index, bool *r_valid) const {
 
 bool Variant::iter_init(Variant &r_iter, bool &r_valid) const {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_iter_init(ptr(), r_iter.ptr(), &valid);
+	internal::gdn_interface->variant_iter_init(_native_ptr(), r_iter._native_ptr(), &valid);
 	return PtrToArg<bool>::convert(&valid);
 }
 
 bool Variant::iter_next(Variant &r_iter, bool &r_valid) const {
 	GDNativeBool valid;
-	internal::gdn_interface->variant_iter_next(ptr(), r_iter.ptr(), &valid);
+	internal::gdn_interface->variant_iter_next(_native_ptr(), r_iter._native_ptr(), &valid);
 	return PtrToArg<bool>::convert(&valid);
 }
 
 Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 	Variant result;
 	GDNativeBool valid;
-	internal::gdn_interface->variant_iter_get(ptr(), r_iter.ptr(), result.ptr(), &valid);
+	internal::gdn_interface->variant_iter_get(_native_ptr(), r_iter._native_ptr(), result._native_ptr(), &valid);
 	r_valid = PtrToArg<bool>::convert(&valid);
 	return result;
 }
 
 Variant::Type Variant::get_type() const {
-	return static_cast<Variant::Type>(internal::gdn_interface->variant_get_type(ptr()));
+	return static_cast<Variant::Type>(internal::gdn_interface->variant_get_type(_native_ptr()));
 }
 
 bool Variant::has_method(const StringName &method) const {
-	GDNativeBool has = internal::gdn_interface->variant_has_method(ptr(), method.ptr());
+	GDNativeBool has = internal::gdn_interface->variant_has_method(_native_ptr(), method._native_ptr());
 	return PtrToArg<bool>::convert(&has);
 }
 
 bool Variant::has_key(const Variant &key, bool *r_valid) const {
 	GDNativeBool valid;
-	GDNativeBool has = internal::gdn_interface->variant_has_key(ptr(), key.ptr(), &valid);
+	GDNativeBool has = internal::gdn_interface->variant_has_key(_native_ptr(), key._native_ptr(), &valid);
 	if (r_valid) {
 		*r_valid = PtrToArg<bool>::convert(&valid);
 	}
@@ -625,23 +625,23 @@ bool Variant::has_key(const Variant &key, bool *r_valid) const {
 }
 
 bool Variant::has_member(Variant::Type type, const StringName &member) {
-	GDNativeBool has = internal::gdn_interface->variant_has_member(static_cast<GDNativeVariantType>(type), member.ptr());
+	GDNativeBool has = internal::gdn_interface->variant_has_member(static_cast<GDNativeVariantType>(type), member._native_ptr());
 	return PtrToArg<bool>::convert(&has);
 }
 
 bool Variant::hash_compare(const Variant &variant) const {
-	GDNativeBool compare = internal::gdn_interface->variant_hash_compare(ptr(), variant.ptr());
+	GDNativeBool compare = internal::gdn_interface->variant_hash_compare(_native_ptr(), variant._native_ptr());
 	return PtrToArg<bool>::convert(&compare);
 }
 
 bool Variant::booleanize() const {
-	GDNativeBool booleanized = internal::gdn_interface->variant_booleanize(ptr());
+	GDNativeBool booleanized = internal::gdn_interface->variant_booleanize(_native_ptr());
 	return PtrToArg<bool>::convert(&booleanized);
 }
 
 String Variant::stringify() const {
 	String result;
-	internal::gdn_interface->variant_stringify(ptr(), result.ptr());
+	internal::gdn_interface->variant_stringify(_native_ptr(), result._native_ptr());
 	return result;
 }
 
@@ -649,21 +649,21 @@ Variant Variant::duplicate(bool deep) const {
 	Variant result;
 	GDNativeBool _deep;
 	PtrToArg<bool>::encode(deep, &_deep);
-	internal::gdn_interface->variant_duplicate(ptr(), result.ptr(), _deep);
+	internal::gdn_interface->variant_duplicate(_native_ptr(), result._native_ptr(), _deep);
 	return result;
 }
 
 void Variant::blend(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::gdn_interface->variant_blend(a.ptr(), b.ptr(), c, r_dst.ptr());
+	internal::gdn_interface->variant_blend(a._native_ptr(), b._native_ptr(), c, r_dst._native_ptr());
 }
 
 void Variant::interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::gdn_interface->variant_interpolate(a.ptr(), b.ptr(), c, r_dst.ptr());
+	internal::gdn_interface->variant_interpolate(a._native_ptr(), b._native_ptr(), c, r_dst._native_ptr());
 }
 
 String Variant::get_type_name(Variant::Type type) {
 	String result;
-	internal::gdn_interface->variant_get_type_name(static_cast<GDNativeVariantType>(type), result.ptr());
+	internal::gdn_interface->variant_get_type_name(static_cast<GDNativeVariantType>(type), result._native_ptr());
 	return result;
 }
 
@@ -723,9 +723,9 @@ void Variant::clear() {
 	};
 
 	if (unlikely(needs_deinit[get_type()])) { // Make it fast for types that don't need deinit.
-		internal::gdn_interface->variant_destroy(ptr());
+		internal::gdn_interface->variant_destroy(_native_ptr());
 	}
-	internal::gdn_interface->variant_new_nil(ptr());
+	internal::gdn_interface->variant_new_nil(_native_ptr());
 }
 
 } // namespace godot


### PR DESCRIPTION
- Adds `ptr()` / `ptrw()` to the arrays, and renames existing `ptr` to `_native_ptr` to avoid conflict.
- Adds `ptr()` / `ptrw()`, `parse_utf*` and `utf*` methods to the `String`.
- Adds missing implementations of `length()` and `get_data()` methods of `Char*String`.