### PR TITLE
Add ERR_ macros variants using `String` messages.

### DIFF
--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -32,14 +32,20 @@
 #define GODOT_CPP_ERROR_MACROS_HPP
 
 #include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/variant/string.hpp>
 
 #include <cstdint>
 
 namespace godot {
 
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, bool p_is_warning = false);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, bool p_is_warning = false);
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_is_warning = false);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, bool p_is_warning = false);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, bool p_is_warning = false);
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_is_warning = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
 
 // Used to strip debug messages in release mode
 #ifdef DEBUG_ENABLED

--- a/src/core/error_macros.cpp
+++ b/src/core/error_macros.cpp
@@ -44,11 +44,45 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 	}
 }
 
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const char *p_message, bool p_is_warning) {
+	if (p_is_warning) {
+		internal::gdn_interface->print_warning(p_message, p_function, p_file, p_line);
+	} else {
+		internal::gdn_interface->print_error(p_message, p_function, p_file, p_line);
+	}
+}
+
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const String &p_message, bool p_is_warning) {
+	if (p_is_warning) {
+		internal::gdn_interface->print_warning(p_message.utf8().get_data(), p_function, p_file, p_line);
+	} else {
+		internal::gdn_interface->print_error(p_message.utf8().get_data(), p_function, p_file, p_line);
+	}
+}
+
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, bool p_is_warning) {
+	if (p_is_warning) {
+		internal::gdn_interface->print_warning(p_message.utf8().get_data(), p_function, p_file, p_line);
+	} else {
+		internal::gdn_interface->print_error(p_message.utf8().get_data(), p_function, p_file, p_line);
+	}
+}
+
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, bool p_is_warning) {
 	_err_print_error(p_function, p_file, p_line, "", p_error, p_is_warning);
 }
 
+void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, bool p_is_warning) {
+	_err_print_error(p_function, p_file, p_line, "", p_error, p_is_warning);
+}
+
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message, bool fatal) {
+	std::string fstr(fatal ? "FATAL: " : "");
+	std::string err(fstr + "Index " + p_index_str + " = " + std::to_string(p_index) + " is out of bounds (" + p_size_str + " = " + std::to_string(p_size) + ").");
+	_err_print_error(p_function, p_file, p_line, err.c_str(), p_message);
+}
+
+void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal) {
 	std::string fstr(fatal ? "FATAL: " : "");
 	std::string err(fstr + "Index " + p_index_str + " = " + std::to_string(p_index) + " is out of bounds (" + p_size_str + " = " + std::to_string(p_size) + ").");
 	_err_print_error(p_function, p_file, p_line, err.c_str(), p_message);


### PR DESCRIPTION
Allows using `String` type messages (for easier error message formatting) in the `ERR_` macros.