### PR TITLE
Add clang-cl support

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -8,6 +8,7 @@ from SCons.Variables import *
 
 def options(opts):
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
+    opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
 
 
 def exists(env):
@@ -29,6 +30,9 @@ def generate(env):
             env.Append(CCFLAGS=["/Z7", "/Od", "/EHsc", "/D_DEBUG", "/MDd"])
         elif env["target"] == "release":
             env.Append(CCFLAGS=["/O2", "/EHsc", "/DNDEBUG", "/MD"])
+        if env["use_clang_cl"]:
+            env["CC"] = "clang-cl"
+            env["CXX"] = "clang-cl"
 
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True


### PR DESCRIPTION
Visual C++ has a clang-based driver, available through the
clang-cl wrapper (which provides the same interface as
cl) - this generates objects binary-compatible with the
default (traditional) driver, and can then be linked in
the normal way. As such, this patch simply configures for
MSVCC and then overwrites the cl compiler with clang-cl
in the environment.

Clang gives (subjectively) much more understandable compiler warnings
and errors than MSVCC, which was my motivation for switching.

Test-Information:
Builds for me with VS2022, and my gdextension library
builds and links.