### PR TITLE
Build javascript target on windows host

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -410,7 +410,12 @@ elif env["platform"] == "android":
         env.Append(CCFLAGS=["-O3"])
 
 elif env["platform"] == "javascript":
-    env["ENV"] = os.environ
+    if host_platform == "windows":
+        env = Environment(ENV=os.environ, tools=["cc", "c++", "ar", "link", "textfile", "zip"])
+        opts.Update(env)
+    else:
+        env["ENV"] = os.environ
+
     env["CC"] = "emcc"
     env["CXX"] = "em++"
     env["AR"] = "emar"


### PR DESCRIPTION
If you build javascript target in windows command line, the arguments will not be in POSIX style which is needed for Emscripten. I fixed it