### PR TITLE
Add explicit namespaces to the GDCLASS*, ERR_*, and WARN_* macros.

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -117,32 +117,32 @@ protected:                                                                      
 		return &m_class::_bind_methods;                                                                                                                  \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static void (Wrapped::*_get_notification())(int) {                                                                                                   \
-		return (void(Wrapped::*)(int)) & m_class::_notification;                                                                                         \
+	static void (::godot::Wrapped::*_get_notification())(int) {                                                                                          \
+		return (void(::godot::Wrapped::*)(int)) & m_class::_notification;                                                                                \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static bool (Wrapped::*_get_set())(const StringName &p_name, const Variant &p_property) {                                                            \
-		return (bool(Wrapped::*)(const StringName &p_name, const Variant &p_property)) & m_class::_set;                                                  \
+	static bool (::godot::Wrapped::*_get_set())(const ::godot::StringName &p_name, const ::godot::Variant &p_property) {                                 \
+		return (bool(::godot::Wrapped::*)(const ::godot::StringName &p_name, const ::godot::Variant &p_property)) & m_class::_set;                       \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static bool (Wrapped::*_get_get())(const StringName &p_name, Variant &r_ret) {                                                                       \
-		return (bool(Wrapped::*)(const StringName &p_name, Variant &r_ret)) & m_class::_set;                                                             \
+	static bool (::godot::Wrapped::*_get_get())(const ::godot::StringName &p_name, ::godot::Variant &r_ret) {                                            \
+		return (bool(::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &r_ret)) & m_class::_set;                                  \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) {                                                                      \
-		return (void(Wrapped::*)(List<PropertyInfo> * p_list)) & m_class::_get_property_list;                                                            \
+	static void (::godot::Wrapped::*_get_get_property_list())(::godot::List<::godot::PropertyInfo> * p_list) {                                           \
+		return (void(::godot::Wrapped::*)(::godot::List<::godot::PropertyInfo> * p_list)) & m_class::_get_property_list;                                 \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static bool (Wrapped::*_get_property_can_revert())(const StringName &p_name) {                                                                       \
-		return (bool(Wrapped::*)(const StringName &p_name)) & m_class::_property_can_revert;                                                             \
+	static bool (::godot::Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) {                                                     \
+		return (bool(::godot::Wrapped::*)(const ::godot::StringName &p_name)) & m_class::_property_can_revert;                                           \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static bool (Wrapped::*_get_property_get_revert())(const StringName &p_name, Variant &) {                                                            \
-		return (bool(Wrapped::*)(const StringName &p_name, Variant &)) & m_class::_property_get_revert;                                                  \
+	static bool (::godot::Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, ::godot::Variant &) {                                 \
+		return (bool(::godot::Wrapped::*)(const ::godot::StringName &p_name, ::godot::Variant &)) & m_class::_property_get_revert;                       \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static String (Wrapped::*_get_to_string())() {                                                                                                       \
-		return (String(Wrapped::*)()) & m_class::_to_string;                                                                                             \
+	static ::godot::String (::godot::Wrapped::*_get_to_string())() {                                                                                     \
+		return (::godot::String(::godot::Wrapped::*)()) & m_class::_to_string;                                                                           \
 	}                                                                                                                                                    \
                                                                                                                                                          \
 	template <class T>                                                                                                                                   \
@@ -191,7 +191,7 @@ public:                                                                         
 		if (p_instance && m_class::_get_set()) {                                                                                                         \
 			if (m_class::_get_set() != m_inherits::_get_set()) {                                                                                         \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				return cls->_set(*reinterpret_cast<const StringName *>(p_name), *reinterpret_cast<const Variant *>(p_value));                            \
+				return cls->_set(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<const ::godot::Variant *>(p_value));          \
 			}                                                                                                                                            \
 			return m_inherits::set_bind(p_instance, p_name, p_value);                                                                                    \
 		}                                                                                                                                                \
@@ -202,7 +202,7 @@ public:                                                                         
 		if (p_instance && m_class::_get_get()) {                                                                                                         \
 			if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                         \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				return cls->_get(*reinterpret_cast<const StringName *>(p_name), *reinterpret_cast<Variant *>(r_ret));                                    \
+				return cls->_get(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret));                  \
 			}                                                                                                                                            \
 			return m_inherits::get_bind(p_instance, p_name, r_ret);                                                                                      \
 		}                                                                                                                                                \
@@ -213,12 +213,12 @@ public:                                                                         
 		if (p_instance && m_class::_get_get_property_list()) {                                                                                           \
 			if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                             \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				List<PropertyInfo> list;                                                                                                                 \
+				::godot::List<::godot::PropertyInfo> list;                                                                                               \
 				cls->_get_property_list(&list);                                                                                                          \
 				ERR_FAIL_COND_V_MSG(cls->plist != nullptr || cls->plist_size != 0, nullptr, "Internal error, property list was not freed by engine!");   \
-				cls->plist = reinterpret_cast<GDNativePropertyInfo *>(memalloc(sizeof(GDNativePropertyInfo) * list.size()));                             \
+				cls->plist = reinterpret_cast<GDNativePropertyInfo *>(::godot::memalloc(sizeof(GDNativePropertyInfo) * list.size()));                    \
 				cls->plist_size = 0;                                                                                                                     \
-				for (const PropertyInfo &E : list) {                                                                                                     \
+				for (const ::godot::PropertyInfo &E : list) {                                                                                            \
 					cls->plist[cls->plist_size].type = E.type;                                                                                           \
 					cls->plist[cls->plist_size].name = _alloc_and_copy_cstr(E.name);                                                                     \
 					cls->plist[cls->plist_size].hint = E.hint;                                                                                           \
@@ -241,11 +241,11 @@ public:                                                                         
 			m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                      \
 			ERR_FAIL_COND_MSG(cls->plist == nullptr, "Internal error, property list double free!");                                                      \
 			for (size_t i = 0; i < cls->plist_size; i++) {                                                                                               \
-				memfree(const_cast<char *>(cls->plist[i].name));                                                                                         \
-				memfree(const_cast<char *>(cls->plist[i].class_name));                                                                                   \
-				memfree(const_cast<char *>(cls->plist[i].hint_string));                                                                                  \
+				::godot::memfree(const_cast<char *>(cls->plist[i].name));                                                                                \
+				::godot::memfree(const_cast<char *>(cls->plist[i].class_name));                                                                          \
+				::godot::memfree(const_cast<char *>(cls->plist[i].hint_string));                                                                         \
 			}                                                                                                                                            \
-			memfree(cls->plist);                                                                                                                         \
+			::godot::memfree(cls->plist);                                                                                                                \
 			cls->plist = nullptr;                                                                                                                        \
 			cls->plist_size = 0;                                                                                                                         \
 		}                                                                                                                                                \
@@ -255,7 +255,7 @@ public:                                                                         
 		if (p_instance && m_class::_get_property_can_revert()) {                                                                                         \
 			if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                                                         \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				return cls->_property_can_revert(*reinterpret_cast<const StringName *>(p_name));                                                         \
+				return cls->_property_can_revert(*reinterpret_cast<const ::godot::StringName *>(p_name));                                                \
 			}                                                                                                                                            \
 			return m_inherits::property_can_revert_bind(p_instance, p_name);                                                                             \
 		}                                                                                                                                                \
@@ -266,7 +266,7 @@ public:                                                                         
 		if (p_instance && m_class::_get_property_get_revert()) {                                                                                         \
 			if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                                                         \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				return cls->_property_get_revert(*reinterpret_cast<const StringName *>(p_name), *reinterpret_cast<Variant *>(r_ret));                    \
+				return cls->_property_get_revert(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret));  \
 			}                                                                                                                                            \
 			return m_inherits::property_get_revert_bind(p_instance, p_name, r_ret);                                                                      \
 		}                                                                                                                                                \
@@ -277,7 +277,7 @@ public:                                                                         
 		if (p_instance && m_class::_get_to_string()) {                                                                                                   \
 			if (m_class::_get_to_string() != m_inherits::_get_to_string()) {                                                                             \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                  \
-				*reinterpret_cast<String *>(r_out) = cls->_to_string();                                                                                  \
+				*reinterpret_cast<::godot::String *>(r_out) = cls->_to_string();                                                                         \
 				return;                                                                                                                                  \
 			}                                                                                                                                            \
 			m_inherits::to_string_bind(p_instance, r_out);                                                                                               \
@@ -310,78 +310,78 @@ public:                                                                         
 	};
 
 // Don't use this for your classes, use GDCLASS() instead.
-#define GDNATIVE_CLASS(m_class, m_inherits)                                                                        \
-private:                                                                                                           \
-	void operator=(const m_class &p_rval) {}                                                                       \
-                                                                                                                   \
-protected:                                                                                                         \
-	virtual const GDNativeInstanceBindingCallbacks *_get_bindings_callbacks() const override {                     \
-		return &___binding_callbacks;                                                                              \
-	}                                                                                                              \
-                                                                                                                   \
-	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                              \
-	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                           \
-                                                                                                                   \
-	static void (*_get_bind_methods())() {                                                                         \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static void (Wrapped::*_get_notification())(int) {                                                             \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static bool (Wrapped::*_get_set())(const StringName &p_name, const Variant &p_property) {                      \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static bool (Wrapped::*_get_get())(const StringName &p_name, Variant &r_ret) {                                 \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) {                                \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static bool (Wrapped::*_get_property_can_revert())(const StringName &p_name) {                                 \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static bool (Wrapped::*_get_property_get_revert())(const StringName &p_name, Variant &) {                      \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-	static String (Wrapped::*_get_to_string())() {                                                                 \
-		return nullptr;                                                                                            \
-	}                                                                                                              \
-                                                                                                                   \
-public:                                                                                                            \
-	static void initialize_class() {}                                                                              \
-                                                                                                                   \
-	static const char *get_class_static() {                                                                        \
-		return #m_class;                                                                                           \
-	}                                                                                                              \
-                                                                                                                   \
-	static const char *get_parent_class_static() {                                                                 \
-		return m_inherits::get_class_static();                                                                     \
-	}                                                                                                              \
-                                                                                                                   \
-	static void *___binding_create_callback(void *p_token, void *p_instance) {                                     \
-		/* Do not call memnew here, we don't want the postinitializer to be called */                              \
-		return new ("") m_class((GodotObject *)p_instance);                                                        \
-	}                                                                                                              \
-	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                       \
-		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                 \
-		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                        \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                               \
-	}                                                                                                              \
-	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) { \
-		return true;                                                                                               \
-	}                                                                                                              \
-	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                     \
-		___binding_create_callback,                                                                                \
-		___binding_free_callback,                                                                                  \
-		___binding_reference_callback,                                                                             \
-	};                                                                                                             \
+#define GDNATIVE_CLASS(m_class, m_inherits)                                                                              \
+private:                                                                                                                 \
+	void operator=(const m_class &p_rval) {}                                                                             \
+                                                                                                                         \
+protected:                                                                                                               \
+	virtual const GDNativeInstanceBindingCallbacks *_get_bindings_callbacks() const override {                           \
+		return &___binding_callbacks;                                                                                    \
+	}                                                                                                                    \
+                                                                                                                         \
+	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                    \
+	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                 \
+                                                                                                                         \
+	static void (*_get_bind_methods())() {                                                                               \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static void (::godot::Wrapped::*_get_notification())(int) {                                                          \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static bool (::godot::Wrapped::*_get_set())(const ::godot::StringName &p_name, const ::godot::Variant &p_property) { \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static bool (::godot::Wrapped::*_get_get())(const ::godot::StringName &p_name, ::godot::Variant &r_ret) {            \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static void (::godot::Wrapped::*_get_get_property_list())(::godot::List<::godot::PropertyInfo> * p_list) {           \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static bool (::godot::Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) {                     \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static bool (::godot::Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) {          \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+	static ::godot::String (::godot::Wrapped::*_get_to_string())() {                                                     \
+		return nullptr;                                                                                                  \
+	}                                                                                                                    \
+                                                                                                                         \
+public:                                                                                                                  \
+	static void initialize_class() {}                                                                                    \
+                                                                                                                         \
+	static const char *get_class_static() {                                                                              \
+		return #m_class;                                                                                                 \
+	}                                                                                                                    \
+                                                                                                                         \
+	static const char *get_parent_class_static() {                                                                       \
+		return m_inherits::get_class_static();                                                                           \
+	}                                                                                                                    \
+                                                                                                                         \
+	static void *___binding_create_callback(void *p_token, void *p_instance) {                                           \
+		/* Do not call memnew here, we don't want the postinitializer to be called */                                    \
+		return new ("") m_class((GodotObject *)p_instance);                                                              \
+	}                                                                                                                    \
+	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                             \
+		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                       \
+		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                              \
+		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                     \
+	}                                                                                                                    \
+	static GDNativeBool ___binding_reference_callback(void *p_token, void *p_instance, GDNativeBool p_reference) {       \
+		return true;                                                                                                     \
+	}                                                                                                                    \
+	static constexpr GDNativeInstanceBindingCallbacks ___binding_callbacks = {                                           \
+		___binding_create_callback,                                                                                      \
+		___binding_free_callback,                                                                                        \
+		___binding_reference_callback,                                                                                   \
+	};                                                                                                                   \
 	m_class() : m_class(#m_class) {}
 
 #endif // ! GODOT_CPP_WRAPPED_HPP

--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -47,6 +47,8 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
 
+} // namespace godot
+
 // Used to strip debug messages in release mode
 #ifdef DEBUG_ENABLED
 #define DEBUG_STR(m_msg) m_msg
@@ -73,22 +75,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define GENERATE_TRAP() __builtin_trap()
 #endif
 
-#define ERR_FAIL_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX(m_index, m_size)                                                                                  \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                              \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return;                                                                                                          \
+	} else                                                                                                               \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg)                                                                                         \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                                \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return;                                                                                                                            \
+	} else                                                                                                                                 \
 		((void)0)
 
 /**
@@ -98,22 +100,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                                      \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                              \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                 \
+	} else                                                                                                               \
 		((void)0)
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                    \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                       \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                             \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                                \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                   \
+	} else                                                                                                                                 \
 		((void)0)
 
 /**
@@ -124,11 +126,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, the application crashes.
  */
-#define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-		GENERATE_TRAP();                                                                                                  \
-	} else                                                                                                                \
+#define CRASH_BAD_INDEX(m_index, m_size)                                                                                           \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                        \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP();                                                                                                           \
+	} else                                                                                                                         \
 		((void)0)
 
 /**
@@ -138,11 +140,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                     \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                             \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                                              \
+	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                                      \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+		GENERATE_TRAP();                                                                                                                         \
+	} else                                                                                                                                       \
 		((void)0)
 
 // Unsigned integer index out of bounds error macros.
@@ -154,22 +156,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return;                                                                                                 \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size)                                                                         \
+	if (unlikely((m_index) >= (m_size))) {                                                                               \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return;                                                                                                          \
+	} else                                                                                                               \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                       \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return;                                                                                                                   \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                 \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return;                                                                                                                            \
+	} else                                                                                                                                 \
 		((void)0)
 
 /**
@@ -179,22 +181,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
-	if (unlikely((m_index) >= (m_size))) {                                                                      \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval;                                                                                        \
-	} else                                                                                                      \
+#define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                             \
+	if (unlikely((m_index) >= (m_size))) {                                                                               \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		return m_retval;                                                                                                 \
+	} else                                                                                                               \
 		((void)0)
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                           \
-	if (unlikely((m_index) >= (m_size))) {                                                                                        \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                                    \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                 \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                   \
+	} else                                                                                                                                 \
 		((void)0)
 
 /**
@@ -205,11 +207,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                         \
-	if (unlikely((m_index) >= (m_size))) {                                                                                \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
-		GENERATE_TRAP();                                                                                                  \
-	} else                                                                                                                \
+#define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                                  \
+	if (unlikely((m_index) >= (m_size))) {                                                                                         \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		GENERATE_TRAP();                                                                                                           \
+	} else                                                                                                                         \
 		((void)0)
 
 /**
@@ -219,11 +221,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the application crashes.
  */
-#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                            \
-	if (unlikely((m_index) >= (m_size))) {                                                                                              \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
-		GENERATE_TRAP();                                                                                                                \
-	} else                                                                                                                              \
+#define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg)                                                                                     \
+	if (unlikely((m_index) >= (m_size))) {                                                                                                       \
+		::godot::_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), DEBUG_STR(m_msg), true); \
+		GENERATE_TRAP();                                                                                                                         \
+	} else                                                                                                                                       \
 		((void)0)
 
 // Null reference error macros.
@@ -235,22 +237,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns.
  */
-#define ERR_FAIL_NULL(m_param)                                                                          \
-	if (unlikely(m_param == nullptr)) {                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return;                                                                                         \
-	} else                                                                                              \
+#define ERR_FAIL_NULL(m_param)                                                                                   \
+	if (unlikely(m_param == nullptr)) {                                                                          \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+		return;                                                                                                  \
+	} else                                                                                                       \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
-#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                 \
-	if (unlikely(m_param == nullptr)) {                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-		return;                                                                                                           \
-	} else                                                                                                                \
+#define ERR_FAIL_NULL_MSG(m_param, m_msg)                                                                                          \
+	if (unlikely(m_param == nullptr)) {                                                                                            \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
+		return;                                                                                                                    \
+	} else                                                                                                                         \
 		((void)0)
 
 /**
@@ -260,22 +262,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures a pointer `m_param` is not null.
  * If it is null, the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
-	if (unlikely(m_param == nullptr)) {                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return m_retval;                                                                                \
-	} else                                                                                              \
+#define ERR_FAIL_NULL_V(m_param, m_retval)                                                                       \
+	if (unlikely(m_param == nullptr)) {                                                                          \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+		return m_retval;                                                                                         \
+	} else                                                                                                       \
 		((void)0)
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
-#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                     \
-	if (unlikely(m_param == nullptr)) {                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                  \
-	} else                                                                                                                \
+#define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                                              \
+	if (unlikely(m_param == nullptr)) {                                                                                            \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                           \
+	} else                                                                                                                         \
 		((void)0)
 
 /**
@@ -287,11 +289,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns.
  */
-#define ERR_FAIL_COND(m_cond)                                                                          \
-	if (unlikely(m_cond)) {                                                                            \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
-		return;                                                                                        \
-	} else                                                                                             \
+#define ERR_FAIL_COND(m_cond)                                                                                   \
+	if (unlikely(m_cond)) {                                                                                     \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
+		return;                                                                                                 \
+	} else                                                                                                      \
 		((void)0)
 
 /**
@@ -301,11 +303,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If checking for null use ERR_FAIL_NULL_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
-#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                 \
-	if (unlikely(m_cond)) {                                                                                              \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-		return;                                                                                                          \
-	} else                                                                                                               \
+#define ERR_FAIL_COND_MSG(m_cond, m_msg)                                                                                          \
+	if (unlikely(m_cond)) {                                                                                                       \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
+		return;                                                                                                                   \
+	} else                                                                                                                        \
 		((void)0)
 
 /**
@@ -317,11 +319,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current function returns `m_retval`.
  */
-#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                         \
-	if (unlikely(m_cond)) {                                                                                                       \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                                          \
-	} else                                                                                                                        \
+#define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                                  \
+	if (unlikely(m_cond)) {                                                                                                                \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
+		return m_retval;                                                                                                                   \
+	} else                                                                                                                                 \
 		((void)0)
 
 /**
@@ -331,11 +333,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If checking for null use ERR_FAIL_NULL_V_MSG instead.
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
-#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                \
-	if (unlikely(m_cond)) {                                                                                                                         \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                                            \
-	} else                                                                                                                                          \
+#define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                                         \
+	if (unlikely(m_cond)) {                                                                                                                                  \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                                     \
+	} else                                                                                                                                                   \
 		((void)0)
 
 /**
@@ -345,22 +347,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop continues.
  */
-#define ERR_CONTINUE(m_cond)                                                                                       \
-	if (unlikely(m_cond)) {                                                                                        \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-		continue;                                                                                                  \
-	} else                                                                                                         \
+#define ERR_CONTINUE(m_cond)                                                                                                \
+	if (unlikely(m_cond)) {                                                                                                 \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
+		continue;                                                                                                           \
+	} else                                                                                                                  \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
-#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                              \
-	if (unlikely(m_cond)) {                                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
-		continue;                                                                                                                    \
-	} else                                                                                                                           \
+#define ERR_CONTINUE_MSG(m_cond, m_msg)                                                                                                       \
+	if (unlikely(m_cond)) {                                                                                                                   \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", DEBUG_STR(m_msg)); \
+		continue;                                                                                                                             \
+	} else                                                                                                                                    \
 		((void)0)
 
 /**
@@ -370,22 +372,22 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the current loop breaks.
  */
-#define ERR_BREAK(m_cond)                                                                                        \
-	if (unlikely(m_cond)) {                                                                                      \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-		break;                                                                                                   \
-	} else                                                                                                       \
+#define ERR_BREAK(m_cond)                                                                                                 \
+	if (unlikely(m_cond)) {                                                                                               \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
+		break;                                                                                                            \
+	} else                                                                                                                \
 		((void)0)
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
-#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                               \
-	if (unlikely(m_cond)) {                                                                                                        \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
-		break;                                                                                                                     \
-	} else                                                                                                                         \
+#define ERR_BREAK_MSG(m_cond, m_msg)                                                                                                        \
+	if (unlikely(m_cond)) {                                                                                                                 \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", DEBUG_STR(m_msg)); \
+		break;                                                                                                                              \
+	} else                                                                                                                                  \
 		((void)0)
 
 /**
@@ -396,11 +398,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, the application crashes.
  */
-#define CRASH_COND(m_cond)                                                                                    \
-	if (unlikely(m_cond)) {                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-		GENERATE_TRAP();                                                                                      \
-	} else                                                                                                    \
+#define CRASH_COND(m_cond)                                                                                             \
+	if (unlikely(m_cond)) {                                                                                            \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
+		GENERATE_TRAP();                                                                                               \
+	} else                                                                                                             \
 		((void)0)
 
 /**
@@ -410,11 +412,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
-#define CRASH_COND_MSG(m_cond, m_msg)                                                                                           \
-	if (unlikely(m_cond)) {                                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
-		GENERATE_TRAP();                                                                                                        \
-	} else                                                                                                                      \
+#define CRASH_COND_MSG(m_cond, m_msg)                                                                                                    \
+	if (unlikely(m_cond)) {                                                                                                              \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", DEBUG_STR(m_msg)); \
+		GENERATE_TRAP();                                                                                                                 \
+	} else                                                                                                                               \
 		((void)0)
 
 // Generic error macros.
@@ -426,11 +428,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * The current function returns.
  */
-#define ERR_FAIL()                                                                     \
-	if (true) {                                                                        \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
-		return;                                                                        \
-	} else                                                                             \
+#define ERR_FAIL()                                                                              \
+	if (true) {                                                                                 \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
+		return;                                                                                 \
+	} else                                                                                      \
 		((void)0)
 
 /**
@@ -439,11 +441,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and the current function returns.
  */
-#define ERR_FAIL_MSG(m_msg)                                                                              \
-	if (true) {                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", DEBUG_STR(m_msg)); \
-		return;                                                                                          \
-	} else                                                                                               \
+#define ERR_FAIL_MSG(m_msg)                                                                                       \
+	if (true) {                                                                                                   \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", DEBUG_STR(m_msg)); \
+		return;                                                                                                   \
+	} else                                                                                                        \
 		((void)0)
 
 /**
@@ -453,11 +455,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * The current function returns `m_retval`.
  */
-#define ERR_FAIL_V(m_retval)                                                                                      \
-	if (true) {                                                                                                   \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
-		return m_retval;                                                                                          \
-	} else                                                                                                        \
+#define ERR_FAIL_V(m_retval)                                                                                               \
+	if (true) {                                                                                                            \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
+		return m_retval;                                                                                                   \
+	} else                                                                                                                 \
 		((void)0)
 
 /**
@@ -466,11 +468,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
-#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                             \
-	if (true) {                                                                                                                     \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
-		return m_retval;                                                                                                            \
-	} else                                                                                                                          \
+#define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                                      \
+	if (true) {                                                                                                                              \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), DEBUG_STR(m_msg)); \
+		return m_retval;                                                                                                                     \
+	} else                                                                                                                                   \
 		((void)0)
 
 /**
@@ -481,19 +483,19 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * Prints `m_msg`.
  */
 #define ERR_PRINT(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg)
+	::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg)
 
 /**
  * Prints `m_msg` once during the application lifetime.
  */
-#define ERR_PRINT_ONCE(m_msg)                                          \
-	if (true) {                                                        \
-		static bool first_print = true;                                \
-		if (first_print) {                                             \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
-			first_print = false;                                       \
-		}                                                              \
-	} else                                                             \
+#define ERR_PRINT_ONCE(m_msg)                                                   \
+	if (true) {                                                                 \
+		static bool first_print = true;                                         \
+		if (first_print) {                                                      \
+			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
+			first_print = false;                                                \
+		}                                                                       \
+	} else                                                                      \
 		((void)0)
 
 // Print warning message macros.
@@ -504,21 +506,21 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
 #define WARN_PRINT(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true)
+	::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true)
 
 /**
  * Prints `m_msg` once during the application lifetime.
  *
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
-#define WARN_PRINT_ONCE(m_msg)                                               \
-	if (true) {                                                              \
-		static bool first_print = true;                                      \
-		if (first_print) {                                                   \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
-			first_print = false;                                             \
-		}                                                                    \
-	} else                                                                   \
+#define WARN_PRINT_ONCE(m_msg)                                                        \
+	if (true) {                                                                       \
+		static bool first_print = true;                                               \
+		if (first_print) {                                                            \
+			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
+			first_print = false;                                                      \
+		}                                                                             \
+	} else                                                                            \
 		((void)0)
 
 // Print deprecated warning message macros.
@@ -526,27 +528,27 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 /**
  * Warns that the current function is deprecated.
  */
-#define WARN_DEPRECATED                                                                                                                     \
-	if (true) {                                                                                                                             \
-		static SafeFlag warning_shown;                                                                                                      \
-		if (!warning_shown.is_set()) {                                                                                                      \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", true); \
-			warning_shown.set();                                                                                                            \
-		}                                                                                                                                   \
-	} else                                                                                                                                  \
+#define WARN_DEPRECATED                                                                                                                              \
+	if (true) {                                                                                                                                      \
+		static ::godot::SafeFlag warning_shown;                                                                                                      \
+		if (!warning_shown.is_set()) {                                                                                                               \
+			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", true); \
+			warning_shown.set();                                                                                                                     \
+		}                                                                                                                                            \
+	} else                                                                                                                                           \
 		((void)0)
 
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
-#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                            \
-	if (true) {                                                                                                                                               \
-		static SafeFlag warning_shown;                                                                                                                        \
-		if (!warning_shown.is_set()) {                                                                                                                        \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), true); \
-			warning_shown.set();                                                                                                                              \
-		}                                                                                                                                                     \
-	} else                                                                                                                                                    \
+#define WARN_DEPRECATED_MSG(m_msg)                                                                                                                                     \
+	if (true) {                                                                                                                                                        \
+		static ::godot::SafeFlag warning_shown;                                                                                                                        \
+		if (!warning_shown.is_set()) {                                                                                                                                 \
+			::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", DEBUG_STR(m_msg), true); \
+			warning_shown.set();                                                                                                                                       \
+		}                                                                                                                                                              \
+	} else                                                                                                                                                             \
 		((void)0)
 
 /**
@@ -555,11 +557,11 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * The application crashes.
  */
-#define CRASH_NOW()                                                                           \
-	if (true) {                                                                               \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
-		GENERATE_TRAP();                                                                      \
-	} else                                                                                    \
+#define CRASH_NOW()                                                                                    \
+	if (true) {                                                                                        \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
+		GENERATE_TRAP();                                                                               \
+	} else                                                                                             \
 		((void)0)
 
 /**
@@ -567,25 +569,23 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
  *
  * Prints `m_msg`, and then the application crashes.
  */
-#define CRASH_NOW_MSG(m_msg)                                                                                    \
-	if (true) {                                                                                                 \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", DEBUG_STR(m_msg)); \
-		GENERATE_TRAP();                                                                                        \
-	} else                                                                                                      \
+#define CRASH_NOW_MSG(m_msg)                                                                                             \
+	if (true) {                                                                                                          \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", DEBUG_STR(m_msg)); \
+		GENERATE_TRAP();                                                                                                 \
+	} else                                                                                                               \
 		((void)0)
-
-} // namespace godot
 
 /**
  * This should be a 'free' assert for program flow and should not be needed in any releases,
  *  only used in dev builds.
  */
 #ifdef DEBUG_ENABLED
-#define DEV_ASSERT(m_cond)                                                                                              \
-	if (unlikely(!(m_cond))) {                                                                                          \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		GENERATE_TRAP();                                                                                                \
-	} else                                                                                                              \
+#define DEV_ASSERT(m_cond)                                                                                                       \
+	if (unlikely(!(m_cond))) {                                                                                                   \
+		::godot::_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
+		GENERATE_TRAP();                                                                                                         \
+	} else                                                                                                                       \
 		((void)0)
 #else
 #define DEV_ASSERT(m_cond)


### PR DESCRIPTION
Fixes #821 and similar issues with `ERR_` macros.