### PR TITLE
Add ready callback after godot setup.

### DIFF
--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -71,11 +71,13 @@ public:
 		void register_driver_initializer(Callback p_driver_init) const;
 		void register_scene_initializer(Callback p_scene_init) const;
 		void register_editor_initializer(Callback p_editor_init) const;
+		void ready_initializer(Callback p_ready_init) const;
 		void register_core_terminator(Callback p_core_terminate) const;
 		void register_server_terminator(Callback p_server_terminate) const;
 		void register_scene_terminator(Callback p_scene_terminate) const;
 		void register_driver_terminator(Callback p_driver_terminate) const;
 		void register_editor_terminator(Callback p_editor_terminate) const;
+		void ready_terminator(Callback p_ready_terminate) const;
 
 		GDNativeBool init() const;
 	};

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -111,6 +111,10 @@ void GDExtensionBinding::InitObject::register_editor_initializer(Callback p_edit
 	GDExtensionBinding::init_callbacks[GDNATIVE_INITIALIZATION_EDITOR] = p_editor_init;
 }
 
+void GDExtensionBinding::InitObject::ready_initializer(Callback p_ready_init) const {
+	GDExtensionBinding::init_callbacks[GDNATIVE_INITIALIZATION_READY] = p_ready_init;
+}
+
 void GDExtensionBinding::InitObject::register_core_terminator(Callback p_core_terminate) const {
 	GDExtensionBinding::terminate_callbacks[GDNATIVE_INITIALIZATION_CORE] = p_core_terminate;
 }
@@ -129,6 +133,10 @@ void GDExtensionBinding::InitObject::register_driver_terminator(Callback p_drive
 
 void GDExtensionBinding::InitObject::register_editor_terminator(Callback p_editor_terminate) const {
 	GDExtensionBinding::terminate_callbacks[GDNATIVE_INITIALIZATION_EDITOR] = p_editor_terminate;
+}
+
+void GDExtensionBinding::InitObject::ready_terminator(Callback p_ready_terminate) const {
+	GDExtensionBinding::terminate_callbacks[GDNATIVE_INITIALIZATION_READY] = p_ready_terminate;
 }
 
 GDNativeBool GDExtensionBinding::InitObject::init() const {


### PR DESCRIPTION
GDExtensions may rely on godot servers which are initialized during
setup, but after type registration. Added ready callback that guarantees
all setup is completed before it is called and corresponding terminate
before any cleanup commences.

Godot-cpp counterpart of [godotengine/godot/#60317](https://github.com/godotengine/godot/pull/60317)