### PR TITLE
SCons: Default `num_jobs` to max CPUs minus 1 if not specified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,17 @@ jobs:
 
       - name: Build godot-cpp (debug)
         run: |
-          scons platform=${{ matrix.platform }} target=debug generate_bindings=yes ${{ matrix.flags }} -j2
+          scons platform=${{ matrix.platform }} target=debug generate_bindings=yes ${{ matrix.flags }}
 
       - name: Build test without rebuilding godot-cpp (debug)
         run: |
           cd test
-          scons platform=${{ matrix.platform }} target=debug ${{ matrix.flags }} build_library=no -j2
+          scons platform=${{ matrix.platform }} target=debug ${{ matrix.flags }} build_library=no
 
       - name: Build test and godot-cpp (release)
         run: |
           cd test
-          scons platform=${{ matrix.platform }} target=release ${{ matrix.flags }} -j2
+          scons platform=${{ matrix.platform }} target=release ${{ matrix.flags }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,24 @@ else:
 
 env = Environment(tools=["default"])
 
+# Default num_jobs to local cpu count if not user specified.
+# SCons has a peculiarity where user-specified options won't be overridden
+# by SetOption, so we can rely on this to know if we should use our default.
+initial_num_jobs = env.GetOption("num_jobs")
+altered_num_jobs = initial_num_jobs + 1
+env.SetOption("num_jobs", altered_num_jobs)
+if env.GetOption("num_jobs") == altered_num_jobs:
+    cpu_count = os.cpu_count()
+    if cpu_count is None:
+        print("Couldn't auto-detect CPU count to configure build parallelism. Specify it with the -j argument.")
+    else:
+        safer_cpu_count = cpu_count if cpu_count <= 4 else cpu_count - 1
+        print(
+            "Auto-detected %d CPU cores available for build parallelism. Using %d cores by default. You can override it with the -j argument."
+            % (cpu_count, safer_cpu_count)
+        )
+        env.SetOption("num_jobs", safer_cpu_count)
+
 platforms = ("linux", "osx", "windows", "android", "ios", "javascript")
 opts = Variables([], ARGUMENTS)
 opts.Add(


### PR DESCRIPTION
This doesn't change the behavior when `--jobs`/`-j` is specified as a
command-line argument or in `SCONSFLAGS`.

The SCons hack used to know if `num_jobs` was set by the user is derived
from the MongoDB setup.

We use `os.cpu_count()` for portability (available since Python 3.4).

With 4 CPUs or less, we use the max. With more than 4 we use max - 1 to
preserve some bandwidth for the user's other programs.

Equivalent to upstream Godot https://github.com/godotengine/godot/pull/63087.

Should speed up macOS builds by using 3 cores by default (and dehardcodes `-j4` in the Makefile).