### PR TITLE
CI: Install MinGW via `egor-tensin/setup-mingw`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,9 @@ jobs:
         run: |
           python -m pip install scons
 
-      - name: Windows GCC dependency
-        if: ${{ matrix.platform == 'windows' }}
-        # Install GCC from Scoop as the default supplied GCC doesn't work ("Error 1").
-        run: |
-          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-          scoop install gcc
-          g++ --version
-          gcc --version
+      - name: Setup MinGW for Windows/MinGW build
+        if: ${{ matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes' }}
+        uses: egor-tensin/setup-mingw@v2
 
       - name: Build godot-cpp (debug)
         run: |
@@ -218,13 +213,11 @@ jobs:
         run: |
           python -m pip install scons
 
+      - name: Setup MinGW for Windows/MinGW build
+        uses: egor-tensin/setup-mingw@v2
+
       - name: Build godot-cpp
-        # Install GCC from Scoop as the default supplied GCC doesn't work ("Error 1").
         run: |
-          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-          scoop install gcc
-          g++ --version
-          gcc --version
           scons target=release generate_bindings=yes use_mingw=yes -j $env:NUMBER_OF_PROCESSORS
 
       #- name: Build test project (TODO currently not supported, leaving uncommented as a reminder to fix this)


### PR DESCRIPTION
Scoop install is being problematic since their 0.1.0 release.

It gives this error:
```
Run Invoke-Expression (New-Object System.Net.WebClient).DownloadString('get.scoop.sh')
Initializing...
Running the installer as administrator is disabled by default, use -RunAsAdmin parameter if you know what you are doing.
Abort.
Error: Process completed with exit code 1.
```

Couldn't find how to work it around.