### PR TITLE
Fix get_file_list not returning all generated files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,7 @@ jobs:
       - name: Python style checks via black (black_format.sh)
         run: |
           bash ./misc/scripts/black_format.sh
+
+      - name: Bindings generation checks (ensures get_file_list returns all generated files)
+        run: |
+          python ./misc/scripts/check_get_file_list.py

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -40,14 +40,27 @@ def get_file_list(api_filepath, output_dir, headers=False, sources=False):
         if sources:
             files.append(str(source_filename.as_posix()))
 
-    utility_functions_header_path = include_gen_folder / "variant" / "utility_functions.hpp"
-    utility_functions_source_path = source_gen_folder / "variant" / "utility_functions.cpp"
-    global_constants_header_path = include_gen_folder / "classes" / "global_constants.hpp"
+    for native_struct in api["native_structures"]:
+        struct_name = native_struct["name"]
+        snake_struct_name = camel_to_snake(struct_name)
+
+        header_filename = include_gen_folder / "classes" / (snake_struct_name + ".hpp")
+        if headers:
+            files.append(str(header_filename.as_posix()))
+
     if headers:
-        files.append(str(utility_functions_header_path.as_posix()))
-        files.append(str(global_constants_header_path.as_posix()))
+        for path in [
+            include_gen_folder / "variant" / "builtin_types.hpp",
+            include_gen_folder / "variant" / "utility_functions.hpp",
+            include_gen_folder / "variant" / "variant_size.hpp",
+            include_gen_folder / "classes" / "global_constants.hpp",
+            include_gen_folder / "classes" / "global_constants_binds.hpp",
+        ]:
+            files.append(str(path.as_posix()))
     if sources:
+        utility_functions_source_path = source_gen_folder / "variant" / "utility_functions.cpp"
         files.append(str(utility_functions_source_path.as_posix()))
+
     return files
 
 

--- a/misc/scripts/check_get_file_list.py
+++ b/misc/scripts/check_get_file_list.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import os, sys
+
+from pathlib import Path
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from binding_generator import get_file_list, generate_bindings
+
+api_filepath = "godot-headers/extension_api.json"
+bits = "64"
+double = "float"
+output_dir = "self_test"
+
+generate_bindings(api_filepath, use_template_get_node=False, bits=bits, double=double, output_dir=output_dir)
+flist = get_file_list(api_filepath, output_dir, headers=True, sources=True)
+
+p = Path(output_dir) / "gen"
+allfiles = [str(f.as_posix()) for f in p.glob("**/*.*")]
+missing = list(filter((lambda f: f not in flist), allfiles))
+extras = list(filter((lambda f: f not in allfiles), flist))
+if len(missing) > 0 or len(extras) > 0:
+    print("Error!")
+    for f in missing:
+        print("MISSING: " + str(f))
+    for f in extras:
+        print("EXTRA: " + str(f))
+    sys.exit(1)
+else:
+    print("OK!")


### PR DESCRIPTION
Adds a CI static check for it.

Was also the cause of intermittent CI failures, affecting both CMake and SCons since they both rely on `get_file_list`.