### PR TITLE
Change PropertyInfo members to String.

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -240,7 +240,7 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(reinterpret_cast<T*>(godot::internal::gdn_interface->object_get_instance_binding(*(const GDNativeObjectPtr *)p_ptr, godot::internal::token, &T::___binding_callbacks)));
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::gdn_interface->object_get_instance_binding(*(const GDNativeObjectPtr *)p_ptr, godot::internal::token, &T::___binding_callbacks)));
 	}
 
 	typedef Ref<T> EncodeT;
@@ -255,7 +255,7 @@ struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(reinterpret_cast<T*>(godot::internal::gdn_interface->object_get_instance_binding(*(const GDNativeObjectPtr *)p_ptr, godot::internal::token, &T::___binding_callbacks)));
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::gdn_interface->object_get_instance_binding(*(const GDNativeObjectPtr *)p_ptr, godot::internal::token, &T::___binding_callbacks)));
 	}
 };
 
@@ -264,8 +264,8 @@ struct GetTypeInfo<Ref<T>, typename EnableIf<TypeInherits<RefCounted, T>::value>
 	static const GDNativeVariantType VARIANT_TYPE = GDNATIVE_VARIANT_TYPE_OBJECT;
 	static const GDNativeExtensionClassMethodArgumentMetadata METADATA = GDNATIVE_EXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(GDNATIVE_VARIANT_TYPE_OBJECT, T::get_class_static());
+	static inline GDNativePropertyInfo get_class_info() {
+		return make_property_info(GDNATIVE_VARIANT_TYPE_OBJECT, T::get_class_static());
 	}
 };
 
@@ -274,8 +274,8 @@ struct GetTypeInfo<const Ref<T> &, typename EnableIf<TypeInherits<RefCounted, T>
 	static const GDNativeVariantType VARIANT_TYPE = GDNATIVE_VARIANT_TYPE_OBJECT;
 	static const GDNativeExtensionClassMethodArgumentMetadata METADATA = GDNATIVE_EXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(GDNATIVE_VARIANT_TYPE_OBJECT, T::get_class_static());
+	static inline GDNativePropertyInfo get_class_info() {
+		return make_property_info(GDNATIVE_VARIANT_TYPE_OBJECT, T::get_class_static());
 	}
 };
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -220,10 +220,10 @@ public:                                                                         
 				cls->plist_size = 0;                                                                                                                     \
 				for (const ::godot::PropertyInfo &E : list) {                                                                                            \
 					cls->plist[cls->plist_size].type = E.type;                                                                                           \
-					cls->plist[cls->plist_size].name = _alloc_and_copy_cstr(E.name);                                                                     \
+					cls->plist[cls->plist_size].name = _alloc_and_copy_cstr(E.name.utf8().get_data());                                                   \
 					cls->plist[cls->plist_size].hint = E.hint;                                                                                           \
-					cls->plist[cls->plist_size].hint_string = _alloc_and_copy_cstr(E.hint_string);                                                       \
-					cls->plist[cls->plist_size].class_name = _alloc_and_copy_cstr(E.class_name);                                                         \
+					cls->plist[cls->plist_size].hint_string = _alloc_and_copy_cstr(E.hint_string.utf8().get_data());                                     \
+					cls->plist[cls->plist_size].class_name = _alloc_and_copy_cstr(E.class_name.utf8().get_data());                                       \
 					cls->plist[cls->plist_size].usage = E.usage;                                                                                         \
 					cls->plist_size++;                                                                                                                   \
 				}                                                                                                                                        \

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -99,6 +99,13 @@ private:
 	static void initialize_class(const ClassInfo &cl);
 	static void bind_method_godot(const char *p_class_name, MethodBind *p_method);
 
+	static _FORCE_INLINE_ char *_alloc_and_copy_cstr(const char *p_str) {
+		size_t size = strlen(p_str) + 1;
+		char *ret = reinterpret_cast<char *>(memalloc(size));
+		memcpy(ret, p_str, size);
+		return ret;
+	}
+
 public:
 	template <class T>
 	static void register_class();

--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -45,26 +45,15 @@ namespace godot {
 
 struct PropertyInfo {
 	Variant::Type type = Variant::NIL;
-	const char *name = nullptr;
-	const char *class_name = nullptr;
+	String name;
+	String class_name;
 	uint32_t hint = 0;
-	const char *hint_string = nullptr;
+	String hint_string;
 	uint32_t usage = 7;
-
-	operator GDNativePropertyInfo() const {
-		GDNativePropertyInfo info;
-		info.type = type;
-		info.name = name;
-		info.hint = hint;
-		info.hint_string = hint_string;
-		info.class_name = class_name;
-		info.usage = usage;
-		return info;
-	}
 
 	PropertyInfo() = default;
 
-	PropertyInfo(Variant::Type p_type, const char *p_name, PropertyHint p_hint = PROPERTY_HINT_NONE, const char *p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const char *p_class_name = "") :
+	PropertyInfo(Variant::Type p_type, const String &p_name, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const String &p_class_name = "") :
 			type(p_type),
 			name(p_name),
 			hint(p_hint),
@@ -77,7 +66,7 @@ struct PropertyInfo {
 		}
 	}
 
-	PropertyInfo(GDNativeVariantType p_type, const char *p_name, PropertyHint p_hint = PROPERTY_HINT_NONE, const char *p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const char *p_class_name = "") :
+	PropertyInfo(GDNativeVariantType p_type, const String &p_name, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const String &p_class_name = "") :
 			PropertyInfo((Variant::Type)p_type, p_name, p_hint, p_hint_string, p_usage, p_class_name) {}
 };
 

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -38,7 +38,13 @@ void Example::_notification(int p_what) {
 }
 
 bool Example::_set(const StringName &p_name, const Variant &p_value) {
-	if (p_name == StringName("property_from_list")) {
+	String name = p_name;
+	if (name.begins_with("dproperty")) {
+		int index = name.get_slicec('_', 1).to_int();
+		dprop[index] = p_value;
+		return true;
+	}
+	if (name == "property_from_list") {
 		property_from_list = p_value;
 		return true;
 	}
@@ -46,7 +52,13 @@ bool Example::_set(const StringName &p_name, const Variant &p_value) {
 }
 
 bool Example::_get(const StringName &p_name, Variant &r_ret) const {
-	if (p_name == StringName("property_from_list")) {
+	String name = p_name;
+	if (name.begins_with("dproperty")) {
+		int index = name.get_slicec('_', 1).to_int();
+		r_ret = dprop[index];
+		return true;
+	}
+	if (name == "property_from_list") {
 		r_ret = property_from_list;
 		return true;
 	}
@@ -59,6 +71,9 @@ String Example::_to_string() const {
 
 void Example::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::VECTOR3, "property_from_list"));
+	for (int i = 0; i < 3; i++) {
+		p_list->push_back(PropertyInfo(Variant::VECTOR2, "dproperty_" + itos(i)));
+	}
 }
 
 bool Example::_property_can_revert(const StringName &p_name) const {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -58,6 +58,7 @@ protected:
 private:
 	Vector2 custom_position;
 	Vector3 property_from_list;
+	Vector2 dprop[3];
 
 public:
 	// Constants.


### PR DESCRIPTION
Improves ability to dynamically define properties, without handling `char *` allocation / de-allocation manually.