### PR TITLE
[SCons] Fix msvc, linux-clang, add version check.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install scons
         run: |
-          python -m pip install scons
+          python -m pip install scons==4.0.0
 
       - name: Setup MinGW for Windows/MinGW build
         if: ${{ matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes' }}

--- a/SConstruct
+++ b/SConstruct
@@ -6,6 +6,8 @@ import sys
 import subprocess
 from binding_generator import scons_generate_bindings, scons_emit_files
 
+EnsureSConsVersion(4, 0)
+
 
 def add_sources(sources, dir, extension):
     for f in os.listdir(dir):

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -1,4 +1,5 @@
 from SCons.Variables import *
+from SCons.Tool import clang, clangxx
 
 
 def options(opts):
@@ -11,8 +12,8 @@ def exists(env):
 
 def generate(env):
     if env["use_llvm"]:
-        base = env.Tool("clang")
-        base.generate(env)
+        clang.generate(env)
+        clangxx.generate(env)
 
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -1,7 +1,8 @@
 import sys
 
 import my_spawn
-from SCons.Tool.MSCommon import msvc_exists
+
+from SCons.Tool import msvc, mingw
 from SCons.Variables import *
 
 
@@ -15,14 +16,13 @@ def exists(env):
 
 def generate(env):
     base = None
-    if not env["use_mingw"] and msvc_exists(env):
-        base = env.Tool("msvc")
-        env["is_msvc"] = True
+    if not env["use_mingw"] and msvc.exists(env):
         if env["arch"] == "x86_64":
             env["TARGET_ARCH"] = "amd64"
         elif env["arch"] == "x86_32":
             env["TARGET_ARCH"] = "x86"
-        base.generate(env)
+        env["is_msvc"] = True
+        msvc.generate(env)
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND"])
         env.Append(LINKFLAGS=["/WX"])
         if env["target"] == "debug":
@@ -32,8 +32,7 @@ def generate(env):
 
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True
-        base = env.Tool("mingw")
-        base.generate(env)
+        mingw.generate(env)
         # Still need to use C++17.
         env.Append(CCFLAGS=["-std=c++17"])
         # Don't want lib prefixes


### PR DESCRIPTION
Fixes #779.
Closes #780.

Minimum SCons version is set to 4.0 .