### PR TITLE
Add missing Vector4 function bindings

### DIFF
--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -75,12 +75,16 @@ public:
 	bool is_normalized() const;
 	Vector4 abs() const;
 	Vector4 sign() const;
+	Vector4 floor() const;
+	Vector4 ceil() const;
+	Vector4 round() const;
 
 	Vector4::Axis min_axis_index() const;
 	Vector4::Axis max_axis_index() const;
 	Vector4 clamp(const Vector4 &p_min, const Vector4 &p_max) const;
 
 	Vector4 inverse() const;
+	Vector4 lerp(const Vector4 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ real_t dot(const Vector4 &p_vec4) const;
 
 	_FORCE_INLINE_ void operator+=(const Vector4 &p_vec4);

--- a/src/variant/vector4.cpp
+++ b/src/variant/vector4.cpp
@@ -63,8 +63,28 @@ Vector4 Vector4::sign() const {
 	return Vector4(Math::sign(x), Math::sign(y), Math::sign(z), Math::sign(w));
 }
 
+Vector4 Vector4::floor() const {
+	return Vector4(Math::floor(x), Math::floor(y), Math::floor(z), Math::floor(w));
+}
+
+Vector4 Vector4::ceil() const {
+	return Vector4(Math::ceil(x), Math::ceil(y), Math::ceil(z), Math::ceil(w));
+}
+
+Vector4 Vector4::round() const {
+	return Vector4(Math::round(x), Math::round(y), Math::round(z), Math::round(w));
+}
+
 Vector4 Vector4::inverse() const {
 	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
+}
+
+Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
+	return Vector4(
+			x + (p_weight * (p_to.x - x)),
+			y + (p_weight * (p_to.y - y)),
+			z + (p_weight * (p_to.z - z)),
+			w + (p_weight * (p_to.w - w)));
 }
 
 Vector4::Axis Vector4::min_axis_index() const {


### PR DESCRIPTION
Attempt to fix [#65997](https://github.com/godotengine/godot/issues/65997). Solves the compile errors, but instead crashes on project load.