### PR TITLE
Fix "_instance_bindings != nullptr" for Wrapped objects.

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -165,9 +165,12 @@ public:                                                                         
 	}                                                                                                              \
                                                                                                                    \
 	static void *___binding_create_callback(void *p_token, void *p_instance) {                                     \
-		return memnew(m_class((GodotObject *)p_instance));                                                         \
+		/* Do not call memnew here, we don't want the postinitializer to be called */                              \
+		return new ("") m_class((GodotObject *)p_instance);                                                        \
 	}                                                                                                              \
 	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                       \
+		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                 \
+		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                        \
 		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                               \
 	}                                                                                                              \
 	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) { \


### PR DESCRIPTION
This is an attempt to make the lifecycle of wrapped objects clearer.

Godot keeps track of bindings' userdata for each object it creates.

This allows allocating the memory of the wrapper only once per object even if that object is passed multiple times between binding code and godot code.

The binding information is composed of multiple functions, this includes a callback for when the userdata is to be allocated (called once) and for when the userdata is to be deallocated (again, called once).

When allocating data with "memnew" we set the object bindings during the postinitialize phase, but surely we shouldn't do that when allocating the userdata as a result of bindings callback themselves.

Additionally, since we let Godot handle (and track) raw memory allocation and de-allocation, we need to manually call the deconstructor of the wrapper class during the free callback, to ensure that its non-trivial members are correctly de-initialized.

Fixes #679