### PR TITLE
Fix for connecting to signals (Enum types treated as GDNativeInt instead of int32_t)

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1083,8 +1083,11 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
                 if has_return:
                     return_type = method["return_value"]["type"]
                     meta_type = method["return_value"]["meta"] if "meta" in method["return_value"] else None
-                    if is_pod_type(return_type) or is_variant(return_type) or is_enum(return_type):
+                    if is_pod_type(return_type) or is_variant(return_type):
                         method_call += f"return internal::_call_native_mb_ret<{correct_type(return_type, meta_type)}>(___method_bind, _owner"
+                    elif is_enum(return_type):
+                        method_call += f"return ({correct_type(return_type, meta_type)})internal::_call_native_mb_ret<GDNativeInt>(___method_bind, _owner"
+						
                     elif is_refcounted(return_type):
                         method_call += f"return Ref<{return_type}>::___internal_constructor(internal::_call_native_mb_ret_obj<{return_type}>(___method_bind, _owner"
                         is_ref = True


### PR DESCRIPTION
(Duplicated PR of #689 'cause of branch removal)

Method that returns enum values as result corrupting memory 'cause Error enum is treated as GDNativeInt instead on int32_t (actual enum size). Changed method generation to prevent this.