### PR TITLE
Cast `GetTypeInfo::VARIANT_TYPE` to `GDNativeVariantType`

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -105,7 +105,7 @@ struct VariantObjectClassChecker<const Ref<T> &> {
 template <class T>
 struct VariantCasterAndValidate {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
-		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
+		GDNativeVariantType argtype = GDNativeVariantType(GetTypeInfo<T>::VARIANT_TYPE);
 		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
@@ -120,7 +120,7 @@ struct VariantCasterAndValidate {
 template <class T>
 struct VariantCasterAndValidate<T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
-		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
+		GDNativeVariantType argtype = GDNativeVariantType(GetTypeInfo<T>::VARIANT_TYPE);
 		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
@@ -135,7 +135,7 @@ struct VariantCasterAndValidate<T &> {
 template <class T>
 struct VariantCasterAndValidate<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant **p_args, uint32_t p_arg_idx, GDNativeCallError &r_error) {
-		GDNativeVariantType argtype = GetTypeInfo<T>::VARIANT_TYPE;
+		GDNativeVariantType argtype = GDNativeVariantType(GetTypeInfo<T>::VARIANT_TYPE);
 		if (!internal::gdn_interface->variant_can_convert_strict(static_cast<GDNativeVariantType>(p_args[p_arg_idx]->get_type()), argtype) ||
 				!VariantObjectClassChecker<T>::check(p_args[p_arg_idx])) {
 			r_error.error = GDNATIVE_CALL_ERROR_INVALID_ARGUMENT;
@@ -384,7 +384,7 @@ void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const,
 template <class Q>
 void call_get_argument_type_helper(int p_arg, int &index, GDNativeVariantType &type) {
 	if (p_arg == index) {
-		type = GetTypeInfo<Q>::VARIANT_TYPE;
+		type = GDNativeVariantType(GetTypeInfo<Q>::VARIANT_TYPE);
 	}
 	index++;
 }

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -431,7 +431,7 @@ protected:
 		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
 			return call_get_argument_type<P...>(p_arg);
 		} else {
-			return GetTypeInfo<R>::VARIANT_TYPE;
+			return GDNativeVariantType(GetTypeInfo<R>::VARIANT_TYPE);
 		}
 	}
 
@@ -514,7 +514,7 @@ protected:
 		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
 			return call_get_argument_type<P...>(p_arg);
 		} else {
-			return GetTypeInfo<R>::VARIANT_TYPE;
+			return GDNativeVariantType(GetTypeInfo<R>::VARIANT_TYPE);
 		}
 	}
 
@@ -655,7 +655,7 @@ protected:
 		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
 			return call_get_argument_type<P...>(p_arg);
 		} else {
-			return GetTypeInfo<R>::VARIANT_TYPE;
+			return GDNativeVariantType(GetTypeInfo<R>::VARIANT_TYPE);
 		}
 	}
 


### PR DESCRIPTION
This fixes issue #753. The value of `GetTypeInfo::VARIANT_TYPE` is normally a member of the enum `GDNativeVariantType` but in some cases, like with the macro `VARIANT_ENUM_CAST()` it's a member of `Variant::Type` and compilation fails. These enums are completely equivalent except for the names (`NIL` vs `GDNATIVE_VARIANT_TYPE_NIL`) so casting between them is safe.

With this fix user defined enums compile and are treated as `int`s in GDScript, which is expected behavior without `PROPERTY_HINT_ENUM`.