### PR TITLE
Move some methods to Animation from Variant

### DIFF
--- a/godot-headers/godot/gdnative_interface.h
+++ b/godot-headers/godot/gdnative_interface.h
@@ -427,9 +427,6 @@ typedef struct {
 	GDNativeInt (*variant_recursive_hash)(const GDNativeVariantPtr p_self, GDNativeInt p_recursion_count);
 	GDNativeBool (*variant_hash_compare)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_other);
 	GDNativeBool (*variant_booleanize)(const GDNativeVariantPtr p_self);
-	void (*variant_sub)(const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, GDNativeVariantPtr r_dst);
-	void (*variant_blend)(const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, float p_c, GDNativeVariantPtr r_dst);
-	void (*variant_interpolate)(const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, float p_c, GDNativeVariantPtr r_dst);
 	void (*variant_duplicate)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_ret, GDNativeBool p_deep);
 	void (*variant_stringify)(const GDNativeVariantPtr p_self, GDNativeStringPtr r_ret);
 

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -693,14 +693,6 @@ Variant Variant::duplicate(bool deep) const {
 	return result;
 }
 
-void Variant::blend(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::gdn_interface->variant_blend(a._native_ptr(), b._native_ptr(), c, r_dst._native_ptr());
-}
-
-void Variant::interpolate(const Variant &a, const Variant &b, float c, Variant &r_dst) {
-	internal::gdn_interface->variant_interpolate(a._native_ptr(), b._native_ptr(), c, r_dst._native_ptr());
-}
-
 String Variant::get_type_name(Variant::Type type) {
 	String result;
 	internal::gdn_interface->variant_get_type_name(static_cast<GDNativeVariantType>(type), result._native_ptr());


### PR DESCRIPTION
For https://github.com/godotengine/godot/pull/65325.

Some of the methods in Variant are specialized for animation use, so they are ported as static methods of Animation.