### PR TITLE
Separate definition of templates to solve the vararg/template issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,10 @@ jobs:
           cd test
           scons platform=${{ matrix.platform }} target=debug ${{ matrix.flags }} build_library=no
 
-      - name: Build test and godot-cpp (release)
+      - name: Build test and godot-cpp (release, with debug symbols)
         run: |
           cd test
-          scons platform=${{ matrix.platform }} target=release ${{ matrix.flags }}
+          scons platform=${{ matrix.platform }} target=release debug_symbols=yes ${{ matrix.flags }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/SConstruct
+++ b/SConstruct
@@ -102,6 +102,10 @@ architecture_aliases = {
 }
 opts.Add(EnumVariable("arch", "CPU architecture", "", architecture_array, architecture_aliases))
 
+# Targets flags tool (optimizations, debug symbols)
+target_tool = Tool("targets", toolpath=["tools"])
+target_tool.options(opts)
+
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
 
@@ -135,6 +139,7 @@ if tool is None or not tool.exists(env):
     raise ValueError("Required toolchain not found for platform " + env["platform"])
 
 tool.generate(env)
+target_tool.generate(env)
 
 # Detect and print a warning listing unknown SCons variables to ease troubleshooting.
 unknown = opts.UnknownVariables()

--- a/include/godot_cpp/core/builtin_ptrcall.hpp
+++ b/include/godot_cpp/core/builtin_ptrcall.hpp
@@ -41,23 +41,34 @@ namespace internal {
 
 template <class... Args>
 void _call_builtin_constructor(const GDNativePtrConstructor constructor, GDNativeTypePtr base, Args... args) {
-	std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
-	constructor(base, call_args.data());
+       std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
+       constructor(base, call_args.data());
 }
 
 template <class T, class... Args>
 T _call_builtin_method_ptr_ret(const GDNativePtrBuiltInMethod method, GDNativeTypePtr base, Args... args) {
-	T ret;
-	std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
-	method(base, call_args.data(), &ret, sizeof...(Args));
+       T ret;
+       std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
+       method(base, call_args.data(), &ret, sizeof...(Args));
 	return ret;
+}
+
+template <class T, class... Args>
+T _call_builtin_method_ret(const GDNativePtrBuiltInMethod method, GDNativeTypePtr base, Args... args) {
+    return _call_builtin_method_ptr_ret<T, Args*...>(method, base, &args...);
 }
 
 template <class... Args>
 void _call_builtin_method_ptr_no_ret(const GDNativePtrBuiltInMethod method, GDNativeTypePtr base, Args... args) {
-	std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
-	method(base, call_args.data(), nullptr, sizeof...(Args));
+       std::array<const GDNativeTypePtr, sizeof...(Args)> call_args = { { (const GDNativeTypePtr)args... } };
+       method(base, call_args.data(), nullptr, sizeof...(Args));
 }
+
+template <class... Args>
+void _call_builtin_method_no_ret(const GDNativePtrBuiltInMethod method, GDNativeTypePtr base, Args... args) {
+    return _call_builtin_method_ptr_no_ret<Args...>(method, base, &args...);
+}
+
 
 template <class T>
 T _call_builtin_operator_ptr(const GDNativePtrOperatorEvaluator op, const GDNativeTypePtr left, const GDNativeTypePtr right) {

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -33,14 +33,23 @@
 
 #include <godot_cpp/core/defs.hpp>
 
-#include <godot_cpp/variant/builtin_types.hpp>
 #include <godot_cpp/variant/variant_size.hpp>
+#include <godot_cpp/variant/string.hpp>
 
 #include <godot/gdnative_interface.h>
 
 #include <array>
 
 namespace godot {
+
+class RID;
+class Vector2;
+class Vector3;
+class Vector3i;
+class Vector2i;
+class Rect2;
+class Rect2i;
+class StringName;
 
 class Variant {
 	uint8_t opaque[GODOT_CPP_VARIANT_SIZE]{ 0 };
@@ -319,5 +328,7 @@ struct VariantComparator {
 };
 
 } // namespace godot
+
+#include <godot_cpp/variant/builtin_types.hpp>
 
 #endif // ! GODOT_CPP_VARIANT_HPP

--- a/misc/scripts/check_get_file_list.py
+++ b/misc/scripts/check_get_file_list.py
@@ -14,7 +14,7 @@ double = "float"
 output_dir = "self_test"
 
 generate_bindings(api_filepath, use_template_get_node=False, bits=bits, double=double, output_dir=output_dir)
-flist = get_file_list(api_filepath, output_dir, headers=True, sources=True)
+flist = get_file_list(api_filepath, output_dir, headers=True, sources=True, impl=True)
 
 p = Path(output_dir) / "gen"
 allfiles = [str(f.as_posix()) for f in p.glob("**/*.*")]

--- a/tools/android.py
+++ b/tools/android.py
@@ -96,11 +96,6 @@ def generate(env):
 
     env.Append(
         CCFLAGS=["--target=" + arch_info["target"] + env["android_api_level"], "-march=" + arch_info["march"], "-fPIC"]
-    )  # , '-fPIE', '-fno-addrsig', '-Oz'])
+    )
     env.Append(CCFLAGS=arch_info["ccflags"])
     env.Append(LINKFLAGS=["--target=" + arch_info["target"] + env["android_api_level"], "-march=" + arch_info["march"]])
-
-    if env["target"] == "debug":
-        env.Append(CCFLAGS=["-Og", "-g"])
-    elif env["target"] == "release":
-        env.Append(CCFLAGS=["-O3"])

--- a/tools/ios.py
+++ b/tools/ios.py
@@ -79,8 +79,3 @@ def generate(env):
 
     env.Append(CCFLAGS=["-isysroot", env["IOS_SDK_PATH"]])
     env.Append(LINKFLAGS=["-isysroot", env["IOS_SDK_PATH"], "-F" + env["IOS_SDK_PATH"]])
-
-    if env["target"] == "debug":
-        env.Append(CCFLAGS=["-Og", "-g"])
-    elif env["target"] == "release":
-        env.Append(CCFLAGS=["-O3"])

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -18,11 +18,6 @@ def generate(env):
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])
 
-    if env["target"] == "debug":
-        env.Append(CCFLAGS=["-Og", "-g"])
-    elif env["target"] == "release":
-        env.Append(CCFLAGS=["-O3"])
-
     if env["arch"] == "x86_64":
         # -m64 and -m32 are x86-specific already, but it doesn't hurt to
         # be clear and also specify -march=x86-64. Similar with 32-bit.

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -48,8 +48,3 @@ def generate(env):
             "-Wl,-undefined,dynamic_lookup",
         ]
     )
-
-    if env["target"] == "debug":
-        env.Append(CCFLAGS=["-Og", "-g"])
-    elif env["target"] == "release":
-        env.Append(CCFLAGS=["-O3"])

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from SCons.Variables import *
+
+
+def options(opts):
+    opts.Add(
+        EnumVariable(
+            "optimize",
+            "The desired optimization flags",
+            "auto",
+            ("auto", "none", "debug", "speed", "size", "0", "1", "2", "3"),
+        )
+    )
+    opts.Add(BoolVariable("debug_symbols", "Add debugging symbols to release builds", False))
+
+
+def exists(env):
+    return True
+
+
+def generate(env):
+    if env["optimize"] == "auto":
+        env["optimize"] = "speed" if env["target"] == "release" else "debug"
+    env["debug_symbols"] = env["debug_symbols"] or env["target"] == "debug"
+
+    if "is_msvc" in env and env["is_msvc"]:
+        if env["debug_symbols"]:
+            env.Append(CCFLAGS=["/Z7", "/D_DEBUG"])
+            env.Append(LINKFLAGS=["/DEBUG:FULL"])
+        else:
+            env.Append(CCFLAGS=["/Z7", "/DNDEBUG"])
+
+        if env["optimize"] == "speed":
+            env.Append(CCFLAGS=["/O2"])
+        elif env["optimize"] == "size":
+            env.Append(CCFLAGS=["/Os"])
+        elif env["optimize"] == "debug":
+            env.Append(CCFLAGS=["/Od"])
+        elif env["optimize"] == "none":
+            env.Append(CCFLAGS=["/Od"])
+        else:
+            env.Append(CCFLAGS=["/O%s" % env["optimize"]])
+    else:
+        if env["debug_symbols"]:
+            env.Append(CCFLAGS=["-g"])
+
+        if env["optimize"] == "speed":
+            env.Append(CCFLAGS=["-O3"])
+        elif env["optimize"] == "size":
+            env.Append(CCFLAGS=["-Os"])
+        elif env["optimize"] == "debug":
+            env.Append(CCFLAGS=["-Og"])
+        elif env["optimize"] == "none":
+            env.Append(CCFLAGS=["-O0"])
+        else:
+            env.Append(CCFLAGS=["-O%s" % env["optimize"]])

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -25,12 +25,13 @@ def generate(env):
         env["is_msvc"] = True
         msvc.generate(env)
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
+        env.Append(CCFLAGS=["/EHsc"])
         env.Append(LINKFLAGS=["/WX"])
-        if env["target"] == "debug":
-            env.Append(CCFLAGS=["/Z7", "/Od", "/EHsc", "/D_DEBUG", "/MDd"])
-            env.Append(LINKFLAGS=["/DEBUG:FULL"])
-        elif env["target"] == "release":
-            env.Append(CCFLAGS=["/O2", "/EHsc", "/DNDEBUG", "/MD"])
+        if env["debug_symbols"] or env["target"] == "debug":
+            env.Append(CCFLAGS=["/MDd"])
+        else:
+            env.Append(CCFLAGS=["/MD"])
+
         if env["use_clang_cl"]:
             env["CC"] = "clang-cl"
             env["CXX"] = "clang-cl"


### PR DESCRIPTION
Hi,

I stumbled upon #802 - I wanted to call Callable::call from GDExtension, but realized all varargs methods were not generated.
Digging a bit, I saw that the deeper problem is the circular dependency between Callable and Variant - at least in my tentative. So I went for a classical approach, defining the template methods separately in an .impl file.

This way, at least, it compiles and links properly when I try to use Callable::call in my code. (by including "godot_cpp/variant/callable.impl")
But this is a first draft: not clean at all and crashes badly! I just wanted to open the PR already to start discussing the idea itself. If this could be the way to go, I can clean up in the coming days. Please feel welcome to do it if you have time and motivation before I do!