### PR TITLE
[CI] Remove duplicate builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,40 +142,6 @@ jobs:
           cd test && cmake -DCMAKE_BUILD_TYPE=Release -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -GNinja .
           cmake --build . -j $(nproc)
 
-  windows-msvc:
-    name: Build (Windows, MSVC)
-    runs-on: windows-2019
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install scons
-
-      - name: Build godot-cpp
-        run: |
-          scons target=release generate_bindings=yes -j $env:NUMBER_OF_PROCESSORS
-
-      - name: Build test project
-        run: |
-          cd test
-          scons target=release -j $env:NUMBER_OF_PROCESSORS
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: godot-cpp-windows-msvc2019-x86_64-release
-          path: bin/libgodot-cpp.windows.release.64.lib
-          if-no-files-found: error
-  
   windows-msvc-cmake:
     name: Build (Windows, MSVC, CMake)
     runs-on: windows-2019
@@ -194,70 +160,6 @@ jobs:
         run: |
           cd test && cmake -DCMAKE_BUILD_TYPE=Release -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -G"Visual Studio 16 2019" .
           cmake --build .
-
-  windows-mingw:
-    name: Build (Windows, MinGW)
-    runs-on: windows-2019
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install scons
-
-      - name: Setup MinGW for Windows/MinGW build
-        uses: egor-tensin/setup-mingw@v2
-
-      - name: Build godot-cpp
-        run: |
-          scons target=release generate_bindings=yes use_mingw=yes -j $env:NUMBER_OF_PROCESSORS
-
-      #- name: Build test project (TODO currently not supported, leaving uncommented as a reminder to fix this)
-      #  run: |
-      #    cd test
-      #    scons target=release use_mingw=yes -j $env:NUMBER_OF_PROCESSORS
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: godot-cpp-linux-mingw-x86_64-release
-          path: bin/libgodot-cpp.windows.release.64.a
-          if-no-files-found: error
-
-  macos:
-    name: Build (macOS, Clang, universal / x86_64 + arm64)
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install scons
-
-      - name: Build godot-cpp
-        run: |
-          scons target=release generate_bindings=yes -j $(sysctl -n hw.logicalcpu)
-
-      - name: Build test project
-        run: |
-          cd test
-          scons target=release -j $(sysctl -n hw.logicalcpu)
 
   static-checks:
     name: Static Checks (clang-format)


### PR DESCRIPTION
Those CI steps were removed in #691 (included in the matrix) but were brought back by a merge commit attached to #683 .