### PR TITLE
Change registered initializers / terminators to the single function with level argument.

### DIFF
--- a/godot-headers/godot/gdnative_interface.h
+++ b/godot-headers/godot/gdnative_interface.h
@@ -545,6 +545,9 @@ typedef struct {
 	void (*classdb_register_extension_class_property_subgroup)(const GDNativeExtensionClassLibraryPtr p_library, const char *p_class_name, const char *p_subgroup_name, const char *p_prefix);
 	void (*classdb_register_extension_class_signal)(const GDNativeExtensionClassLibraryPtr p_library, const char *p_class_name, const char *p_signal_name, const GDNativePropertyInfo *p_argument_info, GDNativeInt p_argument_count);
 	void (*classdb_unregister_extension_class)(const GDNativeExtensionClassLibraryPtr p_library, const char *p_class_name); /* Unregistering a parent class before a class that inherits it will result in failure. Inheritors must be unregistered first. */
+
+	void (*get_library_path)(const GDNativeExtensionClassLibraryPtr p_library, GDNativeStringPtr r_path);
+
 } GDNativeInterface;
 
 /* INITIALIZATION */
@@ -553,7 +556,6 @@ typedef enum {
 	GDNATIVE_INITIALIZATION_CORE,
 	GDNATIVE_INITIALIZATION_SERVERS,
 	GDNATIVE_INITIALIZATION_SCENE,
-	GDNATIVE_INITIALIZATION_DRIVER,
 	GDNATIVE_INITIALIZATION_EDITOR,
 	GDNATIVE_MAX_INITIALIZATION_LEVEL,
 } GDNativeInitializationLevel;

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -43,12 +43,20 @@ extern "C" void *token;
 
 } // namespace internal
 
+enum ModuleInitializationLevel {
+	MODULE_INITIALIZATION_LEVEL_CORE = GDNATIVE_INITIALIZATION_CORE,
+	MODULE_INITIALIZATION_LEVEL_SERVERS = GDNATIVE_INITIALIZATION_SERVERS,
+	MODULE_INITIALIZATION_LEVEL_SCENE = GDNATIVE_INITIALIZATION_SCENE,
+	MODULE_INITIALIZATION_LEVEL_EDITOR = GDNATIVE_INITIALIZATION_EDITOR
+};
+
 class GDExtensionBinding {
 public:
-	using Callback = void (*)();
+	using Callback = void (*)(ModuleInitializationLevel p_level);
 
-	static Callback init_callbacks[GDNATIVE_MAX_INITIALIZATION_LEVEL];
-	static Callback terminate_callbacks[GDNATIVE_MAX_INITIALIZATION_LEVEL];
+	static Callback init_callback;
+	static Callback terminate_callback;
+	static GDNativeInitializationLevel minimum_initialization_level;
 	static GDNativeBool init(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization);
 
 public:
@@ -66,16 +74,9 @@ public:
 				library(p_library),
 				initialization(r_initialization){};
 
-		void register_core_initializer(Callback p_core_init) const;
-		void register_server_initializer(Callback p_server_init) const;
-		void register_driver_initializer(Callback p_driver_init) const;
-		void register_scene_initializer(Callback p_scene_init) const;
-		void register_editor_initializer(Callback p_editor_init) const;
-		void register_core_terminator(Callback p_core_terminate) const;
-		void register_server_terminator(Callback p_server_terminate) const;
-		void register_scene_terminator(Callback p_scene_terminate) const;
-		void register_driver_terminator(Callback p_driver_terminate) const;
-		void register_editor_terminator(Callback p_editor_terminate) const;
+		void register_initializer(Callback p_init) const;
+		void register_terminator(Callback p_init) const;
+		void set_minimum_library_initialization_level(ModuleInitializationLevel p_level) const;
 
 		GDNativeBool init() const;
 	};

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -40,12 +40,20 @@
 
 using namespace godot;
 
-void register_example_types() {
+void initialize_example_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
 	ClassDB::register_class<ExampleRef>();
 	ClassDB::register_class<Example>();
 }
 
-void unregister_example_types() {}
+void uninitialize_example_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+}
 
 extern "C" {
 
@@ -54,8 +62,9 @@ extern "C" {
 GDNativeBool GDN_EXPORT example_library_init(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization) {
 	godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
 
-	init_obj.register_scene_initializer(register_example_types);
-	init_obj.register_scene_terminator(unregister_example_types);
+	init_obj.register_initializer(initialize_example_module);
+	init_obj.register_terminator(uninitialize_example_module);
+	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
 
 	return init_obj.init();
 }

--- a/test/src/register_types.h
+++ b/test/src/register_types.h
@@ -31,7 +31,10 @@
 #ifndef EXAMPLE_REGISTER_TYPES_H
 #define EXAMPLE_REGISTER_TYPES_H
 
-void register_example_types();
-void unregister_example_types();
+#include <godot_cpp/core/class_db.hpp>
+using namespace godot;
+
+void initialize_example_module(ModuleInitializationLevel p_level);
+void uninitialize_example_module(ModuleInitializationLevel p_level);
 
 #endif // ! EXAMPLE_REGISTER_TYPES_H


### PR DESCRIPTION
Follow-up for https://github.com/godotengine/godot/pull/60723

- Changes initializers / terminators to the single function to match new init style and allow using the same code for built-in modules and extensions.
- Syncs headers.