### PR TITLE
[3.4] Run black format on SConstruct files and bindings generator

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5,24 +5,35 @@ import sys
 import subprocess
 
 if sys.version_info < (3,):
+
     def decode_utf8(x):
         return x
+
 else:
     import codecs
+
     def decode_utf8(x):
         return codecs.utf_8_decode(x)[0]
+
 
 # Workaround for MinGW. See:
 # http://www.scons.org/wiki/LongCmdLinesOnWin32
 if os.name == "nt":
     import subprocess
 
-    def mySubProcess(cmdline,env):
-        #print "SPAWNED : " + cmdline
+    def mySubProcess(cmdline, env):
+        # print "SPAWNED : " + cmdline
         startupinfo = subprocess.STARTUPINFO()
         startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        proc = subprocess.Popen(cmdline, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, startupinfo=startupinfo, shell = False, env = env)
+        proc = subprocess.Popen(
+            cmdline,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            startupinfo=startupinfo,
+            shell=False,
+            env=env,
+        )
         data, err = proc.communicate()
         rv = proc.wait()
         if rv:
@@ -33,158 +44,104 @@ if os.name == "nt":
 
     def mySpawn(sh, escape, cmd, args, env):
 
-        newargs = ' '.join(args[1:])
+        newargs = " ".join(args[1:])
         cmdline = cmd + " " + newargs
 
-        rv=0
-        if len(cmdline) > 32000 and cmd.endswith("ar") :
+        rv = 0
+        if len(cmdline) > 32000 and cmd.endswith("ar"):
             cmdline = cmd + " " + args[1] + " " + args[2] + " "
-            for i in range(3,len(args)) :
-                rv = mySubProcess( cmdline + args[i], env )
-                if rv :
+            for i in range(3, len(args)):
+                rv = mySubProcess(cmdline + args[i], env)
+                if rv:
                     break
         else:
-            rv = mySubProcess( cmdline, env )
+            rv = mySubProcess(cmdline, env)
 
         return rv
 
+
 def add_sources(sources, dir, extension):
     for f in os.listdir(dir):
-        if f.endswith('.' + extension):
-            sources.append(dir + '/' + f)
+        if f.endswith("." + extension):
+            sources.append(dir + "/" + f)
 
 
 # Try to detect the host platform automatically.
 # This is used if no `platform` argument is passed
-if sys.platform.startswith('linux'):
-    host_platform = 'linux'
-elif sys.platform.startswith('freebsd'):
-    host_platform = 'freebsd'
-elif sys.platform == 'darwin':
-    host_platform = 'osx'
-elif sys.platform == 'win32' or sys.platform == 'msys':
-    host_platform = 'windows'
+if sys.platform.startswith("linux"):
+    host_platform = "linux"
+elif sys.platform.startswith("freebsd"):
+    host_platform = "freebsd"
+elif sys.platform == "darwin":
+    host_platform = "osx"
+elif sys.platform == "win32" or sys.platform == "msys":
+    host_platform = "windows"
 else:
-    raise ValueError(
-        'Could not detect platform automatically, please specify with '
-        'platform=<platform>'
-    )
+    raise ValueError("Could not detect platform automatically, please specify with platform=<platform>")
 
-env = Environment(ENV = os.environ)
+env = Environment(ENV=os.environ)
 
-is64 = sys.maxsize > 2**32
+is64 = sys.maxsize > 2 ** 32
 if (
-    env['TARGET_ARCH'] == 'amd64' or
-    env['TARGET_ARCH'] == 'emt64' or
-    env['TARGET_ARCH'] == 'x86_64' or
-    env['TARGET_ARCH'] == 'arm64-v8a'
+    env["TARGET_ARCH"] == "amd64"
+    or env["TARGET_ARCH"] == "emt64"
+    or env["TARGET_ARCH"] == "x86_64"
+    or env["TARGET_ARCH"] == "arm64-v8a"
 ):
     is64 = True
 
 opts = Variables([], ARGUMENTS)
-opts.Add(EnumVariable(
-    'platform',
-    'Target platform',
-    host_platform,
-    allowed_values=('linux', 'freebsd', 'osx', 'windows', 'android', 'ios', 'javascript'),
-    ignorecase=2
-))
-opts.Add(EnumVariable(
-    'bits',
-    'Target platform bits',
-    '64' if is64 else '32',
-    ('32', '64')
-))
-opts.Add(BoolVariable(
-    'use_llvm',
-    'Use the LLVM compiler - only effective when targeting Linux or FreeBSD',
-    False
-))
-opts.Add(BoolVariable(
-    'use_mingw',
-    'Use the MinGW compiler instead of MSVC - only effective on Windows',
-    False
-))
+opts.Add(
+    EnumVariable(
+        "platform",
+        "Target platform",
+        host_platform,
+        allowed_values=("linux", "freebsd", "osx", "windows", "android", "ios", "javascript"),
+        ignorecase=2,
+    )
+)
+opts.Add(EnumVariable("bits", "Target platform bits", "64" if is64 else "32", ("32", "64")))
+opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler - only effective when targeting Linux or FreeBSD", False))
+opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
 # Must be the same setting as used for cpp_bindings
-opts.Add(EnumVariable(
-    'target',
-    'Compilation target',
-    'debug',
-    allowed_values=('debug', 'release'),
-    ignorecase=2
-))
-opts.Add(PathVariable(
-    'headers_dir',
-    'Path to the directory containing Godot headers',
-    'godot-headers',
-    PathVariable.PathIsDir
-))
-opts.Add(PathVariable(
-    'custom_api_file',
-    'Path to a custom JSON API file',
-    None,
-    PathVariable.PathIsFile
-))
-opts.Add(EnumVariable(
-    'generate_bindings',
-    'Generate GDNative API bindings',
-    'auto',
-    allowed_values = ['yes', 'no', 'auto', 'true'],
-    ignorecase = 2
-))
-opts.Add(EnumVariable(
-    'android_arch',
-    'Target Android architecture',
-    'armv7',
-    ['armv7','arm64v8','x86','x86_64']
-))
+opts.Add(EnumVariable("target", "Compilation target", "debug", allowed_values=("debug", "release"), ignorecase=2))
 opts.Add(
-    'macos_deployment_target',
-    'macOS deployment target',
-    'default'
+    PathVariable(
+        "headers_dir", "Path to the directory containing Godot headers", "godot-headers", PathVariable.PathIsDir
+    )
+)
+opts.Add(PathVariable("custom_api_file", "Path to a custom JSON API file", None, PathVariable.PathIsFile))
+opts.Add(
+    EnumVariable(
+        "generate_bindings",
+        "Generate GDNative API bindings",
+        "auto",
+        allowed_values=["yes", "no", "auto", "true"],
+        ignorecase=2,
+    )
+)
+opts.Add(EnumVariable("android_arch", "Target Android architecture", "armv7", ["armv7", "arm64v8", "x86", "x86_64"]))
+opts.Add("macos_deployment_target", "macOS deployment target", "default")
+opts.Add("macos_sdk_path", "macOS SDK path", "")
+opts.Add(EnumVariable("macos_arch", "Target macOS architecture", "universal", ["universal", "x86_64", "arm64"]))
+opts.Add(EnumVariable("ios_arch", "Target iOS architecture", "arm64", ["armv7", "arm64", "x86_64"]))
+opts.Add(BoolVariable("ios_simulator", "Target iOS Simulator", False))
+opts.Add(
+    "IPHONEPATH",
+    "Path to iPhone toolchain",
+    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
 )
 opts.Add(
-    'macos_sdk_path',
-    'macOS SDK path',
-    ''
-)
-opts.Add(EnumVariable(
-    'macos_arch',
-    'Target macOS architecture',
-    'universal',
-    ['universal', 'x86_64', 'arm64']
-))
-opts.Add(EnumVariable(
-    'ios_arch',
-    'Target iOS architecture',
-    'arm64',
-    ['armv7', 'arm64', 'x86_64']
-))
-opts.Add(BoolVariable(
-    'ios_simulator',
-    'Target iOS Simulator',
-    False
-))
-opts.Add(
-    'IPHONEPATH',
-    'Path to iPhone toolchain',
-    '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain',
+    "android_api_level",
+    "Target Android API level",
+    "18" if ARGUMENTS.get("android_arch", "armv7") in ["armv7", "x86"] else "21",
 )
 opts.Add(
-    'android_api_level',
-    'Target Android API level',
-    '18' if ARGUMENTS.get("android_arch", 'armv7') in ['armv7', 'x86'] else '21'
+    "ANDROID_NDK_ROOT",
+    "Path to your Android NDK installation. By default, uses ANDROID_NDK_ROOT from your defined environment variables.",
+    os.environ.get("ANDROID_NDK_ROOT", None),
 )
-opts.Add(
-    'ANDROID_NDK_ROOT',
-    'Path to your Android NDK installation. By default, uses ANDROID_NDK_ROOT from your defined environment variables.',
-    os.environ.get("ANDROID_NDK_ROOT", None)
-)
-opts.Add(BoolVariable(
-	'generate_template_get_node',
-	"Generate a template version of the Node class's get_node.",
-	True
-))
+opts.Add(BoolVariable("generate_template_get_node", "Generate a template version of the Node class's get_node.", True))
 
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
@@ -192,41 +149,39 @@ Help(opts.GenerateHelpText(env))
 # This makes sure to keep the session environment variables on Windows.
 # This way, you can run SCons in a Visual Studio 2017 prompt and it will find
 # all the required tools
-if host_platform == 'windows' and env['platform'] != 'android':
-    if env['bits'] == '64':
-        env = Environment(TARGET_ARCH='amd64')
-    elif env['bits'] == '32':
-        env = Environment(TARGET_ARCH='x86')
+if host_platform == "windows" and env["platform"] != "android":
+    if env["bits"] == "64":
+        env = Environment(TARGET_ARCH="amd64")
+    elif env["bits"] == "32":
+        env = Environment(TARGET_ARCH="x86")
 
     opts.Update(env)
 
-if env['platform'] == 'linux' or env['platform'] == 'freebsd':
-    if env['use_llvm']:
-        env['CXX'] = 'clang++'
+if env["platform"] == "linux" or env["platform"] == "freebsd":
+    if env["use_llvm"]:
+        env["CXX"] = "clang++"
 
-    env.Append(CCFLAGS=['-fPIC', '-std=c++14', '-Wwrite-strings'])
+    env.Append(CCFLAGS=["-fPIC", "-std=c++14", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])
 
-    if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', '-g'])
-    elif env['target'] == 'release':
-        env.Append(CCFLAGS=['-O3'])
+    if env["target"] == "debug":
+        env.Append(CCFLAGS=["-Og", "-g"])
+    elif env["target"] == "release":
+        env.Append(CCFLAGS=["-O3"])
 
-    if env['bits'] == '64':
-        env.Append(CCFLAGS=['-m64'])
-        env.Append(LINKFLAGS=['-m64'])
-    elif env['bits'] == '32':
-        env.Append(CCFLAGS=['-m32'])
-        env.Append(LINKFLAGS=['-m32'])
+    if env["bits"] == "64":
+        env.Append(CCFLAGS=["-m64"])
+        env.Append(LINKFLAGS=["-m64"])
+    elif env["bits"] == "32":
+        env.Append(CCFLAGS=["-m32"])
+        env.Append(LINKFLAGS=["-m32"])
 
-elif env['platform'] == 'osx':
+elif env["platform"] == "osx":
     # Use Clang on macOS by default
-    env['CXX'] = 'clang++'
+    env["CXX"] = "clang++"
 
-    if env['bits'] == '32':
-        raise ValueError(
-            'Only 64-bit builds are supported for the macOS target.'
-        )
+    if env["bits"] == "32":
+        raise ValueError("Only 64-bit builds are supported for the macOS target.")
 
     if env["macos_arch"] == "universal":
         env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
@@ -235,175 +190,200 @@ elif env['platform'] == 'osx':
         env.Append(LINKFLAGS=["-arch", env["macos_arch"]])
         env.Append(CCFLAGS=["-arch", env["macos_arch"]])
 
-    env.Append(CCFLAGS=['-std=c++14'])
+    env.Append(CCFLAGS=["-std=c++14"])
 
-    if env['macos_deployment_target'] != 'default':
-        env.Append(CCFLAGS=['-mmacosx-version-min=' + env['macos_deployment_target']])
-        env.Append(LINKFLAGS=['-mmacosx-version-min=' + env['macos_deployment_target']])
+    if env["macos_deployment_target"] != "default":
+        env.Append(CCFLAGS=["-mmacosx-version-min=" + env["macos_deployment_target"]])
+        env.Append(LINKFLAGS=["-mmacosx-version-min=" + env["macos_deployment_target"]])
 
-    if env['macos_sdk_path']:
-        env.Append(CCFLAGS=['-isysroot', env['macos_sdk_path']])
-        env.Append(LINKFLAGS=['-isysroot', env['macos_sdk_path']])
+    if env["macos_sdk_path"]:
+        env.Append(CCFLAGS=["-isysroot", env["macos_sdk_path"]])
+        env.Append(LINKFLAGS=["-isysroot", env["macos_sdk_path"]])
 
-    env.Append(LINKFLAGS=[
-        '-framework',
-        'Cocoa',
-        '-Wl,-undefined,dynamic_lookup',
-    ])
+    env.Append(
+        LINKFLAGS=[
+            "-framework",
+            "Cocoa",
+            "-Wl,-undefined,dynamic_lookup",
+        ]
+    )
 
-    if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', '-g'])
-    elif env['target'] == 'release':
-        env.Append(CCFLAGS=['-O3'])
+    if env["target"] == "debug":
+        env.Append(CCFLAGS=["-Og", "-g"])
+    elif env["target"] == "release":
+        env.Append(CCFLAGS=["-O3"])
 
-elif env['platform'] == 'ios':
-    if env['ios_simulator']:
-        sdk_name = 'iphonesimulator'
-        env.Append(CCFLAGS=['-mios-simulator-version-min=10.0'])
-        env['LIBSUFFIX'] = ".simulator" + env['LIBSUFFIX']
+elif env["platform"] == "ios":
+    if env["ios_simulator"]:
+        sdk_name = "iphonesimulator"
+        env.Append(CCFLAGS=["-mios-simulator-version-min=10.0"])
+        env["LIBSUFFIX"] = ".simulator" + env["LIBSUFFIX"]
     else:
-        sdk_name = 'iphoneos'
-        env.Append(CCFLAGS=['-miphoneos-version-min=10.0'])
+        sdk_name = "iphoneos"
+        env.Append(CCFLAGS=["-miphoneos-version-min=10.0"])
 
     try:
-        sdk_path = decode_utf8(subprocess.check_output(['xcrun', '--sdk', sdk_name, '--show-sdk-path']).strip())
+        sdk_path = decode_utf8(subprocess.check_output(["xcrun", "--sdk", sdk_name, "--show-sdk-path"]).strip())
     except (subprocess.CalledProcessError, OSError):
         raise ValueError("Failed to find SDK path while running xcrun --sdk {} --show-sdk-path.".format(sdk_name))
 
-    compiler_path = env['IPHONEPATH'] + '/usr/bin/'
-    env['ENV']['PATH'] = env['IPHONEPATH'] + "/Developer/usr/bin/:" + env['ENV']['PATH']
+    compiler_path = env["IPHONEPATH"] + "/usr/bin/"
+    env["ENV"]["PATH"] = env["IPHONEPATH"] + "/Developer/usr/bin/:" + env["ENV"]["PATH"]
 
-    env['CC'] = compiler_path + 'clang'
-    env['CXX'] = compiler_path + 'clang++'
-    env['AR'] = compiler_path + 'ar'
-    env['RANLIB'] = compiler_path + 'ranlib'
+    env["CC"] = compiler_path + "clang"
+    env["CXX"] = compiler_path + "clang++"
+    env["AR"] = compiler_path + "ar"
+    env["RANLIB"] = compiler_path + "ranlib"
 
-    env.Append(CCFLAGS=['-std=c++14', '-arch', env['ios_arch'], '-isysroot', sdk_path])
-    env.Append(LINKFLAGS=[
-        '-arch',
-        env['ios_arch'],
-        '-framework',
-        'Cocoa',
-        '-Wl,-undefined,dynamic_lookup',
-        '-isysroot', sdk_path,
-        '-F' + sdk_path
-    ])
+    env.Append(CCFLAGS=["-std=c++14", "-arch", env["ios_arch"], "-isysroot", sdk_path])
+    env.Append(
+        LINKFLAGS=[
+            "-arch",
+            env["ios_arch"],
+            "-framework",
+            "Cocoa",
+            "-Wl,-undefined,dynamic_lookup",
+            "-isysroot",
+            sdk_path,
+            "-F" + sdk_path,
+        ]
+    )
 
-    if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', '-g'])
-    elif env['target'] == 'release':
-        env.Append(CCFLAGS=['-O3'])
+    if env["target"] == "debug":
+        env.Append(CCFLAGS=["-Og", "-g"])
+    elif env["target"] == "release":
+        env.Append(CCFLAGS=["-O3"])
 
-elif env['platform'] == 'windows':
-    if host_platform == 'windows' and not env['use_mingw']:
+elif env["platform"] == "windows":
+    if host_platform == "windows" and not env["use_mingw"]:
         # MSVC
-        env.Append(LINKFLAGS=['/WX'])
-        if env['target'] == 'debug':
-            env.Append(CCFLAGS=['/Z7', '/Od', '/EHsc', '/D_DEBUG', '/MDd'])
-        elif env['target'] == 'release':
-            env.Append(CCFLAGS=['/O2', '/EHsc', '/DNDEBUG', '/MD'])
+        env.Append(LINKFLAGS=["/WX"])
+        if env["target"] == "debug":
+            env.Append(CCFLAGS=["/Z7", "/Od", "/EHsc", "/D_DEBUG", "/MDd"])
+        elif env["target"] == "release":
+            env.Append(CCFLAGS=["/O2", "/EHsc", "/DNDEBUG", "/MD"])
 
-    elif host_platform == 'linux' or host_platform == 'freebsd' or host_platform == 'osx':
+    elif host_platform == "linux" or host_platform == "freebsd" or host_platform == "osx":
         # Cross-compilation using MinGW
-        if env['bits'] == '64':
-            env['CXX'] = 'x86_64-w64-mingw32-g++'
-            env['AR'] = "x86_64-w64-mingw32-ar"
-            env['RANLIB'] = "x86_64-w64-mingw32-ranlib"
-            env['LINK'] = "x86_64-w64-mingw32-g++"
-        elif env['bits'] == '32':
-            env['CXX'] = 'i686-w64-mingw32-g++'
-            env['AR'] = "i686-w64-mingw32-ar"
-            env['RANLIB'] = "i686-w64-mingw32-ranlib"
-            env['LINK'] = "i686-w64-mingw32-g++"
-    
-    elif host_platform == 'windows' and env['use_mingw']:
+        if env["bits"] == "64":
+            env["CXX"] = "x86_64-w64-mingw32-g++"
+            env["AR"] = "x86_64-w64-mingw32-ar"
+            env["RANLIB"] = "x86_64-w64-mingw32-ranlib"
+            env["LINK"] = "x86_64-w64-mingw32-g++"
+        elif env["bits"] == "32":
+            env["CXX"] = "i686-w64-mingw32-g++"
+            env["AR"] = "i686-w64-mingw32-ar"
+            env["RANLIB"] = "i686-w64-mingw32-ranlib"
+            env["LINK"] = "i686-w64-mingw32-g++"
+
+    elif host_platform == "windows" and env["use_mingw"]:
         # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.
-        env = Environment(ENV = os.environ, tools=["mingw"])
+        env = Environment(ENV=os.environ, tools=["mingw"])
         opts.Update(env)
-        #env = env.Clone(tools=['mingw'])
+        # env = env.Clone(tools=['mingw'])
 
         env["SPAWN"] = mySpawn
 
     # Native or cross-compilation using MinGW
-    if host_platform == 'linux' or host_platform == 'freebsd' or host_platform == 'osx' or env['use_mingw']:
+    if host_platform == "linux" or host_platform == "freebsd" or host_platform == "osx" or env["use_mingw"]:
         # These options are for a release build even using target=debug
-        env.Append(CCFLAGS=['-O3', '-std=c++14', '-Wwrite-strings'])
-        env.Append(LINKFLAGS=[
-            '--static',
-            '-Wl,--no-undefined',
-            '-static-libgcc',
-            '-static-libstdc++',
-        ])
+        env.Append(CCFLAGS=["-O3", "-std=c++14", "-Wwrite-strings"])
+        env.Append(
+            LINKFLAGS=[
+                "--static",
+                "-Wl,--no-undefined",
+                "-static-libgcc",
+                "-static-libstdc++",
+            ]
+        )
 
-elif env['platform'] == 'android':
-    if host_platform == 'windows':
+elif env["platform"] == "android":
+    if host_platform == "windows":
         # Don't Clone the environment. Because otherwise, SCons will pick up msvc stuff.
-        env = Environment(ENV = os.environ, tools=["mingw"])
+        env = Environment(ENV=os.environ, tools=["mingw"])
         opts.Update(env)
-        #env = env.Clone(tools=['mingw'])
+        # env = env.Clone(tools=['mingw'])
 
         env["SPAWN"] = mySpawn
 
     # Verify NDK root
-    if not 'ANDROID_NDK_ROOT' in env:
-        raise ValueError("To build for Android, ANDROID_NDK_ROOT must be defined. Please set ANDROID_NDK_ROOT to the root folder of your Android NDK installation.")
+    if not "ANDROID_NDK_ROOT" in env:
+        raise ValueError(
+            "To build for Android, ANDROID_NDK_ROOT must be defined. Please set ANDROID_NDK_ROOT to the root folder of your Android NDK installation."
+        )
 
     # Validate API level
-    api_level = int(env['android_api_level'])
-    if env['android_arch'] in ['x86_64', 'arm64v8'] and api_level < 21:
+    api_level = int(env["android_api_level"])
+    if env["android_arch"] in ["x86_64", "arm64v8"] and api_level < 21:
         print("WARN: 64-bit Android architectures require an API level of at least 21; setting android_api_level=21")
-        env['android_api_level'] = '21'
+        env["android_api_level"] = "21"
         api_level = 21
 
     # Setup toolchain
-    toolchain = env['ANDROID_NDK_ROOT'] + "/toolchains/llvm/prebuilt/"
+    toolchain = env["ANDROID_NDK_ROOT"] + "/toolchains/llvm/prebuilt/"
     if host_platform == "windows":
         toolchain += "windows"
         import platform as pltfm
+
         if pltfm.machine().endswith("64"):
             toolchain += "-x86_64"
     elif host_platform == "linux":
         toolchain += "linux-x86_64"
     elif host_platform == "osx":
         toolchain += "darwin-x86_64"
-    env.PrependENVPath('PATH', toolchain + "/bin") # This does nothing half of the time, but we'll put it here anyways
+    env.PrependENVPath("PATH", toolchain + "/bin")  # This does nothing half of the time, but we'll put it here anyways
 
     # Get architecture info
     arch_info_table = {
-        "armv7" : {
-            "march":"armv7-a", "target":"armv7a-linux-androideabi", "tool_path":"arm-linux-androideabi", "compiler_path":"armv7a-linux-androideabi",
-            "ccflags" : ['-mfpu=neon']
-            },
-        "arm64v8" : {
-            "march":"armv8-a", "target":"aarch64-linux-android", "tool_path":"aarch64-linux-android", "compiler_path":"aarch64-linux-android",
-            "ccflags" : []
-            },
-        "x86" : {
-            "march":"i686", "target":"i686-linux-android", "tool_path":"i686-linux-android", "compiler_path":"i686-linux-android",
-            "ccflags" : ['-mstackrealign']
-            },
-        "x86_64" : {"march":"x86-64", "target":"x86_64-linux-android", "tool_path":"x86_64-linux-android", "compiler_path":"x86_64-linux-android",
-            "ccflags" : []
-        }
+        "armv7": {
+            "march": "armv7-a",
+            "target": "armv7a-linux-androideabi",
+            "tool_path": "arm-linux-androideabi",
+            "compiler_path": "armv7a-linux-androideabi",
+            "ccflags": ["-mfpu=neon"],
+        },
+        "arm64v8": {
+            "march": "armv8-a",
+            "target": "aarch64-linux-android",
+            "tool_path": "aarch64-linux-android",
+            "compiler_path": "aarch64-linux-android",
+            "ccflags": [],
+        },
+        "x86": {
+            "march": "i686",
+            "target": "i686-linux-android",
+            "tool_path": "i686-linux-android",
+            "compiler_path": "i686-linux-android",
+            "ccflags": ["-mstackrealign"],
+        },
+        "x86_64": {
+            "march": "x86-64",
+            "target": "x86_64-linux-android",
+            "tool_path": "x86_64-linux-android",
+            "compiler_path": "x86_64-linux-android",
+            "ccflags": [],
+        },
     }
-    arch_info = arch_info_table[env['android_arch']]
+    arch_info = arch_info_table[env["android_arch"]]
 
     # Setup tools
-    env['CC'] = toolchain + "/bin/clang"
-    env['CXX'] = toolchain + "/bin/clang++"
-    env['AR'] = toolchain + "/bin/" + arch_info['tool_path'] + "-ar"
-    env["AS"] = toolchain + "/bin/" + arch_info['tool_path'] + "-as"
-    env["LD"] = toolchain + "/bin/" + arch_info['tool_path'] + "-ld"
-    env["STRIP"] = toolchain + "/bin/" + arch_info['tool_path'] + "-strip"
-    env["RANLIB"] = toolchain + "/bin/" + arch_info['tool_path'] + "-ranlib"
+    env["CC"] = toolchain + "/bin/clang"
+    env["CXX"] = toolchain + "/bin/clang++"
+    env["AR"] = toolchain + "/bin/" + arch_info["tool_path"] + "-ar"
+    env["AS"] = toolchain + "/bin/" + arch_info["tool_path"] + "-as"
+    env["LD"] = toolchain + "/bin/" + arch_info["tool_path"] + "-ld"
+    env["STRIP"] = toolchain + "/bin/" + arch_info["tool_path"] + "-strip"
+    env["RANLIB"] = toolchain + "/bin/" + arch_info["tool_path"] + "-ranlib"
 
-    env.Append(CCFLAGS=['--target=' + arch_info['target'] + env['android_api_level'], '-march=' + arch_info['march'], '-fPIC'])
-    env.Append(CCFLAGS=arch_info['ccflags'])
+    env.Append(
+        CCFLAGS=["--target=" + arch_info["target"] + env["android_api_level"], "-march=" + arch_info["march"], "-fPIC"]
+    )
+    env.Append(CCFLAGS=arch_info["ccflags"])
 
-    if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', '-g'])
-    elif env['target'] == 'release':
-        env.Append(CCFLAGS=['-O3'])
+    if env["target"] == "debug":
+        env.Append(CCFLAGS=["-Og", "-g"])
+    elif env["target"] == "release":
+        env.Append(CCFLAGS=["-O3"])
 
 elif env["platform"] == "javascript":
     env["ENV"] = os.environ
@@ -430,64 +410,62 @@ elif env["platform"] == "javascript":
     env["LIBSUFFIX"] = ".a"
     env["LIBPREFIXES"] = ["$LIBPREFIX"]
     env["LIBSUFFIXES"] = ["$LIBSUFFIX"]
-    env.Replace(SHLINKFLAGS='$LINKFLAGS')
-    env.Replace(SHLINKFLAGS='$LINKFLAGS')
+    env.Replace(SHLINKFLAGS="$LINKFLAGS")
+    env.Replace(SHLINKFLAGS="$LINKFLAGS")
 
-    if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-O0', '-g'])
-    elif env['target'] == 'release':
-        env.Append(CCFLAGS=['-O3'])
+    if env["target"] == "debug":
+        env.Append(CCFLAGS=["-O0", "-g"])
+    elif env["target"] == "release":
+        env.Append(CCFLAGS=["-O3"])
 
-env.Append(CPPPATH=[
-    '.',
-    env['headers_dir'],
-    'include',
-    'include/gen',
-    'include/core',
-])
+env.Append(
+    CPPPATH=[
+        ".",
+        env["headers_dir"],
+        "include",
+        "include/gen",
+        "include/core",
+    ]
+)
 
 # Generate bindings?
-json_api_file = ''
+json_api_file = ""
 
-if 'custom_api_file' in env:
-    json_api_file = env['custom_api_file']
+if "custom_api_file" in env:
+    json_api_file = env["custom_api_file"]
 else:
-    json_api_file = os.path.join(os.getcwd(), env['headers_dir'], 'api.json')
+    json_api_file = os.path.join(os.getcwd(), env["headers_dir"], "api.json")
 
-if env['generate_bindings'] == 'auto':
+if env["generate_bindings"] == "auto":
     # Check if generated files exist
-    should_generate_bindings = not os.path.isfile(os.path.join(os.getcwd(), 'src', 'gen', 'Object.cpp'))
+    should_generate_bindings = not os.path.isfile(os.path.join(os.getcwd(), "src", "gen", "Object.cpp"))
 else:
-    should_generate_bindings = env['generate_bindings'] in ['yes', 'true']
+    should_generate_bindings = env["generate_bindings"] in ["yes", "true"]
 
 if should_generate_bindings:
     # Actually create the bindings here
     import binding_generator
 
-    binding_generator.generate_bindings(json_api_file, env['generate_template_get_node'])
+    binding_generator.generate_bindings(json_api_file, env["generate_template_get_node"])
 
 # Sources to compile
 sources = []
-add_sources(sources, 'src/core', 'cpp')
-add_sources(sources, 'src/gen', 'cpp')
+add_sources(sources, "src/core", "cpp")
+add_sources(sources, "src/gen", "cpp")
 
-arch_suffix = env['bits']
-if env['platform'] == 'android':
-    arch_suffix = env['android_arch']
-elif env['platform'] == 'ios':
-    arch_suffix = env['ios_arch']
-elif env['platform'] == 'osx':
-    if env['macos_arch'] != 'universal':
-        arch_suffix = env['macos_arch']
-elif env['platform'] == 'javascript':
-    arch_suffix = 'wasm'
+arch_suffix = env["bits"]
+if env["platform"] == "android":
+    arch_suffix = env["android_arch"]
+elif env["platform"] == "ios":
+    arch_suffix = env["ios_arch"]
+elif env["platform"] == "osx":
+    if env["macos_arch"] != "universal":
+        arch_suffix = env["macos_arch"]
+elif env["platform"] == "javascript":
+    arch_suffix = "wasm"
 
 library = env.StaticLibrary(
-    target='bin/' + 'libgodot-cpp.{}.{}.{}{}'.format(
-        env['platform'],
-        env['target'],
-        arch_suffix,
-        env['LIBSUFFIX']
-    ), source=sources
+    target="bin/" + "libgodot-cpp.{}.{}.{}{}".format(env["platform"], env["target"], arch_suffix, env["LIBSUFFIX"]),
+    source=sources,
 )
 Default(library)

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -17,11 +17,11 @@ classes = []
 
 def print_file_list(api_filepath, output_dir, headers=False, sources=False):
     global classes
-    end = ';'
+    end = ";"
     with open(api_filepath) as api_file:
         classes = json.load(api_file)
-    include_gen_folder = Path(output_dir) / 'include' / 'gen'
-    source_gen_folder = Path(output_dir) / 'src' / 'gen'
+    include_gen_folder = Path(output_dir) / "include" / "gen"
+    source_gen_folder = Path(output_dir) / "src" / "gen"
     for _class in classes:
         header_filename = include_gen_folder / (strip_name(_class["name"]) + ".hpp")
         source_filename = source_gen_folder / (strip_name(_class["name"]) + ".cpp")
@@ -29,9 +29,9 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
             print(str(header_filename.as_posix()), end=end)
         if sources:
             print(str(source_filename.as_posix()), end=end)
-    icall_header_filename = include_gen_folder / '__icalls.hpp'
-    register_types_filename = source_gen_folder / '__register_types.cpp'
-    init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
+    icall_header_filename = include_gen_folder / "__icalls.hpp"
+    register_types_filename = source_gen_folder / "__register_types.cpp"
+    init_method_bindings_filename = source_gen_folder / "__init_method_bindings.cpp"
     if headers:
         print(str(icall_header_filename.as_posix()), end=end)
     if sources:
@@ -45,8 +45,8 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
         classes = json.load(api_file)
 
     icalls = set()
-    include_gen_folder = Path(output_dir) / 'include' / 'gen'
-    source_gen_folder = Path(output_dir) / 'src' / 'gen'
+    include_gen_folder = Path(output_dir) / "include" / "gen"
+    source_gen_folder = Path(output_dir) / "src" / "gen"
 
     try:
         include_gen_folder.mkdir(parents=True)
@@ -82,26 +82,27 @@ def generate_bindings(api_filepath, use_template_get_node, output_dir="."):
         with source_filename.open("w+") as source_file:
             source_file.write(impl)
 
-    icall_header_filename = include_gen_folder / '__icalls.hpp'
+    icall_header_filename = include_gen_folder / "__icalls.hpp"
     with icall_header_filename.open("w+") as icall_header_file:
         icall_header_file.write(generate_icall_header(icalls))
 
-    register_types_filename = source_gen_folder / '__register_types.cpp'
+    register_types_filename = source_gen_folder / "__register_types.cpp"
     with register_types_filename.open("w+") as register_types_file:
         register_types_file.write(generate_type_registry(classes))
 
-    init_method_bindings_filename = source_gen_folder / '__init_method_bindings.cpp'
+    init_method_bindings_filename = source_gen_folder / "__init_method_bindings.cpp"
     with init_method_bindings_filename.open("w+") as init_method_bindings_file:
         init_method_bindings_file.write(generate_init_method_bindings(classes))
 
 
 def is_reference_type(t):
     for c in classes:
-        if c['name'] != t:
+        if c["name"] != t:
             continue
-        if c['is_reference']:
+        if c["is_reference"]:
             return True
     return False
+
 
 def make_gdnative_type(t, ref_allowed):
     if is_enum(t):
@@ -131,7 +132,6 @@ def generate_class_header(used_classes, c, use_template_get_node):
     source.append("#include <cstdint>")
     source.append("")
 
-
     source.append("#include <core/CoreTypes.hpp>")
 
     class_name = strip_name(c["name"])
@@ -145,7 +145,6 @@ def generate_class_header(used_classes, c, use_template_get_node):
         source.append("#include <core/TagDB.hpp>")
         ref_allowed = False
 
-
     included = []
 
     for used_class in used_classes:
@@ -153,22 +152,20 @@ def generate_class_header(used_classes, c, use_template_get_node):
             used_class_name = remove_enum_prefix(extract_nested_type(used_class))
             if used_class_name not in included:
                 included.append(used_class_name)
-                source.append("#include \"" + used_class_name + ".hpp\"")
+                source.append('#include "' + used_class_name + '.hpp"')
         elif is_enum(used_class) and is_nested_type(used_class) and not is_nested_type(used_class, class_name):
             used_class_name = remove_enum_prefix(used_class)
             if used_class_name not in included:
                 included.append(used_class_name)
-                source.append("#include \"" + used_class_name + ".hpp\"")
+                source.append('#include "' + used_class_name + '.hpp"')
 
     source.append("")
 
     if c["base_class"] != "":
-        source.append("#include \"" + strip_name(c["base_class"]) + ".hpp\"")
-
+        source.append('#include "' + strip_name(c["base_class"]) + '.hpp"')
 
     source.append("namespace godot {")
     source.append("")
-
 
     for used_type in used_classes:
         if is_enum(used_type) or is_nested_type(used_type, class_name):
@@ -176,13 +173,17 @@ def generate_class_header(used_classes, c, use_template_get_node):
         else:
             source.append("class " + strip_name(used_type) + ";")
 
-
     source.append("")
 
     vararg_templates = ""
 
     # generate the class definition here
-    source.append("class " + class_name + (" : public _Wrapped" if c["base_class"] == "" else (" : public " + strip_name(c["base_class"])) ) + " {")
+    source.append(
+        "class "
+        + class_name
+        + (" : public _Wrapped" if c["base_class"] == "" else (" : public " + strip_name(c["base_class"])))
+        + " {"
+    )
 
     if c["base_class"] == "":
         source.append("public: enum { ___CLASS_IS_SCRIPT = 0, };")
@@ -213,7 +214,6 @@ def generate_class_header(used_classes, c, use_template_get_node):
 
     source.append("")
 
-
     if c["singleton"]:
         source.append("\tstatic inline " + class_name + " *get_singleton()")
         source.append("\t{")
@@ -229,10 +229,18 @@ def generate_class_header(used_classes, c, use_template_get_node):
     # class name:
     # Two versions needed needed because when the user implements a custom class,
     # we want to override `___get_class_name` while `___get_godot_class_name` can keep returning the base name
-    source.append("\tstatic inline const char *___get_class_name() { return (const char *) \"" + strip_name(c["name"]) + "\"; }")
-    source.append("\tstatic inline const char *___get_godot_class_name() { return (const char *) \"" + strip_name(c["name"]) + "\"; }")
+    source.append(
+        '\tstatic inline const char *___get_class_name() { return (const char *) "' + strip_name(c["name"]) + '"; }'
+    )
+    source.append(
+        '\tstatic inline const char *___get_godot_class_name() { return (const char *) "'
+        + strip_name(c["name"])
+        + '"; }'
+    )
 
-    source.append("\tstatic inline Object *___get_from_variant(Variant a) { godot_object *o = (godot_object*) a; return (o) ? (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, o) : nullptr; }")
+    source.append(
+        "\tstatic inline Object *___get_from_variant(Variant a) { godot_object *o = (godot_object*) a; return (o) ? (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, o) : nullptr; }"
+    )
 
     enum_values = []
 
@@ -250,14 +258,12 @@ def generate_class_header(used_classes, c, use_template_get_node):
         if name not in enum_values:
             source.append("\tconst static int " + name + " = " + str(c["constants"][name]) + ";")
 
-
     if c["instanciable"]:
         source.append("")
         source.append("")
         source.append("\tstatic " + class_name + " *_new();")
 
     source.append("\n\t// methods")
-
 
     if class_name == "Object":
         source.append("#ifndef GODOT_CPP_NO_OBJECT_CAST")
@@ -273,8 +279,7 @@ def generate_class_header(used_classes, c, use_template_get_node):
         # method_signature += "virtual " if method["is_virtual"] else ""
         method_signature += make_gdnative_type(method["return_type"], ref_allowed)
         method_name = escape_cpp(method["name"])
-        method_signature +=  method_name + "("
-
+        method_signature += method_name + "("
 
         has_default_argument = False
         method_arguments = ""
@@ -285,7 +290,6 @@ def generate_class_header(used_classes, c, use_template_get_node):
             method_signature += argument_name
             method_arguments += argument_name
 
-
             # default arguments
             def escape_default_arg(_type, default_value):
                 if _type == "Color":
@@ -294,7 +298,15 @@ def generate_class_header(used_classes, c, use_template_get_node):
                     return default_value.lower()
                 if _type == "Array":
                     return "Array()"
-                if _type in ["PoolVector2Array", "PoolStringArray", "PoolVector3Array", "PoolColorArray", "PoolIntArray", "PoolRealArray", "PoolByteArray"]:
+                if _type in [
+                    "PoolVector2Array",
+                    "PoolStringArray",
+                    "PoolVector3Array",
+                    "PoolColorArray",
+                    "PoolIntArray",
+                    "PoolRealArray",
+                    "PoolByteArray",
+                ]:
                     return _type + "()"
                 if _type == "Vector2":
                     return "Vector2" + default_value
@@ -309,7 +321,7 @@ def generate_class_header(used_classes, c, use_template_get_node):
                 if _type == "Variant":
                     return "Variant()" if default_value == "Null" else default_value
                 if _type == "String" or _type == "NodePath":
-                    return "\"" + default_value + "\""
+                    return '"' + default_value + '"'
                 if _type == "RID":
                     return "RID()"
 
@@ -318,14 +330,9 @@ def generate_class_header(used_classes, c, use_template_get_node):
 
                 return default_value
 
-
-
-
             if argument["has_default_value"] or has_default_argument:
                 method_signature += " = " + escape_default_arg(argument["type"], argument["default_value"])
                 has_default_argument = True
-
-
 
             if i != len(method["arguments"]) - 1:
                 method_signature += ", "
@@ -335,11 +342,19 @@ def generate_class_header(used_classes, c, use_template_get_node):
             if len(method["arguments"]) > 0:
                 method_signature += ", "
                 method_arguments += ", "
-            vararg_templates += "\ttemplate <class... Args> " + method_signature + "Args... args){\n\t\treturn " + method_name + "(" + method_arguments + "Array::make(args...));\n\t}\n"""
+            vararg_templates += (
+                "\ttemplate <class... Args> "
+                + method_signature
+                + "Args... args){\n\t\treturn "
+                + method_name
+                + "("
+                + method_arguments
+                + "Array::make(args...));\n\t}\n"
+                ""
+            )
             method_signature += "const Array& __var_args = Array()"
 
         method_signature += ")" + (" const" if method["is_const"] else "")
-
 
         source.append("\t" + method_signature + ";")
 
@@ -370,11 +385,7 @@ def generate_class_header(used_classes, c, use_template_get_node):
 
     source.append("#endif")
 
-
     return "\n".join(source)
-
-
-
 
 
 def generate_class_implementation(icalls, used_classes, c, use_template_get_node):
@@ -383,7 +394,7 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
     ref_allowed = class_name != "Object" and class_name != "Reference"
 
     source = []
-    source.append("#include \"" + class_name + ".hpp\"")
+    source.append('#include "' + class_name + '.hpp"')
     source.append("")
     source.append("")
 
@@ -394,8 +405,7 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
     source.append("#include <core/Godot.hpp>")
     source.append("")
 
-
-    source.append("#include \"__icalls.hpp\"")
+    source.append('#include "__icalls.hpp"')
     source.append("")
     source.append("")
 
@@ -403,16 +413,14 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
         if is_enum(used_class):
             continue
         else:
-            source.append("#include \"" + strip_name(used_class) + ".hpp\"")
+            source.append('#include "' + strip_name(used_class) + '.hpp"')
 
     source.append("")
     source.append("")
 
     source.append("namespace godot {")
 
-
     core_object_name = "this"
-
 
     source.append("")
     source.append("")
@@ -424,7 +432,7 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
 
         # FIXME Test if inlining has a huge impact on binary size
         source.append(class_name + "::" + class_name + "() {")
-        source.append("\t_owner = godot::api->godot_global_get_singleton((char *) \"" + strip_name(c["name"]) + "\");")
+        source.append('\t_owner = godot::api->godot_global_get_singleton((char *) "' + strip_name(c["name"]) + '");')
         source.append("}")
 
         source.append("")
@@ -440,10 +448,18 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
     source.append("void " + class_name + "::___init_method_bindings() {")
 
     for method in c["methods"]:
-        source.append("\t___mb.mb_" + method["name"] + " = godot::api->godot_method_bind_get_method(\"" + c["name"] + "\", \"" + ("get_node" if use_template_get_node and method["name"] == "get_node_internal" else method["name"]) + "\");")
+        source.append(
+            "\t___mb.mb_"
+            + method["name"]
+            + ' = godot::api->godot_method_bind_get_method("'
+            + c["name"]
+            + '", "'
+            + ("get_node" if use_template_get_node and method["name"] == "get_node_internal" else method["name"])
+            + '");'
+        )
 
     source.append("\tgodot_string_name class_name;")
-    source.append("\tgodot::api->godot_string_name_new_data(&class_name, \"" + c["name"] + "\");")
+    source.append('\tgodot::api->godot_string_name_new_data(&class_name, "' + c["name"] + '");')
     source.append("\t_detail_class_tag = godot::core_1_2_api->godot_get_class_tag(&class_name);")
     source.append("\tgodot::api->godot_string_name_destroy(&class_name);")
 
@@ -453,7 +469,13 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
     if c["instanciable"]:
         source.append(class_name + " *" + strip_name(c["name"]) + "::_new()")
         source.append("{")
-        source.append("\treturn (" + class_name + " *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, godot::api->godot_get_class_constructor((char *)\"" + c["name"] + "\")());")
+        source.append(
+            "\treturn ("
+            + class_name
+            + ' *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, godot::api->godot_get_class_constructor((char *)"'
+            + c["name"]
+            + '")());'
+        )
         source.append("}")
 
     for method in c["methods"]:
@@ -478,7 +500,6 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
 
         source.append(method_signature + " {")
 
-
         if method["name"] == "free":
             # dirty hack because Object::free is marked virtual but doesn't actually exist...
             source.append("\tgodot::api->godot_object_destroy(_owner);")
@@ -496,7 +517,9 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
                 elif return_type_is_ref:
                     return_statement += "return Ref<" + strip_name(method["return_type"]) + ">::__internal_constructor("
                 else:
-                    return_statement += "return " + ("(" + strip_name(method["return_type"]) + " *) " if is_class_type(method["return_type"]) else "")
+                    return_statement += "return " + (
+                        "(" + strip_name(method["return_type"]) + " *) " if is_class_type(method["return_type"]) else ""
+                    )
             else:
                 return_statement += "return "
 
@@ -507,8 +530,6 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
                 return "Object"
             return name
 
-
-
         if method["has_varargs"]:
 
             if len(method["arguments"]) != 0:
@@ -518,7 +539,6 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
                 source.append("\tgodot::api->godot_variant_new_nil((godot_variant *) &__given_args[" + str(i) + "]);")
 
             source.append("")
-
 
             for i, argument in enumerate(method["arguments"]):
                 source.append("\t__given_args[" + str(i) + "] = " + escape_cpp(argument["name"]) + ";")
@@ -531,7 +551,9 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
             else:
                 size = "(" + str(len(method["arguments"])) + ")"
 
-            source.append("\tgodot_variant **__args = (godot_variant **) alloca(sizeof(godot_variant *) * " + size + ");")
+            source.append(
+                "\tgodot_variant **__args = (godot_variant **) alloca(sizeof(godot_variant *) * " + size + ");"
+            )
 
             source.append("")
 
@@ -542,23 +564,34 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
 
             if method["has_varargs"]:
                 source.append("\tfor (int i = 0; i < __var_args.size(); i++) {")
-                source.append("\t\t__args[i + " + str(len(method["arguments"])) + "] = (godot_variant *) &((Array &) __var_args)[i];")
+                source.append(
+                    "\t\t__args[i + "
+                    + str(len(method["arguments"]))
+                    + "] = (godot_variant *) &((Array &) __var_args)[i];"
+                )
                 source.append("\t}")
 
             source.append("")
 
             source.append("\tVariant __result;")
-            source.append("\t*(godot_variant *) &__result = godot::api->godot_method_bind_call(___mb.mb_" + method["name"] + ", ((const Object *) " + core_object_name + ")->_owner, (const godot_variant **) __args, " + size + ", nullptr);")
+            source.append(
+                "\t*(godot_variant *) &__result = godot::api->godot_method_bind_call(___mb.mb_"
+                + method["name"]
+                + ", ((const Object *) "
+                + core_object_name
+                + ")->_owner, (const godot_variant **) __args, "
+                + size
+                + ", nullptr);"
+            )
 
             source.append("")
 
             if is_class_type(method["return_type"]):
                 source.append("\tObject *obj = Object::___get_from_variant(__result);")
-                source.append("\tif (obj->has_method(\"reference\"))")
-                source.append("\t\tobj->callv(\"reference\", Array());")
+                source.append('\tif (obj->has_method("reference"))')
+                source.append('\t\tobj->callv("reference", Array());')
 
                 source.append("")
-
 
             for i, argument in enumerate(method["arguments"]):
                 source.append("\tgodot::api->godot_variant_destroy((godot_variant *) &__given_args[" + str(i) + "]);")
@@ -571,11 +604,16 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
                     if return_type_is_ref:
                         cast += "Ref<" + strip_name(method["return_type"]) + ">::__internal_constructor(__result);"
                     else:
-                        cast += "(" + strip_name(method["return_type"]) + " *) " + strip_name(method["return_type"] + "::___get_from_variant(") + "__result);"
+                        cast += (
+                            "("
+                            + strip_name(method["return_type"])
+                            + " *) "
+                            + strip_name(method["return_type"] + "::___get_from_variant(")
+                            + "__result);"
+                        )
                 else:
                     cast += "__result;"
                 source.append("\treturn " + cast)
-
 
         else:
 
@@ -607,15 +645,9 @@ def generate_class_implementation(icalls, used_classes, c, use_template_get_node
         source.append("}")
         source.append("")
 
-
-
     source.append("}")
 
-
     return "\n".join(source)
-
-
-
 
 
 def generate_icall_header(icalls):
@@ -632,7 +664,7 @@ def generate_icall_header(icalls):
 
     source.append("#include <core/GodotGlobal.hpp>")
     source.append("#include <core/CoreTypes.hpp>")
-    source.append("#include \"Object.hpp\"")
+    source.append('#include "Object.hpp"')
     source.append("")
     source.append("")
 
@@ -645,7 +677,9 @@ def generate_icall_header(icalls):
 
         method_signature = "static inline "
 
-        method_signature += get_icall_return_type(ret_type) + get_icall_name(icall) + "(godot_method_bind *mb, const Object *inst"
+        method_signature += (
+            get_icall_return_type(ret_type) + get_icall_name(icall) + "(godot_method_bind *mb, const Object *inst"
+        )
 
         for i, arg in enumerate(args):
             method_signature += ", const "
@@ -668,10 +702,11 @@ def generate_icall_header(icalls):
         source.append(method_signature + " {")
 
         if ret_type != "void":
-            source.append("\t" + ("godot_object *" if is_class_type(ret_type) else get_icall_return_type(ret_type)) + "ret;")
+            source.append(
+                "\t" + ("godot_object *" if is_class_type(ret_type) else get_icall_return_type(ret_type)) + "ret;"
+            )
             if is_class_type(ret_type):
                 source.append("\tret = nullptr;")
-
 
         source.append("\tconst void *args[" + ("1" if len(args) == 0 else "") + "] = {")
 
@@ -689,12 +724,18 @@ def generate_icall_header(icalls):
         source.append("\t};")
         source.append("")
 
-        source.append("\tgodot::api->godot_method_bind_ptrcall(mb, inst->_owner, args, " + ("nullptr" if ret_type == "void" else "&ret") + ");")
+        source.append(
+            "\tgodot::api->godot_method_bind_ptrcall(mb, inst->_owner, args, "
+            + ("nullptr" if ret_type == "void" else "&ret")
+            + ");"
+        )
 
         if ret_type != "void":
             if is_class_type(ret_type):
                 source.append("\tif (ret) {")
-                source.append("\t\treturn (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, ret);")
+                source.append(
+                    "\t\treturn (Object *) godot::nativescript_1_1_api->godot_nativescript_get_instance_binding_data(godot::_RegisterState::language_index, ret);"
+                )
                 source.append("\t}")
                 source.append("")
                 source.append("\treturn (Object *) ret;")
@@ -715,7 +756,7 @@ def generate_icall_header(icalls):
 def generate_type_registry(classes):
     source = []
 
-    source.append("#include \"TagDB.hpp\"")
+    source.append('#include "TagDB.hpp"')
     source.append("#include <typeinfo>")
     source.append("\n")
 
@@ -741,13 +782,20 @@ def generate_type_registry(classes):
         if base_class_name == "":
             base_class_type_hash = "0"
 
-        source.append("\tgodot::_TagDB::register_global_type(\"" + c["name"] + "\", " + class_type_hash + ", " + base_class_type_hash + ");")
+        source.append(
+            '\tgodot::_TagDB::register_global_type("'
+            + c["name"]
+            + '", '
+            + class_type_hash
+            + ", "
+            + base_class_type_hash
+            + ");"
+        )
 
     source.append("}")
 
     source.append("")
     source.append("}")
-
 
     return "\n".join(source)
 
@@ -799,9 +847,6 @@ def get_icall_name(sig):
     return name
 
 
-
-
-
 def get_used_classes(c):
     classes = []
     for method in c["methods"]:
@@ -814,86 +859,91 @@ def get_used_classes(c):
     return classes
 
 
-
-
-
 def strip_name(name):
     if len(name) == 0:
         return name
-    if name[0] == '_':
+    if name[0] == "_":
         return name[1:]
     return name
 
+
 def extract_nested_type(nested_type):
-    return strip_name(nested_type[:nested_type.find("::")])
+    return strip_name(nested_type[: nested_type.find("::")])
+
 
 def remove_nested_type_prefix(name):
-    return name if name.find("::") == -1 else strip_name(name[name.find("::") + 2:])
+    return name if name.find("::") == -1 else strip_name(name[name.find("::") + 2 :])
+
 
 def remove_enum_prefix(name):
-    return strip_name(name[name.find("enum.") + 5:])
+    return strip_name(name[name.find("enum.") + 5 :])
 
-def is_nested_type(name, type = ""):
+
+def is_nested_type(name, type=""):
     return name.find(type + "::") != -1
+
 
 def is_enum(name):
     return name.find("enum.") == 0
 
+
 def is_class_type(name):
     return not is_core_type(name) and not is_primitive(name)
 
+
 def is_core_type(name):
-    core_types = ["Array",
-                  "Basis",
-                  "Color",
-                  "Dictionary",
-                  "Error",
-                  "NodePath",
-                  "Plane",
-                  "PoolByteArray",
-                  "PoolIntArray",
-                  "PoolRealArray",
-                  "PoolStringArray",
-                  "PoolVector2Array",
-                  "PoolVector3Array",
-                  "PoolColorArray",
-                  "PoolIntArray",
-                  "PoolRealArray",
-                  "Quat",
-                  "Rect2",
-                  "AABB",
-                  "RID",
-                  "String",
-                  "Transform",
-                  "Transform2D",
-                  "Variant",
-                  "Vector2",
-                  "Vector3"]
+    core_types = [
+        "Array",
+        "Basis",
+        "Color",
+        "Dictionary",
+        "Error",
+        "NodePath",
+        "Plane",
+        "PoolByteArray",
+        "PoolIntArray",
+        "PoolRealArray",
+        "PoolStringArray",
+        "PoolVector2Array",
+        "PoolVector3Array",
+        "PoolColorArray",
+        "PoolIntArray",
+        "PoolRealArray",
+        "Quat",
+        "Rect2",
+        "AABB",
+        "RID",
+        "String",
+        "Transform",
+        "Transform2D",
+        "Variant",
+        "Vector2",
+        "Vector3",
+    ]
     return name in core_types
-
-
 
 
 def is_primitive(name):
     core_types = ["int", "bool", "real", "float", "void"]
     return name in core_types
 
+
 def escape_cpp(name):
     escapes = {
-        "class":    "_class",
-        "enum":     "_enum",
-        "char":     "_char",
-        "short":    "_short",
-        "bool":     "_bool",
-        "int":      "_int",
-        "default":  "_default",
-        "case":     "_case",
-        "switch":   "_switch",
-        "export":   "_export",
+        "class": "_class",
+        "enum": "_enum",
+        "char": "_char",
+        "short": "_short",
+        "bool": "_bool",
+        "int": "_int",
+        "default": "_default",
+        "case": "_case",
+        "switch": "_switch",
+        "export": "_export",
         "template": "_template",
-        "new":      "new_",
+        "new": "new_",
         "operator": "_operator",
-        "typename": "_typename"
+        "typename": "_typename",
     }
     if name in escapes:
         return escapes[name]

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -4,30 +4,29 @@ import sys
 
 # Try to detect the host platform automatically.
 # This is used if no `platform` argument is passed
-if sys.platform.startswith('linux'):
-    host_platform = 'linux'
-elif sys.platform == 'darwin':
-    host_platform = 'osx'
-elif sys.platform == 'win32' or sys.platform == 'msys':
-    host_platform = 'windows'
+if sys.platform.startswith("linux"):
+    host_platform = "linux"
+elif sys.platform == "darwin":
+    host_platform = "osx"
+elif sys.platform == "win32" or sys.platform == "msys":
+    host_platform = "windows"
 else:
-    raise ValueError(
-        'Could not detect platform automatically, please specify with '
-        'platform=<platform>'
-    )
+    raise ValueError("Could not detect platform automatically, please specify with platform=<platform>")
 
-env = Environment(ENV = os.environ)
+env = Environment(ENV=os.environ)
 
 opts = Variables([], ARGUMENTS)
 
 # Define our options
-opts.Add(EnumVariable('target', "Compilation target", 'debug', ['d', 'debug', 'r', 'release']))
-opts.Add(EnumVariable('platform', "Compilation platform", host_platform, ['', 'windows', 'x11', 'linux', 'osx']))
-opts.Add(EnumVariable('p', "Compilation target, alias for 'platform'", host_platform, ['', 'windows', 'x11', 'linux', 'osx']))
-opts.Add(EnumVariable('bits', 'Target platform bits', '64', ('32', '64')))
-opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
-opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/', PathVariable.PathAccept))
-opts.Add(PathVariable('target_name', 'The library name.', 'libgdexample', PathVariable.PathAccept))
+opts.Add(EnumVariable("target", "Compilation target", "debug", ["d", "debug", "r", "release"]))
+opts.Add(EnumVariable("platform", "Compilation platform", host_platform, ["", "windows", "x11", "linux", "osx"]))
+opts.Add(
+    EnumVariable("p", "Compilation target, alias for 'platform'", host_platform, ["", "windows", "x11", "linux", "osx"])
+)
+opts.Add(EnumVariable("bits", "Target platform bits", "64", ("32", "64")))
+opts.Add(BoolVariable("use_llvm", "Use the LLVM / Clang compiler", "no"))
+opts.Add(PathVariable("target_path", "The path where the lib is installed.", "bin/", PathVariable.PathAccept))
+opts.Add(PathVariable("target_name", "The library name.", "libgdexample", PathVariable.PathAccept))
 
 # Local dependency paths, adapt them to your setup
 godot_headers_path = "../godot-headers/"
@@ -45,25 +44,25 @@ Help(opts.GenerateHelpText(env))
 # This makes sure to keep the session environment variables on Windows.
 # This way, you can run SCons in a Visual Studio 2017 prompt and it will find
 # all the required tools
-if host_platform == 'windows' and env['platform'] != 'android':
-    if env['bits'] == '64':
-        env = Environment(TARGET_ARCH='amd64')
-    elif env['bits'] == '32':
-        env = Environment(TARGET_ARCH='x86')
+if host_platform == "windows" and env["platform"] != "android":
+    if env["bits"] == "64":
+        env = Environment(TARGET_ARCH="amd64")
+    elif env["bits"] == "32":
+        env = Environment(TARGET_ARCH="x86")
 
     opts.Update(env)
 
 # Process some arguments
-if env['use_llvm']:
-    env['CC'] = 'clang'
-    env['CXX'] = 'clang++'
+if env["use_llvm"]:
+    env["CC"] = "clang"
+    env["CXX"] = "clang++"
 
-if env['p'] != '':
-    env['platform'] = env['p']
+if env["p"] != "":
+    env["platform"] = env["p"]
 
-if env['platform'] == '':
+if env["platform"] == "":
     print("No valid target platform selected.")
-    quit();
+    quit()
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++
@@ -74,62 +73,69 @@ if env['platform'] == '':
 # - LINKFLAGS are for linking flags
 
 # Check our platform specifics
-if env['platform'] == "osx":
-    env['target_path'] += 'osx/'
-    cpp_library += '.osx'
-    env.Append(CCFLAGS=['-arch', 'x86_64'])
-    env.Append(CXXFLAGS=['-std=c++17'])
-    env.Append(LINKFLAGS=['-arch', 'x86_64'])
-    if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS=['-g', '-O2'])
+if env["platform"] == "osx":
+    env["target_path"] += "osx/"
+    cpp_library += ".osx"
+    env.Append(CCFLAGS=["-arch", "x86_64"])
+    env.Append(CXXFLAGS=["-std=c++17"])
+    env.Append(LINKFLAGS=["-arch", "x86_64"])
+    if env["target"] in ("debug", "d"):
+        env.Append(CCFLAGS=["-g", "-O2"])
     else:
-        env.Append(CCFLAGS=['-g', '-O3'])
+        env.Append(CCFLAGS=["-g", "-O3"])
 
-elif env['platform'] in ('x11', 'linux'):
-    env['target_path'] += 'x11/'
-    cpp_library += '.linux'
-    env.Append(CCFLAGS=['-fPIC'])
-    env.Append(CXXFLAGS=['-std=c++17'])
-    if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS=['-g3', '-Og'])
+elif env["platform"] in ("x11", "linux"):
+    env["target_path"] += "x11/"
+    cpp_library += ".linux"
+    env.Append(CCFLAGS=["-fPIC"])
+    env.Append(CXXFLAGS=["-std=c++17"])
+    if env["target"] in ("debug", "d"):
+        env.Append(CCFLAGS=["-g3", "-Og"])
     else:
-        env.Append(CCFLAGS=['-g', '-O3'])
+        env.Append(CCFLAGS=["-g", "-O3"])
 
-elif env['platform'] == "windows":
-    env['target_path'] += 'win64/'
-    cpp_library += '.windows'
+elif env["platform"] == "windows":
+    env["target_path"] += "win64/"
+    cpp_library += ".windows"
     # This makes sure to keep the session environment variables on windows,
     # that way you can run scons in a vs 2017 prompt and it will find all the required tools
     env.Append(ENV=os.environ)
 
-    env.Append(CPPDEFINES=['WIN32', '_WIN32', '_WINDOWS', '_CRT_SECURE_NO_WARNINGS'])
-    env.Append(CCFLAGS=['-W3', '-GR'])
-    env.Append(CXXFLAGS=['-std:c++17'])
-    if env['target'] in ('debug', 'd'):
-        env.Append(CPPDEFINES=['_DEBUG'])
-        env.Append(CCFLAGS=['-EHsc', '-MDd', '-ZI'])
-        env.Append(LINKFLAGS=['-DEBUG'])
+    env.Append(CPPDEFINES=["WIN32", "_WIN32", "_WINDOWS", "_CRT_SECURE_NO_WARNINGS"])
+    env.Append(CCFLAGS=["-W3", "-GR"])
+    env.Append(CXXFLAGS=["-std:c++17"])
+    if env["target"] in ("debug", "d"):
+        env.Append(CPPDEFINES=["_DEBUG"])
+        env.Append(CCFLAGS=["-EHsc", "-MDd", "-ZI"])
+        env.Append(LINKFLAGS=["-DEBUG"])
     else:
-        env.Append(CPPDEFINES=['NDEBUG'])
-        env.Append(CCFLAGS=['-O2', '-EHsc', '-MD'])
+        env.Append(CPPDEFINES=["NDEBUG"])
+        env.Append(CCFLAGS=["-O2", "-EHsc", "-MD"])
 
-if env['target'] in ('debug', 'd'):
-    cpp_library += '.debug'
+if env["target"] in ("debug", "d"):
+    cpp_library += ".debug"
 else:
-    cpp_library += '.release'
+    cpp_library += ".release"
 
-cpp_library += '.' + str(bits)
+cpp_library += "." + str(bits)
 
 # make sure our binding library is properly includes
-env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])
-env.Append(LIBPATH=[cpp_bindings_path + 'bin/'])
+env.Append(
+    CPPPATH=[
+        ".",
+        godot_headers_path,
+        cpp_bindings_path + "include/",
+        cpp_bindings_path + "include/core/",
+        cpp_bindings_path + "include/gen/",
+    ]
+)
+env.Append(LIBPATH=[cpp_bindings_path + "bin/"])
 env.Append(LIBS=[cpp_library])
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
-env.Append(CPPPATH=['src/'])
-sources = Glob('src/*.cpp')
+env.Append(CPPPATH=["src/"])
+sources = Glob("src/*.cpp")
 
-library = env.SharedLibrary(target=env['target_path'] + env['target_name'] , source=sources)
+library = env.SharedLibrary(target=env["target_path"] + env["target_name"], source=sources)
 
 Default(library)
-


### PR DESCRIPTION
This PR runs `black --line-length 120` on these files in the 3.4 branch. 3.x version: #710 master version: #712

I don't actually know what line length we prefer, but the default value of `80` breaks up the `opts.Add(EnumVariable(` lines, which makes it look way less readable in my opinion.