### PR TITLE
Add support for `_notification` method.

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -164,7 +164,7 @@ void ClassDB::register_class() {
 		nullptr, // GDNativeExtensionClassFreePropertyList free_property_list_func;
 		nullptr, // GDNativeExtensionClassPropertyCanRevert property_can_revert_func;
 		nullptr, // GDNativeExtensionClassPropertyGetRevert property_get_revert_func;
-		nullptr, // GDNativeExtensionClassNotification notification_func;
+		T::notification_bind, // GDNativeExtensionClassNotification notification_func;
 		nullptr, // GDNativeExtensionClassToString to_string_func;
 		nullptr, // GDNativeExtensionClassReference reference_func;
 		nullptr, // GDNativeExtensionClassUnreference unreference_func;

--- a/test/demo/main.tscn
+++ b/test/demo/main.tscn
@@ -7,6 +7,8 @@ script = ExtResource( "1_c326s" )
 
 [node name="Example" type="Example" parent="."]
 
+[node name="ExampleMin" type="ExampleMin" parent="Example"]
+
 [node name="Label" type="Label" parent="Example"]
 offset_left = 194.0
 offset_top = -2.0

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -58,6 +58,10 @@ int Example::def_args(int p_a, int p_b) {
 	return p_a + p_b;
 }
 
+void Example::_notification(int p_what) {
+	UtilityFunctions::print("Notification: ", String::num(p_what));
+}
+
 void Example::_bind_methods() {
 	// Methods.
 	ClassDB::bind_method(D_METHOD("simple_func"), &Example::simple_func);

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -56,11 +56,20 @@ public:
 	~ExampleRef();
 };
 
+class ExampleMin : public Control {
+	GDCLASS(ExampleMin, Control);
+
+protected:
+	static void _bind_methods(){};
+};
+
 class Example : public Control {
 	GDCLASS(Example, Control);
 
 protected:
 	static void _bind_methods();
+
+	void _notification(int p_what);
 
 private:
 	Vector2 custom_position;


### PR DESCRIPTION
Adds support for implementing `_notification` method in the GDExtension classes, adds `_notification` to the demo project (as well as minimal class example to ensure `_notification` is optional).

*Note: the same should be done for dynamic property methods (`_set`, `_get`, `_get_property_list`) which are also missing. I'll do a separate PR later.*