### PR TITLE
Allow GDCLASS in own namespaces

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -67,7 +67,7 @@ public:
 #define GDCLASS(m_class, m_inherits)                                                                               \
 private:                                                                                                           \
 	void operator=(const m_class &p_rval) {}                                                                       \
-	friend class ClassDB;                                                                                          \
+	friend class ::godot::ClassDB;                                                                                 \
                                                                                                                    \
 protected:                                                                                                         \
 	virtual const char *_get_extension_class() const override {                                                    \


### PR DESCRIPTION
The unqualified ClassDB friending was causing (at least for me on
VS2022) an implicit forward declaration of ClassDB in the namespace
of my class, instead of using the godot namespaced one. By qualifying
the namespace, this compiles for me.

Test-Information:
My project builds now.