### PR TITLE
Object::cast_to checks provided object for nullptr

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -169,6 +169,9 @@ public:
 
 template <class T>
 T *Object::cast_to(Object *p_object) {
+	if (p_object == nullptr) {
+		return nullptr;
+	}
 	GDNativeObjectPtr casted = internal::gdn_interface->object_cast_to(p_object->_owner, internal::gdn_interface->classdb_get_class_tag(T::get_class_static()));
 	if (casted == nullptr) {
 		return nullptr;


### PR DESCRIPTION
As ``Objec::cast_to`` is merely a dynamic_cast, it shouldn't fail on ``nullptr``. As the provided argument gets dereferenced right away, we have to make the initial check. As I'm fairly new to the godot scene, I do not have much insights into the code base. Perhaps there is a more elegant solution to the problem, but I won't find it right now.

Nevertheless, this fix also fixes calls to ``Node::get_node<T>`` when no ``Node`` with the given name can be found (and probably even more other parts).