### PR TITLE
Add debug information to Windows builds

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -28,6 +28,7 @@ def generate(env):
         env.Append(LINKFLAGS=["/WX"])
         if env["target"] == "debug":
             env.Append(CCFLAGS=["/Z7", "/Od", "/EHsc", "/D_DEBUG", "/MDd"])
+            env.Append(LINKFLAGS=["/DEBUG:FULL"])
         elif env["target"] == "release":
             env.Append(CCFLAGS=["/O2", "/EHsc", "/DNDEBUG", "/MD"])
         if env["use_clang_cl"]:


### PR DESCRIPTION
Previously, Windows builds were being produced without debug
information, leading to somewhat unhelpful backtraces etc.
without symbols.

This builds the symbols in (only for debug builds - I've
deliberately not touched release builds here) so gdextension
bugs are a little more tractable.

Test-Information:
Have been running this patch for weeks, and getting useful
traces out on the commandline, and useful debugging from
debuggers.