### PR TITLE
Add `Object::cast_to` for `const Object*`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1083,10 +1083,15 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
     # Special cases.
     if class_name == "Object":
         result.append("")
+
         result.append("\ttemplate<class T>")
         result.append("\tstatic T *cast_to(Object *p_object);")
 
+        result.append("\ttemplate<class T>")
+        result.append("\tstatic const T *cast_to(const Object *p_object);")
+
         result.append("\tvirtual ~Object() = default;")
+
     elif use_template_get_node and class_name == "Node":
         result.append("\ttemplate<class T>")
         result.append(

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -144,6 +144,18 @@ T *Object::cast_to(Object *p_object) {
 	return reinterpret_cast<T *>(internal::gdn_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
+template <class T>
+const T *Object::cast_to(const Object *p_object) {
+	if (p_object == nullptr) {
+		return nullptr;
+	}
+	GDNativeObjectPtr casted = internal::gdn_interface->object_cast_to(p_object->_owner, internal::gdn_interface->classdb_get_class_tag(T::get_class_static()));
+	if (casted == nullptr) {
+		return nullptr;
+	}
+	return reinterpret_cast<const T *>(internal::gdn_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+}
+
 } // namespace godot
 
 #endif // ! GODOT_OBJECT_HPP


### PR DESCRIPTION
Before it wasn't possible to use `Object::cast_to(obj)` if `obj` was a `const T*`. Godot does the same thing: https://github.com/godotengine/godot/blob/908795301b9e4fcf24b115329a48d7d295c13a1a/core/object/object.h#L734-L764