### PR TITLE
Fix build after "Discern between VIRTUAL and ABSTRACT class bindings".

### DIFF
--- a/godot-headers/godot/gdnative_interface.h
+++ b/godot-headers/godot/gdnative_interface.h
@@ -194,6 +194,7 @@ typedef void *GDExtensionClassInstancePtr;
 
 typedef GDNativeBool (*GDNativeExtensionClassSet)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name, const GDNativeVariantPtr p_value);
 typedef GDNativeBool (*GDNativeExtensionClassGet)(GDExtensionClassInstancePtr p_instance, const GDNativeStringNamePtr p_name, GDNativeVariantPtr r_ret);
+typedef uint64_t (*GDNativeExtensionClassGetRID)(GDExtensionClassInstancePtr p_instance);
 
 typedef struct {
 	uint32_t type;
@@ -228,6 +229,7 @@ typedef struct {
 	GDNativeExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
 	GDNativeExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 	GDNativeExtensionClassGetVirtual get_virtual_func;
+	GDNativeExtensionClassGetRID get_rid_func;
 	void *class_userdata;
 } GDNativeExtensionClassCreationInfo;
 

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -155,10 +155,11 @@ void ClassDB::register_class() {
 		nullptr, // GDNativeExtensionClassNotification notification_func;
 		nullptr, // GDNativeExtensionClassToString to_string_func;
 		nullptr, // GDNativeExtensionClassReference reference_func;
-		nullptr, // GDNativeExtensionClassUnreference
+		nullptr, // GDNativeExtensionClassUnreference unreference_func;
 		T::create, // GDNativeExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
 		T::free, // GDNativeExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		&ClassDB::get_virtual_func, // GDNativeExtensionClassGetVirtual get_virtual_func;
+		nullptr, // GDNativeExtensionClassGetRID get_rid;
 		(void *)cl.name, // void *class_userdata;
 	};
 


### PR DESCRIPTION
Fix build after https://github.com/godotengine/godot/pull/58972.

Note: Also requires `godot-headers` sync to work. I guess it worth waiting for https://github.com/godotengine/godot/pull/59140, which will also require headers sync (but should not break anything else).