### PR TITLE
[master] Run black format on SConstruct files and bindings generator

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,7 +9,6 @@ if sys.version_info < (3,):
     def decode_utf8(x):
         return x
 
-
 else:
     import codecs
 
@@ -265,7 +264,7 @@ elif env["platform"] == "ios":
         env.Append(CCFLAGS=["-arch", env["ios_arch"]])
 
     env.Append(CCFLAGS=["-isysroot", sdk_path])
-    env.Append(LINKFLAGS=["-isysroot", sdk_path, "-F" + sdk_path,])
+    env.Append(LINKFLAGS=["-isysroot", sdk_path, "-F" + sdk_path])
 
     if env["target"] == "debug":
         env.Append(CCFLAGS=["-Og", "-g"])

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -623,7 +623,9 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
     # Move constructor.
     result.append(f"{class_name}::{class_name}({class_name} &&other) {{")
     if needs_copy_instead_of_move(class_name) and copy_constructor_index >= 0:
-        result.append(f"\tinternal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &other);")
+        result.append(
+            f"\tinternal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &other);"
+        )
     else:
         result.append("\tstd::swap(opaque, other.opaque);")
     result.append("}")
@@ -741,7 +743,9 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
     # Move assignment.
     result.append(f"{class_name} &{class_name}::operator=({class_name} &&other) {{")
     if needs_copy_instead_of_move(class_name) and copy_constructor_index >= 0:
-        result.append(f"\tinternal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &other);")
+        result.append(
+            f"\tinternal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &other);"
+        )
     else:
         result.append("\tstd::swap(opaque, other.opaque);")
     result.append("\treturn *this;")
@@ -1626,6 +1630,7 @@ def is_packed_array(type_name):
         "PackedVector3Array",
     ]
 
+
 def needs_copy_instead_of_move(type_name):
     """
     Those are types which need initialised data or we'll get warning spam so need a copy instead of move.
@@ -1633,6 +1638,7 @@ def needs_copy_instead_of_move(type_name):
     return type_name in [
         "Dictionary",
     ]
+
 
 def is_enum(type_name):
     return type_name.startswith("enum::")

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -17,8 +17,18 @@ env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
 if env["platform"] == "osx":
-    library = env.SharedLibrary("demo/bin/libgdexample.{}.{}.framework/libgdexample.{}.{}".format(env["platform"], env["target"], env["platform"], env["target"]), source=sources)
+    library = env.SharedLibrary(
+        "demo/bin/libgdexample.{}.{}.framework/libgdexample.{}.{}".format(
+            env["platform"], env["target"], env["platform"], env["target"]
+        ),
+        source=sources,
+    )
 else:
-    library = env.SharedLibrary("demo/bin/libgdexample.{}.{}.{}{}".format(env["platform"], env["target"], env["arch_suffix"], env["SHLIBSUFFIX"]), source=sources)
+    library = env.SharedLibrary(
+        "demo/bin/libgdexample.{}.{}.{}{}".format(
+            env["platform"], env["target"], env["arch_suffix"], env["SHLIBSUFFIX"]
+        ),
+        source=sources,
+    )
 
 Default(library)


### PR DESCRIPTION
This PR runs `black --line-length 120` on these files in the master branch. 3.x version: #710 3.4 version: #711