### PR TITLE
Unify bits, android_arch, macos_arch ios_arch into arch, support non-x86 Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,26 @@ jobs:
             os: ubuntu-18.04
             platform: linux
             artifact-name: godot-cpp-linux-glibc2.27-x86_64-release
-            artifact-path: bin/libgodot-cpp.linux.release.64.a
+            artifact-path: bin/libgodot-cpp.linux.release.x86_64.a
 
           - name: 🐧 Linux (GCC, Double Precision)
             os: ubuntu-18.04
             platform: linux
             artifact-name: godot-cpp-linux-glibc2.27-x86_64-double-release
-            artifact-path: bin/libgodot-cpp.linux.release.64.a
+            artifact-path: bin/libgodot-cpp.linux.release.x86_64.a
             flags: float=64
 
           - name: 🏁 Windows (x86_64, MSVC)
             os: windows-2019
             platform: windows
             artifact-name: godot-cpp-windows-msvc2019-x86_64-release
-            artifact-path: bin/libgodot-cpp.windows.release.64.lib
+            artifact-path: bin/libgodot-cpp.windows.release.x86_64.lib
 
           - name: 🏁 Windows (x86_64, MinGW)
             os: windows-2019
             platform: windows
             artifact-name: godot-cpp-linux-mingw-x86_64-release
-            artifact-path: bin/libgodot-cpp.windows.release.64.a
+            artifact-path: bin/libgodot-cpp.windows.release.x86_64.a
             flags: use_mingw=yes
 
           - name: 🍎 macOS (universal)
@@ -40,20 +40,21 @@ jobs:
             platform: osx
             artifact-name: godot-cpp-macos-universal-release
             artifact-path: bin/libgodot-cpp.osx.release.universal.a
-            flags: macos_arch=universal
+            flags: arch=universal
 
           - name: 🤖 Android (arm64)
             os: ubuntu-18.04
             platform: android
             artifact-name: godot-cpp-android-arm64-release
-            artifact-path: bin/libgodot-cpp.android.release.arm64v8.a
-            flags: android_arch=arm64v8
+            artifact-path: bin/libgodot-cpp.android.release.arm64.a
+            flags: arch=arm64
 
           - name: 🍏 iOS (arm64)
             os: macos-11
             platform: ios
             artifact-name: godot-cpp-ios-arm64-release
             artifact-path: bin/libgodot-cpp.ios.release.arm64.a
+            flags: arch=arm64
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -42,12 +42,15 @@ so formatting is done before your changes are submitted.
 
 ## Getting Started
 
-It's a bit similar to what it was for 3.x but also a bit different. This new approach is much more akin to how core Godot modules are structured.
+It's a bit similar to what it was for 3.x but also a bit different.
+This new approach is much more akin to how core Godot modules are structured.
 
 Compiling this repository generates a static library to be linked with your shared lib,
 just like before.
 
-To use the shared lib in your Godot project you'll need a `.gdextension` file, which replaces what was the `.gdnlib` before. Follow the example:
+To use the shared lib in your Godot project you'll need a `.gdextension`
+file, which replaces what was the `.gdnlib` before.
+Follow [the example](test/demo/example.gdextension):
 
 ```ini
 [configuration]
@@ -56,15 +59,17 @@ entry_symbol = "example_library_init"
 
 [libraries]
 
-linux.64.debug = "bin/libgdexample.linux.debug.64.so"
-linux.64.release = "bin/libgdexample.linux.release.64.so"
-windows.64.debug = "bin/libgdexample.windows.debug.64.dll"
-windows.64.release = "bin/libgdexample.windows.release.64.dll"
-macos.debug = "bin/libgdexample.debug.framework"
-macos.release = "bin/libgdexample.release.framework"
+macos.debug = "bin/libgdexample.osx.debug.framework"
+macos.release = "bin/libgdexample.osx.release.framework"
+windows.debug.x86_64 = "bin/libgdexample.windows.debug.x86_64.dll"
+windows.release.x86_64 = "bin/libgdexample.windows.release.x86_64.dll"
+linux.debug.x86_64 = "bin/libgdexample.linux.debug.x86_64.so"
+linux.release.x86_64 = "bin/libgdexample.linux.release.x86_64.so"
+# Repeat for other architectures to support arm64, rv64, etc.
 ```
 
-The `entry_symbol` is the name of the function that initializes your library. It should be similar to following layout:
+The `entry_symbol` is the name of the function that initializes
+your library. It should be similar to following layout:
 
 ```cpp
 extern "C" {

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -67,7 +67,7 @@ def scons_generate_bindings(target, source, env):
     generate_bindings(
         str(source[0]),
         env["generate_template_get_node"],
-        env["bits"],
+        "32" if "32" in env["arch"] else "64",
         "double" if (env["float"] == "64") else "float",
         target[0].abspath,
     )

--- a/test/demo/example.gdextension
+++ b/test/demo/example.gdextension
@@ -4,9 +4,13 @@ entry_symbol = "example_library_init"
 
 [libraries]
 
-linux.64.debug = "bin/libgdexample.linux.debug.64.so"
-linux.64.release = "bin/libgdexample.linux.release.64.so"
-windows.64.debug = "bin/libgdexample.windows.debug.64.dll"
-windows.64.release = "bin/libgdexample.windows.release.64.dll"
 macos.debug = "bin/libgdexample.osx.debug.framework"
 macos.release = "bin/libgdexample.osx.release.framework"
+windows.debug.x86_64 = "bin/libgdexample.windows.debug.x86_64.dll"
+windows.release.x86_64 = "bin/libgdexample.windows.release.x86_64.dll"
+linux.debug.x86_64 = "bin/libgdexample.linux.debug.x86_64.so"
+linux.release.x86_64 = "bin/libgdexample.linux.release.x86_64.so"
+linux.debug.arm64 = "bin/libgdexample.linux.debug.arm64.so"
+linux.release.arm64 = "bin/libgdexample.linux.release.arm64.so"
+linux.debug.rv64 = "bin/libgdexample.linux.debug.rv64.so"
+linux.release.rv64 = "bin/libgdexample.linux.release.rv64.so"

--- a/test/demo/icon.png.import
+++ b/test/demo/icon.png.import
@@ -1,9 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture2D"
+type="CompressedTexture2D"
 uid="uid://cswr8vy4lt7dt"
-path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -11,7 +11,7 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
@@ -21,7 +21,6 @@ compress/hdr_compression=1
 compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
-compress/streamed=false
 mipmaps/generate=false
 mipmaps/limit=-1
 roughness/mode=0
@@ -29,7 +28,7 @@ roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
-process/HDR_as_SRGB=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -46,5 +46,5 @@ func _ready():
 	prints("  ANSWER_TO_EVERYTHING", $Example.ANSWER_TO_EVERYTHING)
 	prints("  CONSTANT_WITHOUT_ENUM", $Example.CONSTANT_WITHOUT_ENUM)
 
-func _on_Example_custom_signal(name, value):
-	prints("Example emitted:", name, value)
+func _on_Example_custom_signal(signal_name, value):
+	prints("Example emitted:", signal_name, value)

--- a/test/demo/main.tscn
+++ b/test/demo/main.tscn
@@ -12,16 +12,10 @@ offset_left = 194.0
 offset_top = -2.0
 offset_right = 234.0
 offset_bottom = 21.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Button" type="Button" parent="."]
 offset_right = 79.0
 offset_bottom = 29.0
 text = "Click me!"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [connection signal="custom_signal" from="Example" to="." method="_on_Example_custom_signal"]

--- a/test/demo/project.godot
+++ b/test/demo/project.godot
@@ -6,13 +6,14 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 [application]
 
 config/name="GDExtension Test Project"
 run/main_scene="res://main.tscn"
 config/icon="res://icon.png"
+config/features=PackedStringArray("4.0")
 
 [native_extensions]
 


### PR DESCRIPTION
This PR is the `master` / 4.x version of #714, and is similar to [55778](https://github.com/godotengine/godot/pull/55778) in the engine repo.

In the current master branch of godot-cpp, we have several arguments for specifying the architecture: `bits`, `ios_arch`, `macos_arch`, and `android_arch`. This is a bit of a mess, so this PR replaces all of these with a single unified `arch`.

The list of valid architectures is `["", "universal", "x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]`. The names were chosen to be explicit such that each architecture always includes the bitness in the name (except universal, which contains multiple architectures).

If `""`, then it will automatically determine the architecture. It will use universal for macOS and iOS, arm64 for Android, wasm32 for JavaScript, and otherwise it will use the host architecture, so arm64 on modern ARM devices, x86_64 on a typical modern desktop, and x86_32 on an old 32-bit desktop. Most users won't have to specify `arch` manually because it will be automatically selected.

For macOS, iOS, JavaScript, and Android, it will throw an error if trying to build for an invalid architecture. The same should be done for Windows and Linux but I'm not sure how to get cross-compiling working in all cases where it should exist or how to show an error when the necessary libs etc are missing.

This PR does NOT require engine changes to work. The engine can already recognize the names `x86_64` etc because it checks these names via the list of supported features in the OS class. There are a few cases where the names are still not quite the same, like `x86_32` isn't recognized, but these inconsistencies can be fixed later in the engine code independently of this PR.

I have tested this on Windows x86_64 (works fine before/after this PR), macOS x86_64 (builds with errors before/after this PR), macOS arm64 (builds fine but crashes at runtime before/after this PR), Linux x86_64 (works fine before/after this PR), Linux arm64 and Linux rv64 (doesn't work without this PR, but does work with this PR). PowerPC is untested, and I was not able to get the web / javascript platform working with or without this PR.

This PR also updates the test project to the latest Godot master.