### PR TITLE
Adding SCons Version requirement.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -6,6 +6,8 @@ import sys
 import subprocess
 from binding_generator import scons_generate_bindings, scons_emit_files
 
+EnsureSConsVersion(4, 3)
+
 
 def add_sources(sources, dir, extension):
     for f in os.listdir(dir):


### PR DESCRIPTION
The build breaks with SCons 4.1 but works with SCons 4.3 (#779)
Adding this to notify the fix to used.