### PR TITLE
Fix Rect2::distance_to not returning 0

### DIFF
--- a/src/core/Rect2.cpp
+++ b/src/core/Rect2.cpp
@@ -46,25 +46,35 @@ namespace godot {
 #endif
 
 real_t Rect2::distance_to(const Vector2 &p_point) const {
-	real_t dist = 1e20;
+	real_t dist = 0.0;
+	bool inside = true;
 
 	if (p_point.x < position.x) {
-		dist = MIN(dist, position.x - p_point.x);
+		real_t d = position.x - p_point.x;
+		dist = d;
+		inside = false;
 	}
 	if (p_point.y < position.y) {
-		dist = MIN(dist, position.y - p_point.y);
+		real_t d = position.y - p_point.y;
+		dist = inside ? d : MIN(dist, d);
+		inside = false;
 	}
 	if (p_point.x >= (position.x + size.x)) {
-		dist = MIN(p_point.x - (position.x + size.x), dist);
+		real_t d = p_point.x - (position.x + size.x);
+		dist = inside ? d : MIN(dist, d);
+		inside = false;
 	}
 	if (p_point.y >= (position.y + size.y)) {
-		dist = MIN(p_point.y - (position.y + size.y), dist);
+		real_t d = p_point.y - (position.y + size.y);
+		dist = inside ? d : MIN(dist, d);
+		inside = false;
 	}
 
-	if (dist == 1e20)
+	if (inside) {
 		return 0;
-	else
+	} else {
 		return dist;
+	}
 }
 
 Rect2 Rect2::clip(const Rect2 &p_rect) const { /// return a clipped rect


### PR DESCRIPTION
Was relying on comparison with 1e20 which cannot be represented as float, causing some epsilon to always be returned and compilers complaining when using -Werror.

Basically porting https://github.com/godotengine/godot/pull/15091 to godot-cpp.

Fixes #775