### PR TITLE
Rename Transform2D and Basis `elements` to `columns` and `rows` respectively

### DIFF
--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -43,17 +43,17 @@ class Basis {
 	friend class Variant;
 
 public:
-	Vector3 elements[3] = {
+	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),
 		Vector3(0, 0, 1)
 	};
 
 	inline const Vector3 &operator[](int axis) const {
-		return elements[axis];
+		return rows[axis];
 	}
 	inline Vector3 &operator[](int axis) {
-		return elements[axis];
+		return rows[axis];
 	}
 
 	void invert();
@@ -67,14 +67,14 @@ public:
 	void from_z(const Vector3 &p_z);
 
 	inline Vector3 get_axis(int p_axis) const {
-		// get actual basis axis (elements is transposed for performance)
-		return Vector3(elements[0][p_axis], elements[1][p_axis], elements[2][p_axis]);
+		// get actual basis axis (rows is transposed for performance)
+		return Vector3(rows[0][p_axis], rows[1][p_axis], rows[2][p_axis]);
 	}
 	inline void set_axis(int p_axis, const Vector3 &p_value) {
-		// get actual basis axis (elements is transposed for performance)
-		elements[0][p_axis] = p_value.x;
-		elements[1][p_axis] = p_value.y;
-		elements[2][p_axis] = p_value.z;
+		// get actual basis axis (rows is transposed for performance)
+		rows[0][p_axis] = p_value.x;
+		rows[1][p_axis] = p_value.y;
+		rows[2][p_axis] = p_value.z;
 	}
 
 	void rotate(const Vector3 &p_axis, real_t p_phi);
@@ -143,13 +143,13 @@ public:
 
 	// transposed dot products
 	inline real_t tdotx(const Vector3 &v) const {
-		return elements[0][0] * v[0] + elements[1][0] * v[1] + elements[2][0] * v[2];
+		return rows[0][0] * v[0] + rows[1][0] * v[1] + rows[2][0] * v[2];
 	}
 	inline real_t tdoty(const Vector3 &v) const {
-		return elements[0][1] * v[0] + elements[1][1] * v[1] + elements[2][1] * v[2];
+		return rows[0][1] * v[0] + rows[1][1] * v[1] + rows[2][1] * v[2];
 	}
 	inline real_t tdotz(const Vector3 &v) const {
-		return elements[0][2] * v[0] + elements[1][2] * v[1] + elements[2][2] * v[2];
+		return rows[0][2] * v[0] + rows[1][2] * v[1] + rows[2][2] * v[2];
 	}
 
 	bool is_equal_approx(const Basis &p_basis) const;
@@ -185,15 +185,15 @@ public:
 	/* create / set */
 
 	inline void set(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz) {
-		elements[0][0] = xx;
-		elements[0][1] = xy;
-		elements[0][2] = xz;
-		elements[1][0] = yx;
-		elements[1][1] = yy;
-		elements[1][2] = yz;
-		elements[2][0] = zx;
-		elements[2][1] = zy;
-		elements[2][2] = zz;
+		rows[0][0] = xx;
+		rows[0][1] = xy;
+		rows[0][2] = xz;
+		rows[1][0] = yx;
+		rows[1][1] = yy;
+		rows[1][2] = yz;
+		rows[2][0] = zx;
+		rows[2][1] = zy;
+		rows[2][2] = zz;
 	}
 	inline void set(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z) {
 		set_axis(0, p_x);
@@ -201,39 +201,39 @@ public:
 		set_axis(2, p_z);
 	}
 	inline Vector3 get_column(int i) const {
-		return Vector3(elements[0][i], elements[1][i], elements[2][i]);
+		return Vector3(rows[0][i], rows[1][i], rows[2][i]);
 	}
 
 	inline Vector3 get_row(int i) const {
-		return Vector3(elements[i][0], elements[i][1], elements[i][2]);
+		return Vector3(rows[i][0], rows[i][1], rows[i][2]);
 	}
 	inline Vector3 get_main_diagonal() const {
-		return Vector3(elements[0][0], elements[1][1], elements[2][2]);
+		return Vector3(rows[0][0], rows[1][1], rows[2][2]);
 	}
 
 	inline void set_row(int i, const Vector3 &p_row) {
-		elements[i][0] = p_row.x;
-		elements[i][1] = p_row.y;
-		elements[i][2] = p_row.z;
+		rows[i][0] = p_row.x;
+		rows[i][1] = p_row.y;
+		rows[i][2] = p_row.z;
 	}
 
 	inline void set_zero() {
-		elements[0].zero();
-		elements[1].zero();
-		elements[2].zero();
+		rows[0].zero();
+		rows[1].zero();
+		rows[2].zero();
 	}
 
 	inline Basis transpose_xform(const Basis &m) const {
 		return Basis(
-				elements[0].x * m[0].x + elements[1].x * m[1].x + elements[2].x * m[2].x,
-				elements[0].x * m[0].y + elements[1].x * m[1].y + elements[2].x * m[2].y,
-				elements[0].x * m[0].z + elements[1].x * m[1].z + elements[2].x * m[2].z,
-				elements[0].y * m[0].x + elements[1].y * m[1].x + elements[2].y * m[2].x,
-				elements[0].y * m[0].y + elements[1].y * m[1].y + elements[2].y * m[2].y,
-				elements[0].y * m[0].z + elements[1].y * m[1].z + elements[2].y * m[2].z,
-				elements[0].z * m[0].x + elements[1].z * m[1].x + elements[2].z * m[2].x,
-				elements[0].z * m[0].y + elements[1].z * m[1].y + elements[2].z * m[2].y,
-				elements[0].z * m[0].z + elements[1].z * m[1].z + elements[2].z * m[2].z);
+				rows[0].x * m[0].x + rows[1].x * m[1].x + rows[2].x * m[2].x,
+				rows[0].x * m[0].y + rows[1].x * m[1].y + rows[2].x * m[2].y,
+				rows[0].x * m[0].z + rows[1].x * m[1].z + rows[2].x * m[2].z,
+				rows[0].y * m[0].x + rows[1].y * m[1].x + rows[2].y * m[2].x,
+				rows[0].y * m[0].y + rows[1].y * m[1].y + rows[2].y * m[2].y,
+				rows[0].y * m[0].z + rows[1].y * m[1].z + rows[2].y * m[2].z,
+				rows[0].z * m[0].x + rows[1].z * m[1].x + rows[2].z * m[2].x,
+				rows[0].z * m[0].y + rows[1].z * m[1].y + rows[2].z * m[2].y,
+				rows[0].z * m[0].z + rows[1].z * m[1].z + rows[2].z * m[2].z);
 	}
 	Basis(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz) {
 		set(xx, xy, xz, yx, yy, yz, zx, zy, zz);
@@ -269,22 +269,22 @@ public:
 
 inline void Basis::operator*=(const Basis &p_matrix) {
 	set(
-			p_matrix.tdotx(elements[0]), p_matrix.tdoty(elements[0]), p_matrix.tdotz(elements[0]),
-			p_matrix.tdotx(elements[1]), p_matrix.tdoty(elements[1]), p_matrix.tdotz(elements[1]),
-			p_matrix.tdotx(elements[2]), p_matrix.tdoty(elements[2]), p_matrix.tdotz(elements[2]));
+			p_matrix.tdotx(rows[0]), p_matrix.tdoty(rows[0]), p_matrix.tdotz(rows[0]),
+			p_matrix.tdotx(rows[1]), p_matrix.tdoty(rows[1]), p_matrix.tdotz(rows[1]),
+			p_matrix.tdotx(rows[2]), p_matrix.tdoty(rows[2]), p_matrix.tdotz(rows[2]));
 }
 
 inline Basis Basis::operator*(const Basis &p_matrix) const {
 	return Basis(
-			p_matrix.tdotx(elements[0]), p_matrix.tdoty(elements[0]), p_matrix.tdotz(elements[0]),
-			p_matrix.tdotx(elements[1]), p_matrix.tdoty(elements[1]), p_matrix.tdotz(elements[1]),
-			p_matrix.tdotx(elements[2]), p_matrix.tdoty(elements[2]), p_matrix.tdotz(elements[2]));
+			p_matrix.tdotx(rows[0]), p_matrix.tdoty(rows[0]), p_matrix.tdotz(rows[0]),
+			p_matrix.tdotx(rows[1]), p_matrix.tdoty(rows[1]), p_matrix.tdotz(rows[1]),
+			p_matrix.tdotx(rows[2]), p_matrix.tdoty(rows[2]), p_matrix.tdotz(rows[2]));
 }
 
 inline void Basis::operator+=(const Basis &p_matrix) {
-	elements[0] += p_matrix.elements[0];
-	elements[1] += p_matrix.elements[1];
-	elements[2] += p_matrix.elements[2];
+	rows[0] += p_matrix.rows[0];
+	rows[1] += p_matrix.rows[1];
+	rows[2] += p_matrix.rows[2];
 }
 
 inline Basis Basis::operator+(const Basis &p_matrix) const {
@@ -294,9 +294,9 @@ inline Basis Basis::operator+(const Basis &p_matrix) const {
 }
 
 inline void Basis::operator-=(const Basis &p_matrix) {
-	elements[0] -= p_matrix.elements[0];
-	elements[1] -= p_matrix.elements[1];
-	elements[2] -= p_matrix.elements[2];
+	rows[0] -= p_matrix.rows[0];
+	rows[1] -= p_matrix.rows[1];
+	rows[2] -= p_matrix.rows[2];
 }
 
 inline Basis Basis::operator-(const Basis &p_matrix) const {
@@ -306,9 +306,9 @@ inline Basis Basis::operator-(const Basis &p_matrix) const {
 }
 
 inline void Basis::operator*=(real_t p_val) {
-	elements[0] *= p_val;
-	elements[1] *= p_val;
-	elements[2] *= p_val;
+	rows[0] *= p_val;
+	rows[1] *= p_val;
+	rows[2] *= p_val;
 }
 
 inline Basis Basis::operator*(real_t p_val) const {
@@ -319,22 +319,22 @@ inline Basis Basis::operator*(real_t p_val) const {
 
 Vector3 Basis::xform(const Vector3 &p_vector) const {
 	return Vector3(
-			elements[0].dot(p_vector),
-			elements[1].dot(p_vector),
-			elements[2].dot(p_vector));
+			rows[0].dot(p_vector),
+			rows[1].dot(p_vector),
+			rows[2].dot(p_vector));
 }
 
 Vector3 Basis::xform_inv(const Vector3 &p_vector) const {
 	return Vector3(
-			(elements[0][0] * p_vector.x) + (elements[1][0] * p_vector.y) + (elements[2][0] * p_vector.z),
-			(elements[0][1] * p_vector.x) + (elements[1][1] * p_vector.y) + (elements[2][1] * p_vector.z),
-			(elements[0][2] * p_vector.x) + (elements[1][2] * p_vector.y) + (elements[2][2] * p_vector.z));
+			(rows[0][0] * p_vector.x) + (rows[1][0] * p_vector.y) + (rows[2][0] * p_vector.z),
+			(rows[0][1] * p_vector.x) + (rows[1][1] * p_vector.y) + (rows[2][1] * p_vector.z),
+			(rows[0][2] * p_vector.x) + (rows[1][2] * p_vector.y) + (rows[2][2] * p_vector.z));
 }
 
 real_t Basis::determinant() const {
-	return elements[0][0] * (elements[1][1] * elements[2][2] - elements[2][1] * elements[1][2]) -
-		   elements[1][0] * (elements[0][1] * elements[2][2] - elements[2][1] * elements[0][2]) +
-		   elements[2][0] * (elements[0][1] * elements[1][2] - elements[1][1] * elements[0][2]);
+	return rows[0][0] * (rows[1][1] * rows[2][2] - rows[2][1] * rows[1][2]) -
+		   rows[1][0] * (rows[0][1] * rows[2][2] - rows[2][1] * rows[0][2]) +
+		   rows[2][0] * (rows[0][1] * rows[1][2] - rows[1][1] * rows[0][2]);
 }
 
 } // namespace godot

--- a/include/godot_cpp/variant/transform2d.hpp
+++ b/include/godot_cpp/variant/transform2d.hpp
@@ -45,32 +45,32 @@ class Transform2D {
 	friend class Variant;
 
 public:
-	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
-	// M = (elements[0][0] elements[1][0])
-	//     (elements[0][1] elements[1][1])
-	// This is such that the columns, which can be interpreted as basis vectors of the coordinate system "painted" on the object, can be accessed as elements[i].
-	// Note that this is the opposite of the indices in mathematical texts, meaning: $M_{12}$ in a math book corresponds to elements[1][0] here.
+	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of columns array, the basis matrix looks like "on paper":
+	// M = (columns[0][0] columns[1][0])
+	//     (columns[0][1] columns[1][1])
+	// This is such that the columns, which can be interpreted as basis vectors of the coordinate system "painted" on the object, can be accessed as columns[i].
+	// Note that this is the opposite of the indices in mathematical texts, meaning: $M_{12}$ in a math book corresponds to columns[1][0] here.
 	// This requires additional care when working with explicit indices.
 	// See https://en.wikipedia.org/wiki/Row-_and_column-major_order for further reading.
 
 	// Warning #2: 2D be aware that unlike 3D code, 2D code uses a left-handed coordinate system: Y-axis points down,
 	// and angle is measure from +X to +Y in a clockwise-fashion.
 
-	Vector2 elements[3];
+	Vector2 columns[3];
 
-	inline real_t tdotx(const Vector2 &v) const { return elements[0][0] * v.x + elements[1][0] * v.y; }
-	inline real_t tdoty(const Vector2 &v) const { return elements[0][1] * v.x + elements[1][1] * v.y; }
+	inline real_t tdotx(const Vector2 &v) const { return columns[0][0] * v.x + columns[1][0] * v.y; }
+	inline real_t tdoty(const Vector2 &v) const { return columns[0][1] * v.x + columns[1][1] * v.y; }
 
-	const Vector2 &operator[](int p_idx) const { return elements[p_idx]; }
-	Vector2 &operator[](int p_idx) { return elements[p_idx]; }
+	const Vector2 &operator[](int p_idx) const { return columns[p_idx]; }
+	Vector2 &operator[](int p_idx) { return columns[p_idx]; }
 
 	inline Vector2 get_axis(int p_axis) const {
 		ERR_FAIL_INDEX_V(p_axis, 3, Vector2());
-		return elements[p_axis];
+		return columns[p_axis];
 	}
 	inline void set_axis(int p_axis, const Vector2 &p_vec) {
 		ERR_FAIL_INDEX(p_axis, 3);
-		elements[p_axis] = p_vec;
+		columns[p_axis] = p_vec;
 	}
 
 	void invert();
@@ -97,8 +97,8 @@ public:
 	Size2 get_scale() const;
 	void set_scale(const Size2 &p_scale);
 
-	inline const Vector2 &get_origin() const { return elements[2]; }
-	inline void set_origin(const Vector2 &p_origin) { elements[2] = p_origin; }
+	inline const Vector2 &get_origin() const { return columns[2]; }
+	inline void set_origin(const Vector2 &p_origin) { columns[2] = p_origin; }
 
 	Transform2D scaled(const Size2 &p_scale) const;
 	Transform2D basis_scaled(const Size2 &p_scale) const;
@@ -131,24 +131,24 @@ public:
 	operator String() const;
 
 	Transform2D(real_t xx, real_t xy, real_t yx, real_t yy, real_t ox, real_t oy) {
-		elements[0][0] = xx;
-		elements[0][1] = xy;
-		elements[1][0] = yx;
-		elements[1][1] = yy;
-		elements[2][0] = ox;
-		elements[2][1] = oy;
+		columns[0][0] = xx;
+		columns[0][1] = xy;
+		columns[1][0] = yx;
+		columns[1][1] = yy;
+		columns[2][0] = ox;
+		columns[2][1] = oy;
 	}
 
 	Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) {
-		elements[0] = p_x;
-		elements[1] = p_y;
-		elements[2] = p_origin;
+		columns[0] = p_x;
+		columns[1] = p_y;
+		columns[2] = p_origin;
 	}
 
 	Transform2D(real_t p_rot, const Vector2 &p_pos);
 	Transform2D() {
-		elements[0][0] = 1.0;
-		elements[1][1] = 1.0;
+		columns[0][0] = 1.0;
+		columns[1][1] = 1.0;
 	}
 };
 
@@ -160,28 +160,28 @@ Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {
 
 Vector2 Transform2D::basis_xform_inv(const Vector2 &p_vec) const {
 	return Vector2(
-			elements[0].dot(p_vec),
-			elements[1].dot(p_vec));
+			columns[0].dot(p_vec),
+			columns[1].dot(p_vec));
 }
 
 Vector2 Transform2D::xform(const Vector2 &p_vec) const {
 	return Vector2(
 				   tdotx(p_vec),
 				   tdoty(p_vec)) +
-		   elements[2];
+		   columns[2];
 }
 
 Vector2 Transform2D::xform_inv(const Vector2 &p_vec) const {
-	Vector2 v = p_vec - elements[2];
+	Vector2 v = p_vec - columns[2];
 
 	return Vector2(
-			elements[0].dot(v),
-			elements[1].dot(v));
+			columns[0].dot(v),
+			columns[1].dot(v));
 }
 
 Rect2 Transform2D::xform(const Rect2 &p_rect) const {
-	Vector2 x = elements[0] * p_rect.size.x;
-	Vector2 y = elements[1] * p_rect.size.y;
+	Vector2 x = columns[0] * p_rect.size.x;
+	Vector2 y = columns[1] * p_rect.size.y;
 	Vector2 pos = xform(p_rect.position);
 
 	Rect2 new_rect;
@@ -193,17 +193,17 @@ Rect2 Transform2D::xform(const Rect2 &p_rect) const {
 }
 
 void Transform2D::set_rotation_and_scale(real_t p_rot, const Size2 &p_scale) {
-	elements[0][0] = Math::cos(p_rot) * p_scale.x;
-	elements[1][1] = Math::cos(p_rot) * p_scale.y;
-	elements[1][0] = -Math::sin(p_rot) * p_scale.y;
-	elements[0][1] = Math::sin(p_rot) * p_scale.x;
+	columns[0][0] = Math::cos(p_rot) * p_scale.x;
+	columns[1][1] = Math::cos(p_rot) * p_scale.y;
+	columns[1][0] = -Math::sin(p_rot) * p_scale.y;
+	columns[0][1] = Math::sin(p_rot) * p_scale.x;
 }
 
 void Transform2D::set_rotation_scale_and_skew(real_t p_rot, const Size2 &p_scale, float p_skew) {
-	elements[0][0] = Math::cos(p_rot) * p_scale.x;
-	elements[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
-	elements[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
-	elements[0][1] = Math::sin(p_rot) * p_scale.x;
+	columns[0][0] = Math::cos(p_rot) * p_scale.x;
+	columns[1][1] = Math::cos(p_rot + p_skew) * p_scale.y;
+	columns[1][0] = -Math::sin(p_rot + p_skew) * p_scale.y;
+	columns[0][1] = Math::sin(p_rot) * p_scale.x;
 }
 
 Rect2 Transform2D::xform_inv(const Rect2 &p_rect) const {

--- a/include/godot_cpp/variant/transform3d.hpp
+++ b/include/godot_cpp/variant/transform3d.hpp
@@ -134,9 +134,9 @@ inline Vector3 Transform3D::xform_inv(const Vector3 &p_vector) const {
 	Vector3 v = p_vector - origin;
 
 	return Vector3(
-			(basis.elements[0][0] * v.x) + (basis.elements[1][0] * v.y) + (basis.elements[2][0] * v.z),
-			(basis.elements[0][1] * v.x) + (basis.elements[1][1] * v.y) + (basis.elements[2][1] * v.z),
-			(basis.elements[0][2] * v.x) + (basis.elements[1][2] * v.y) + (basis.elements[2][2] * v.z));
+			(basis.rows[0][0] * v.x) + (basis.rows[1][0] * v.y) + (basis.rows[2][0] * v.z),
+			(basis.rows[0][1] * v.x) + (basis.rows[1][1] * v.y) + (basis.rows[2][1] * v.z),
+			(basis.rows[0][2] * v.x) + (basis.rows[1][2] * v.y) + (basis.rows[2][2] * v.z));
 }
 
 inline Plane Transform3D::xform(const Plane &p_plane) const {

--- a/src/variant/projection.cpp
+++ b/src/variant/projection.cpp
@@ -882,17 +882,17 @@ Projection::operator Transform3D() const {
 	Transform3D tr;
 	const real_t *m = &matrix[0][0];
 
-	tr.basis.elements[0][0] = m[0];
-	tr.basis.elements[1][0] = m[1];
-	tr.basis.elements[2][0] = m[2];
+	tr.basis.rows[0][0] = m[0];
+	tr.basis.rows[1][0] = m[1];
+	tr.basis.rows[2][0] = m[2];
 
-	tr.basis.elements[0][1] = m[4];
-	tr.basis.elements[1][1] = m[5];
-	tr.basis.elements[2][1] = m[6];
+	tr.basis.rows[0][1] = m[4];
+	tr.basis.rows[1][1] = m[5];
+	tr.basis.rows[2][1] = m[6];
 
-	tr.basis.elements[0][2] = m[8];
-	tr.basis.elements[1][2] = m[9];
-	tr.basis.elements[2][2] = m[10];
+	tr.basis.rows[0][2] = m[8];
+	tr.basis.rows[1][2] = m[9];
+	tr.basis.rows[2][2] = m[10];
 
 	tr.origin.x = m[12];
 	tr.origin.y = m[13];
@@ -910,17 +910,17 @@ Projection::Projection(const Transform3D &p_transform) {
 	const Transform3D &tr = p_transform;
 	real_t *m = &matrix[0][0];
 
-	m[0] = tr.basis.elements[0][0];
-	m[1] = tr.basis.elements[1][0];
-	m[2] = tr.basis.elements[2][0];
+	m[0] = tr.basis.rows[0][0];
+	m[1] = tr.basis.rows[1][0];
+	m[2] = tr.basis.rows[2][0];
 	m[3] = 0.0;
-	m[4] = tr.basis.elements[0][1];
-	m[5] = tr.basis.elements[1][1];
-	m[6] = tr.basis.elements[2][1];
+	m[4] = tr.basis.rows[0][1];
+	m[5] = tr.basis.rows[1][1];
+	m[6] = tr.basis.rows[2][1];
 	m[7] = 0.0;
-	m[8] = tr.basis.elements[0][2];
-	m[9] = tr.basis.elements[1][2];
-	m[10] = tr.basis.elements[2][2];
+	m[8] = tr.basis.rows[0][2];
+	m[9] = tr.basis.rows[1][2];
+	m[10] = tr.basis.rows[2][2];
 	m[11] = 0.0;
 	m[12] = tr.origin.x;
 	m[13] = tr.origin.y;

--- a/src/variant/rect2.cpp
+++ b/src/variant/rect2.cpp
@@ -193,33 +193,33 @@ next4:
 		Vector2(position.x + size.x, position.y + size.y),
 	};
 
-	real_t maxa = p_xform.elements[0].dot(xf_points2[0]);
+	real_t maxa = p_xform.columns[0].dot(xf_points2[0]);
 	real_t mina = maxa;
 
-	real_t dp = p_xform.elements[0].dot(xf_points2[1]);
+	real_t dp = p_xform.columns[0].dot(xf_points2[1]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	dp = p_xform.elements[0].dot(xf_points2[2]);
+	dp = p_xform.columns[0].dot(xf_points2[2]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	dp = p_xform.elements[0].dot(xf_points2[3]);
+	dp = p_xform.columns[0].dot(xf_points2[3]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	real_t maxb = p_xform.elements[0].dot(xf_points[0]);
+	real_t maxb = p_xform.columns[0].dot(xf_points[0]);
 	real_t minb = maxb;
 
-	dp = p_xform.elements[0].dot(xf_points[1]);
+	dp = p_xform.columns[0].dot(xf_points[1]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 
-	dp = p_xform.elements[0].dot(xf_points[2]);
+	dp = p_xform.columns[0].dot(xf_points[2]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 
-	dp = p_xform.elements[0].dot(xf_points[3]);
+	dp = p_xform.columns[0].dot(xf_points[3]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 
@@ -230,33 +230,33 @@ next4:
 		return false;
 	}
 
-	maxa = p_xform.elements[1].dot(xf_points2[0]);
+	maxa = p_xform.columns[1].dot(xf_points2[0]);
 	mina = maxa;
 
-	dp = p_xform.elements[1].dot(xf_points2[1]);
+	dp = p_xform.columns[1].dot(xf_points2[1]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	dp = p_xform.elements[1].dot(xf_points2[2]);
+	dp = p_xform.columns[1].dot(xf_points2[2]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	dp = p_xform.elements[1].dot(xf_points2[3]);
+	dp = p_xform.columns[1].dot(xf_points2[3]);
 	maxa = Math::max(dp, maxa);
 	mina = Math::min(dp, mina);
 
-	maxb = p_xform.elements[1].dot(xf_points[0]);
+	maxb = p_xform.columns[1].dot(xf_points[0]);
 	minb = maxb;
 
-	dp = p_xform.elements[1].dot(xf_points[1]);
+	dp = p_xform.columns[1].dot(xf_points[1]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 
-	dp = p_xform.elements[1].dot(xf_points[2]);
+	dp = p_xform.columns[1].dot(xf_points[2]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 
-	dp = p_xform.elements[1].dot(xf_points[3]);
+	dp = p_xform.columns[1].dot(xf_points[3]);
 	maxb = Math::max(dp, maxb);
 	minb = Math::min(dp, minb);
 

--- a/src/variant/transform2d.cpp
+++ b/src/variant/transform2d.cpp
@@ -35,8 +35,8 @@ namespace godot {
 void Transform2D::invert() {
 	// FIXME: this function assumes the basis is a rotation matrix, with no scaling.
 	// Transform2D::affine_inverse can handle matrices with scaling, so GDScript should eventually use that.
-	SWAP(elements[0][1], elements[1][0]);
-	elements[2] = basis_xform(-elements[2]);
+	SWAP(columns[0][1], columns[1][0]);
+	columns[2] = basis_xform(-columns[2]);
 }
 
 Transform2D Transform2D::inverse() const {
@@ -52,11 +52,11 @@ void Transform2D::affine_invert() {
 #endif
 	real_t idet = 1.0 / det;
 
-	SWAP(elements[0][0], elements[1][1]);
-	elements[0] *= Vector2(idet, -idet);
-	elements[1] *= Vector2(-idet, idet);
+	SWAP(columns[0][0], columns[1][1]);
+	columns[0] *= Vector2(idet, -idet);
+	columns[1] *= Vector2(-idet, idet);
 
-	elements[2] = basis_xform(-elements[2]);
+	columns[2] = basis_xform(-columns[2]);
 }
 
 Transform2D Transform2D::affine_inverse() const {
@@ -71,61 +71,61 @@ void Transform2D::rotate(real_t p_phi) {
 
 real_t Transform2D::get_skew() const {
 	real_t det = basis_determinant();
-	return Math::acos(elements[0].normalized().dot(Math::sign(det) * elements[1].normalized())) - Math_PI * 0.5;
+	return Math::acos(columns[0].normalized().dot(Math::sign(det) * columns[1].normalized())) - Math_PI * 0.5;
 }
 
 void Transform2D::set_skew(float p_angle) {
 	real_t det = basis_determinant();
-	elements[1] = Math::sign(det) * elements[0].rotated((Math_PI * 0.5 + p_angle)).normalized() * elements[1].length();
+	columns[1] = Math::sign(det) * columns[0].rotated((Math_PI * 0.5 + p_angle)).normalized() * columns[1].length();
 }
 
 real_t Transform2D::get_rotation() const {
-	return Math::atan2(elements[0].y, elements[0].x);
+	return Math::atan2(columns[0].y, columns[0].x);
 }
 
 void Transform2D::set_rotation(real_t p_rot) {
 	Size2 scale = get_scale();
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
-	elements[0][0] = cr;
-	elements[0][1] = sr;
-	elements[1][0] = -sr;
-	elements[1][1] = cr;
+	columns[0][0] = cr;
+	columns[0][1] = sr;
+	columns[1][0] = -sr;
+	columns[1][1] = cr;
 	set_scale(scale);
 }
 
 Transform2D::Transform2D(real_t p_rot, const Vector2 &p_pos) {
 	real_t cr = Math::cos(p_rot);
 	real_t sr = Math::sin(p_rot);
-	elements[0][0] = cr;
-	elements[0][1] = sr;
-	elements[1][0] = -sr;
-	elements[1][1] = cr;
-	elements[2] = p_pos;
+	columns[0][0] = cr;
+	columns[0][1] = sr;
+	columns[1][0] = -sr;
+	columns[1][1] = cr;
+	columns[2] = p_pos;
 }
 
 Size2 Transform2D::get_scale() const {
 	real_t det_sign = Math::sign(basis_determinant());
-	return Size2(elements[0].length(), det_sign * elements[1].length());
+	return Size2(columns[0].length(), det_sign * columns[1].length());
 }
 
 void Transform2D::set_scale(const Size2 &p_scale) {
-	elements[0].normalize();
-	elements[1].normalize();
-	elements[0] *= p_scale.x;
-	elements[1] *= p_scale.y;
+	columns[0].normalize();
+	columns[1].normalize();
+	columns[0] *= p_scale.x;
+	columns[1] *= p_scale.y;
 }
 
 void Transform2D::scale(const Size2 &p_scale) {
 	scale_basis(p_scale);
-	elements[2] *= p_scale;
+	columns[2] *= p_scale;
 }
 
 void Transform2D::scale_basis(const Size2 &p_scale) {
-	elements[0][0] *= p_scale.x;
-	elements[0][1] *= p_scale.y;
-	elements[1][0] *= p_scale.x;
-	elements[1][1] *= p_scale.y;
+	columns[0][0] *= p_scale.x;
+	columns[0][1] *= p_scale.y;
+	columns[1][0] *= p_scale.x;
+	columns[1][1] *= p_scale.y;
 }
 
 void Transform2D::translate(real_t p_tx, real_t p_ty) {
@@ -133,21 +133,21 @@ void Transform2D::translate(real_t p_tx, real_t p_ty) {
 }
 
 void Transform2D::translate(const Vector2 &p_translation) {
-	elements[2] += basis_xform(p_translation);
+	columns[2] += basis_xform(p_translation);
 }
 
 void Transform2D::orthonormalize() {
 	// Gram-Schmidt Process
 
-	Vector2 x = elements[0];
-	Vector2 y = elements[1];
+	Vector2 x = columns[0];
+	Vector2 y = columns[1];
 
 	x.normalize();
 	y = (y - x * (x.dot(y)));
 	y.normalize();
 
-	elements[0] = x;
-	elements[1] = y;
+	columns[0] = x;
+	columns[1] = y;
 }
 
 Transform2D Transform2D::orthonormalized() const {
@@ -157,12 +157,12 @@ Transform2D Transform2D::orthonormalized() const {
 }
 
 bool Transform2D::is_equal_approx(const Transform2D &p_transform) const {
-	return elements[0].is_equal_approx(p_transform.elements[0]) && elements[1].is_equal_approx(p_transform.elements[1]) && elements[2].is_equal_approx(p_transform.elements[2]);
+	return columns[0].is_equal_approx(p_transform.columns[0]) && columns[1].is_equal_approx(p_transform.columns[1]) && columns[2].is_equal_approx(p_transform.columns[2]);
 }
 
 bool Transform2D::operator==(const Transform2D &p_transform) const {
 	for (int i = 0; i < 3; i++) {
-		if (elements[i] != p_transform.elements[i]) {
+		if (columns[i] != p_transform.columns[i]) {
 			return false;
 		}
 	}
@@ -172,7 +172,7 @@ bool Transform2D::operator==(const Transform2D &p_transform) const {
 
 bool Transform2D::operator!=(const Transform2D &p_transform) const {
 	for (int i = 0; i < 3; i++) {
-		if (elements[i] != p_transform.elements[i]) {
+		if (columns[i] != p_transform.columns[i]) {
 			return true;
 		}
 	}
@@ -181,19 +181,19 @@ bool Transform2D::operator!=(const Transform2D &p_transform) const {
 }
 
 void Transform2D::operator*=(const Transform2D &p_transform) {
-	elements[2] = xform(p_transform.elements[2]);
+	columns[2] = xform(p_transform.columns[2]);
 
 	real_t x0, x1, y0, y1;
 
-	x0 = tdotx(p_transform.elements[0]);
-	x1 = tdoty(p_transform.elements[0]);
-	y0 = tdotx(p_transform.elements[1]);
-	y1 = tdoty(p_transform.elements[1]);
+	x0 = tdotx(p_transform.columns[0]);
+	x1 = tdoty(p_transform.columns[0]);
+	y0 = tdotx(p_transform.columns[1]);
+	y1 = tdoty(p_transform.columns[1]);
 
-	elements[0][0] = x0;
-	elements[0][1] = x1;
-	elements[1][0] = y0;
-	elements[1][1] = y1;
+	columns[0][0] = x0;
+	columns[0][1] = x1;
+	columns[1][0] = y0;
+	columns[1][1] = y1;
 }
 
 Transform2D Transform2D::operator*(const Transform2D &p_transform) const {
@@ -216,7 +216,7 @@ Transform2D Transform2D::basis_scaled(const Size2 &p_scale) const {
 
 Transform2D Transform2D::untranslated() const {
 	Transform2D copy = *this;
-	copy.elements[2] = Vector2();
+	copy.columns[2] = Vector2();
 	return copy;
 }
 
@@ -233,7 +233,7 @@ Transform2D Transform2D::rotated(real_t p_phi) const {
 }
 
 real_t Transform2D::basis_determinant() const {
-	return elements[0].x * elements[1].y - elements[0].y * elements[1].x;
+	return columns[0].x * columns[1].y - columns[0].y * columns[1].x;
 }
 
 Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t p_c) const {
@@ -272,7 +272,7 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t
 }
 
 Transform2D::operator String() const {
-	return elements[0].operator String() + ", " + elements[1].operator String() + ", " + elements[2].operator String();
+	return columns[0].operator String() + ", " + columns[1].operator String() + ", " + columns[2].operator String();
 }
 
 } // namespace godot


### PR DESCRIPTION
This PR is the same as https://github.com/godotengine/godot/pull/60627 but for godot-cpp.

There are still more changes needed to sync these types with the engine, but this rename is the single largest/noisiest change, so I think it deserves a PR of its own.