### PR TITLE
Fix crash when using static methods without return value due to uninitialized GDNativePropertyInfo struct members

### DIFF
--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -600,7 +600,11 @@ protected:
 
 	virtual GDNativePropertyInfo gen_argument_type_info(int p_arg) const {
 		GDNativePropertyInfo pi;
-		call_get_argument_type_info<P...>(p_arg, pi);
+		if (p_arg >= 0 && p_arg < (int)sizeof...(P)) {
+			call_get_argument_type_info<P...>(p_arg, pi);
+		} else {
+			pi = PropertyInfo();
+		}
 		return pi;
 	}
 #if defined(__GNUC__) && !defined(__clang__)


### PR DESCRIPTION

When `get_argument_info_func` is called in [godot/core/extension/native_extension.cpp](https://github.com/godotengine/godot/blob/f41cb30f9b7fe46a014162aba9c0e9a9697343d2/core/extension/native_extension.cpp#L55-L66) with `p_arg == -1`, which is the index of the argument to get the type info for, in this case the return value, the ``GDNativePropertyInfo`` struct variable ``pinfo`` will never be filled with the type info and the struct members will stay uninitialized. This happens here:

https://github.com/godotengine/godot-cpp/blob/eaaf941c10fca3ef8e69574a9c256369b31f5b92/include/godot_cpp/core/method_bind.hpp#L601-L605

Sometimes the editor still runs, but looking at the documentation of an example class, the static method without return value shows a missing return type, which should be `void`:

<img src="https://user-images.githubusercontent.com/26153311/174152251-35957d05-ffb1-4cc4-b64b-8b556b945968.png " width="50%">

and an error will show up in the output console:
```
Unicode parsing error: Invalid unicode codepoint ffffff89.
ERROR: U_ILLEGAL_ARGUMENT_ERROR
   at: ScriptIterator (modules/text_server_adv/script_iterator.cpp:71)
```

The fix mirrors the way it is handled for [no return, not const methods](https://github.com/godotengine/godot-cpp/blob/eaaf941c10fca3ef8e69574a9c256369b31f5b92/include/godot_cpp/core/method_bind.hpp#L285-L293) by initializing `p_info` with default values.

This prevents a ``EXC_BAD_ACCESS`` exception when ``String::operator=`` is called [here](https://github.com/godotengine/godot/blob/f41cb30f9b7fe46a014162aba9c0e9a9697343d2/core/extension/native_extension.cpp#L60) for example. [String::copy_from](https://github.com/godotengine/godot/blob/e79cb76146d7a5212454b6ada8bd01357cbdacd6/core/string/ustring.cpp#L307-L314) will not return early and crash at ``strlen``.

The PR should fix https://github.com/godotengine/godot/issues/61963 and https://github.com/godotengine/godot-cpp/issues/768.