### PR TITLE
Fix generating static methods without return value.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1135,7 +1135,10 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
                         else:
                             method_call += f"return internal::_call_native_mb_ret_obj<{return_type}>(___method_bind, _owner"
                 else:
-                    method_call += f"internal::_call_native_mb_no_ret(___method_bind, _owner"
+                    if method["is_static"]:
+                        method_call += f"internal::_call_native_mb_no_ret(___method_bind, nullptr"
+                    else:
+                        method_call += f"internal::_call_native_mb_no_ret(___method_bind, _owner"
 
                 if "arguments" in method:
                     method_call += ", "


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot-cpp/pull/729, I have missed the branch for `void` return.