### PR TITLE
Add Godot 3.x ignores to the .gitignore file in master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           if-no-files-found: error
 
   linux-cmake:
-    name: Build (Linux, GCC, CMake)
+    name: 🐧 Build (Linux, GCC, CMake)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -127,7 +127,7 @@ jobs:
           make -j $(nproc)
 
   linux-cmake-ninja:
-    name: Build (Linux, GCC, CMake Ninja)
+    name: 🐧 Build (Linux, GCC, CMake Ninja)
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -151,7 +151,7 @@ jobs:
           cmake --build . -j $(nproc)
 
   windows-msvc-cmake:
-    name: Build (Windows, MSVC, CMake)
+    name: 🏁 Build (Windows, MSVC, CMake)
     runs-on: windows-2019
     steps:
       - name: Checkout
@@ -170,7 +170,7 @@ jobs:
           cmake --build .
 
   static-checks:
-    name: Static Checks (clang-format)
+    name: 📊 Static Checks (clang-format)
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 .godot/
 /gen/
 
+# Godot 3.x ignores
+include/gen
+src/gen
+
 # Misc
 logs/*
 *.log


### PR DESCRIPTION
This PR does two small things:

* Update the .gitignore to ignore 3.x's generated folders (to avoid those files showing up when switching branches).
* Update the static checks CI to have a 📊 emoji, and make Windows/Linux builds have 🏁 and 🐧 emojis.