### PR TITLE
Use forward declares for vector math types

### DIFF
--- a/include/godot_cpp/variant/rect2.hpp
+++ b/include/godot_cpp/variant/rect2.hpp
@@ -37,6 +37,8 @@
 
 namespace godot {
 
+class Rect2i;
+class String;
 class Transform2D;
 
 class Rect2 {
@@ -326,6 +328,7 @@ public:
 	}
 
 	operator String() const;
+	operator Rect2i() const;
 
 	Rect2() {}
 	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :

--- a/include/godot_cpp/variant/rect2i.hpp
+++ b/include/godot_cpp/variant/rect2i.hpp
@@ -31,10 +31,14 @@
 #ifndef GODOT_RECT2I_HPP
 #define GODOT_RECT2I_HPP
 
-#include <godot_cpp/variant/rect2.hpp>
+#include <godot_cpp/classes/global_constants.hpp>
+#include <godot_cpp/core/math.hpp>
 #include <godot_cpp/variant/vector2i.hpp>
 
 namespace godot {
+
+class Rect2;
+class String;
 
 class Rect2i {
 	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
@@ -206,15 +210,10 @@ public:
 		return position + size;
 	}
 
-	operator String() const { return String(position) + ", " + String(size); }
-
-	operator Rect2() const { return Rect2(position, size); }
+	operator String() const;
+	operator Rect2() const;
 
 	Rect2i() {}
-	Rect2i(const Rect2 &p_r2) :
-			position(p_r2.position),
-			size(p_r2.size) {
-	}
 	Rect2i(int p_x, int p_y, int p_width, int p_height) :
 			position(Point2i(p_x, p_y)),
 			size(Size2i(p_width, p_height)) {

--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -32,10 +32,10 @@
 #define GODOT_VECTOR2_HPP
 
 #include <godot_cpp/core/math.hpp>
-#include <godot_cpp/variant/string.hpp>
 
 namespace godot {
 
+class String;
 class Vector2i;
 
 class Vector2 {

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -32,10 +32,11 @@
 #define GODOT_VECTOR2I_HPP
 
 #include <godot_cpp/core/math.hpp>
-#include <godot_cpp/variant/string.hpp>
-#include <godot_cpp/variant/vector2.hpp>
 
 namespace godot {
+
+class String;
+class Vector2;
 
 class Vector2i {
 	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
@@ -96,14 +97,9 @@ public:
 	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
 
 	operator String() const;
-
-	operator Vector2() const { return Vector2((real_t)x, (real_t)y); }
+	operator Vector2() const;
 
 	inline Vector2i() {}
-	inline Vector2i(const Vector2 &p_vec2) {
-		x = (int32_t)p_vec2.x;
-		y = (int32_t)p_vec2.y;
-	}
 	inline Vector2i(int32_t p_x, int32_t p_y) {
 		x = p_x;
 		y = p_y;

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -32,11 +32,11 @@
 #define GODOT_VECTOR3_HPP
 
 #include <godot_cpp/core/math.hpp>
-#include <godot_cpp/variant/string.hpp>
 
 namespace godot {
 
 class Basis;
+class String;
 class Vector3i;
 
 class Vector3 {
@@ -159,7 +159,6 @@ public:
 		y = p_y;
 		z = p_z;
 	}
-	Vector3(const Vector3i &p_ivec);
 };
 
 Vector3 Vector3::cross(const Vector3 &p_b) const {

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -32,9 +32,11 @@
 #define GODOT_VECTOR3I_HPP
 
 #include <godot_cpp/core/math.hpp>
-#include <godot_cpp/variant/string.hpp>
 
 namespace godot {
+
+class String;
+class Vector3;
 
 class Vector3i {
 	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
@@ -107,6 +109,7 @@ public:
 	inline bool operator>=(const Vector3i &p_v) const;
 
 	operator String() const;
+	operator Vector3() const;
 
 	inline Vector3i() {}
 	inline Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {

--- a/src/variant/rect2.cpp
+++ b/src/variant/rect2.cpp
@@ -30,6 +30,8 @@
 
 #include <godot_cpp/variant/rect2.hpp>
 
+#include <godot_cpp/variant/rect2i.hpp>
+#include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/transform2d.hpp>
 
 namespace godot {
@@ -266,6 +268,14 @@ next4:
 	}
 
 	return true;
+}
+
+Rect2::operator String() const {
+	return String(position) + ", " + String(size);
+}
+
+Rect2::operator Rect2i() const {
+	return Rect2i(position, size);
 }
 
 } // namespace godot

--- a/src/variant/rect2i.cpp
+++ b/src/variant/rect2i.cpp
@@ -30,4 +30,17 @@
 
 #include <godot_cpp/variant/rect2i.hpp>
 
-// No implementation left. This is here to add the header as a compiled unit.
+#include <godot_cpp/variant/rect2.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+Rect2i::operator String() const {
+	return String(position) + ", " + String(size);
+}
+
+Rect2i::operator Rect2() const {
+	return Rect2(position, size);
+}
+
+} // namespace godot

--- a/src/variant/vector2.cpp
+++ b/src/variant/vector2.cpp
@@ -28,20 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include <godot_cpp/variant/vector2.hpp>
+
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/string.hpp>
-#include <godot_cpp/variant/vector2.hpp>
 #include <godot_cpp/variant/vector2i.hpp>
 
 namespace godot {
-
-Vector2::operator String() const {
-	return String::num(x, 5) + ", " + String::num(y, 5);
-}
-
-Vector2::operator Vector2i() const {
-	return Vector2i(x, y);
-}
 
 real_t Vector2::angle() const {
 	return Math::atan2(y, x);
@@ -198,6 +191,14 @@ Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 
 bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y);
+}
+
+Vector2::operator String() const {
+	return String::num(x, 5) + ", " + String::num(y, 5);
+}
+
+Vector2::operator Vector2i() const {
+	return Vector2i(x, y);
 }
 
 } // namespace godot

--- a/src/variant/vector2i.cpp
+++ b/src/variant/vector2i.cpp
@@ -28,15 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include <godot_cpp/core/error_macros.hpp>
-#include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/vector2i.hpp>
 
-namespace godot {
+#include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/vector2.hpp>
 
-Vector2i::operator String() const {
-	return String::num(x, 0) + ", " + String::num(y, 0);
-}
+namespace godot {
 
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);
@@ -105,6 +103,14 @@ bool Vector2i::operator==(const Vector2i &p_vec2) const {
 
 bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 	return x != p_vec2.x || y != p_vec2.y;
+}
+
+Vector2i::operator String() const {
+	return String::num(x, 0) + ", " + String::num(y, 0);
+}
+
+Vector2i::operator Vector2() const {
+	return Vector2((real_t)x, (real_t)y);
 }
 
 } // namespace godot

--- a/src/variant/vector3.cpp
+++ b/src/variant/vector3.cpp
@@ -28,9 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include <godot_cpp/variant/vector3.hpp>
+
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/basis.hpp>
-#include <godot_cpp/variant/vector3.hpp>
 #include <godot_cpp/variant/vector3i.hpp>
 
 namespace godot {

--- a/src/variant/vector3i.cpp
+++ b/src/variant/vector3i.cpp
@@ -28,9 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include <godot_cpp/variant/vector3i.hpp>
+
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/variant/string.hpp>
-#include <godot_cpp/variant/vector3i.hpp>
+#include <godot_cpp/variant/vector3.hpp>
 
 namespace godot {
 
@@ -54,6 +56,10 @@ int Vector3i::max_axis() const {
 
 Vector3i::operator String() const {
 	return (String::num(x, 0) + ", " + String::num(y, 0) + ", " + String::num(z, 5));
+}
+
+Vector3i::operator Vector3() const {
+	return Vector3((real_t)x, (real_t)y, (real_t)z);
 }
 
 } // namespace godot


### PR DESCRIPTION
Adds operators to convert from int vector types to float vector types
as done in the upstream engine implementations.

Follow-up to https://github.com/godotengine/godot/pull/58321 and other recent upstream PRs, and #688.

**Note:** When we're closer to the 4.0-stable release upstream, we should do a comparative review of core types implemented here and upstream - there might have been a number of fixes upstream since this was implemented, and not all of them found their way back to this repo.