### PR TITLE
Update Vector2/2i/3/3i/4/4i to match the engine

### DIFF
--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -45,6 +45,8 @@ class Vector2 {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 2;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -72,10 +74,6 @@ public:
 	_FORCE_INLINE_ const real_t &operator[](int p_idx) const {
 		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
-	}
-
-	_FORCE_INLINE_ void set_all(const real_t p_value) {
-		x = y = p_value;
 	}
 
 	_FORCE_INLINE_ Vector2::Axis min_axis_index() const {
@@ -119,6 +117,7 @@ public:
 	_FORCE_INLINE_ Vector2 lerp(const Vector2 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector2 slerp(const Vector2 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector2 cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight) const;
+	_FORCE_INLINE_ Vector2 cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
 	_FORCE_INLINE_ Vector2 bezier_interpolate(const Vector2 &p_control_1, const Vector2 &p_control_2, const Vector2 &p_end, const real_t p_t) const;
 
 	Vector2 move_toward(const Vector2 &p_to, const real_t p_delta) const;
@@ -128,6 +127,7 @@ public:
 	Vector2 reflect(const Vector2 &p_normal) const;
 
 	bool is_equal_approx(const Vector2 &p_v) const;
+	bool is_zero_approx() const;
 
 	Vector2 operator+(const Vector2 &p_v) const;
 	void operator+=(const Vector2 &p_v);
@@ -272,6 +272,13 @@ Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, c
 	Vector2 res = *this;
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
+	return res;
+}
+
+Vector2 Vector2::cubic_interpolate_in_time(const Vector2 &p_b, const Vector2 &p_pre_a, const Vector2 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+	Vector2 res = *this;
+	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	return res;
 }
 

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -45,6 +45,8 @@ class Vector2i {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 2;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -122,7 +124,7 @@ public:
 
 	real_t aspect() const { return width / (real_t)height; }
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
-	Vector2i abs() const { return Vector2i(ABS(x), ABS(y)); }
+	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }
 	Vector2i clamp(const Vector2i &p_min, const Vector2i &p_max) const;
 
 	operator String() const;

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -47,6 +47,8 @@ class Vector3 {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 3;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -71,13 +73,6 @@ public:
 	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
-	}
-
-	void set_axis(const int p_axis, const real_t p_value);
-	real_t get_axis(const int p_axis) const;
-
-	_FORCE_INLINE_ void set_all(const real_t p_value) {
-		x = y = z = p_value;
 	}
 
 	_FORCE_INLINE_ Vector3::Axis min_axis_index() const {
@@ -110,12 +105,15 @@ public:
 	_FORCE_INLINE_ Vector3 lerp(const Vector3 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector3 slerp(const Vector3 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ Vector3 cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const;
+	_FORCE_INLINE_ Vector3 cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
 	_FORCE_INLINE_ Vector3 bezier_interpolate(const Vector3 &p_control_1, const Vector3 &p_control_2, const Vector3 &p_end, const real_t p_t) const;
 
 	Vector3 move_toward(const Vector3 &p_to, const real_t p_delta) const;
 
 	Vector2 octahedron_encode() const;
 	static Vector3 octahedron_decode(const Vector2 &p_oct);
+	Vector2 octahedron_tangent_encode(const float sign) const;
+	static Vector3 octahedron_tangent_decode(const Vector2 &p_oct, float *sign);
 
 	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_with) const;
 	_FORCE_INLINE_ real_t dot(const Vector3 &p_with) const;
@@ -144,6 +142,7 @@ public:
 	_FORCE_INLINE_ Vector3 reflect(const Vector3 &p_normal) const;
 
 	bool is_equal_approx(const Vector3 &p_v) const;
+	bool is_zero_approx() const;
 
 	/* Operators */
 
@@ -222,16 +221,25 @@ Vector3 Vector3::lerp(const Vector3 &p_to, const real_t p_weight) const {
 }
 
 Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
+	// This method seems more complicated than it really is, since we write out
+	// the internals of some methods for efficiency (mainly, checking length).
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
 	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
 		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
 		return lerp(p_to, p_weight);
 	}
+	Vector3 axis = cross(p_to);
+	real_t axis_length_sq = axis.length_squared();
+	if (unlikely(axis_length_sq == 0.0f)) {
+		// Colinear vectors have no rotation axis or angle between them, so the best we can do is lerp.
+		return lerp(p_to, p_weight);
+	}
+	axis /= Math::sqrt(axis_length_sq);
 	real_t start_length = Math::sqrt(start_length_sq);
 	real_t result_length = Math::lerp(start_length, Math::sqrt(end_length_sq), p_weight);
 	real_t angle = angle_to(p_to);
-	return rotated(cross(p_to).normalized(), angle * p_weight) * (result_length / start_length);
+	return rotated(axis, angle * p_weight) * (result_length / start_length);
 }
 
 Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight) const {
@@ -239,6 +247,14 @@ Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, c
 	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
 	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
 	res.z = Math::cubic_interpolate(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight);
+	return res;
+}
+
+Vector3 Vector3::cubic_interpolate_in_time(const Vector3 &p_b, const Vector3 &p_pre_a, const Vector3 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+	Vector3 res = *this;
+	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.z = Math::cubic_interpolate_in_time(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
 	return res;
 }
 

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -45,6 +45,8 @@ class Vector3i {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 3;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -70,9 +72,6 @@ public:
 		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
-
-	void set_axis(const int p_axis, const int32_t p_value);
-	int32_t get_axis(const int p_axis) const;
 
 	Vector3i::Axis min_axis_index() const;
 	Vector3i::Axis max_axis_index() const;
@@ -135,7 +134,7 @@ double Vector3i::length() const {
 }
 
 Vector3i Vector3i::abs() const {
-	return Vector3i(ABS(x), ABS(y), ABS(z));
+	return Vector3i(Math::abs(x), Math::abs(y), Math::abs(z));
 }
 
 Vector3i Vector3i::sign() const {

--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -44,6 +44,8 @@ class Vector4 {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 4;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -61,30 +63,46 @@ public:
 		real_t components[4] = { 0, 0, 0, 0 };
 	};
 
-	_FORCE_INLINE_ real_t &operator[](int idx) {
-		return components[idx];
+	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
+		DEV_ASSERT((unsigned int)p_axis < 4);
+		return components[p_axis];
 	}
-	_FORCE_INLINE_ const real_t &operator[](int idx) const {
-		return components[idx];
+	_FORCE_INLINE_ const real_t &operator[](const int p_axis) const {
+		DEV_ASSERT((unsigned int)p_axis < 4);
+		return components[p_axis];
 	}
+
+	Vector4::Axis min_axis_index() const;
+	Vector4::Axis max_axis_index() const;
+
 	_FORCE_INLINE_ real_t length_squared() const;
 	bool is_equal_approx(const Vector4 &p_vec4) const;
+	bool is_zero_approx() const;
 	real_t length() const;
 	void normalize();
 	Vector4 normalized() const;
 	bool is_normalized() const;
+
+	real_t distance_to(const Vector4 &p_to) const;
+	real_t distance_squared_to(const Vector4 &p_to) const;
+	Vector4 direction_to(const Vector4 &p_to) const;
+
 	Vector4 abs() const;
 	Vector4 sign() const;
 	Vector4 floor() const;
 	Vector4 ceil() const;
 	Vector4 round() const;
+	Vector4 lerp(const Vector4 &p_to, const real_t p_weight) const;
+	Vector4 cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const;
+	Vector4 cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const;
 
-	Vector4::Axis min_axis_index() const;
-	Vector4::Axis max_axis_index() const;
+	Vector4 posmod(const real_t p_mod) const;
+	Vector4 posmodv(const Vector4 &p_modv) const;
+	void snap(const Vector4 &p_step);
+	Vector4 snapped(const Vector4 &p_step) const;
 	Vector4 clamp(const Vector4 &p_min, const Vector4 &p_max) const;
 
 	Vector4 inverse() const;
-	Vector4 lerp(const Vector4 &p_to, const real_t p_weight) const;
 	_FORCE_INLINE_ real_t dot(const Vector4 &p_vec4) const;
 
 	_FORCE_INLINE_ void operator+=(const Vector4 &p_vec4);
@@ -197,7 +215,7 @@ Vector4 Vector4::operator/(const Vector4 &p_vec4) const {
 }
 
 Vector4 Vector4::operator-() const {
-	return Vector4(x, y, z, w);
+	return Vector4(-x, -y, -z, -w);
 }
 
 Vector4 Vector4::operator*(const real_t &s) const {
@@ -221,15 +239,12 @@ bool Vector4::operator<(const Vector4 &p_v) const {
 		if (y == p_v.y) {
 			if (z == p_v.z) {
 				return w < p_v.w;
-			} else {
-				return z < p_v.z;
 			}
-		} else {
-			return y < p_v.y;
+			return z < p_v.z;
 		}
-	} else {
-		return x < p_v.x;
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector4::operator>(const Vector4 &p_v) const {
@@ -237,15 +252,12 @@ bool Vector4::operator>(const Vector4 &p_v) const {
 		if (y == p_v.y) {
 			if (z == p_v.z) {
 				return w > p_v.w;
-			} else {
-				return z > p_v.z;
 			}
-		} else {
-			return y > p_v.y;
+			return z > p_v.z;
 		}
-	} else {
-		return x > p_v.x;
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 bool Vector4::operator<=(const Vector4 &p_v) const {
@@ -253,15 +265,12 @@ bool Vector4::operator<=(const Vector4 &p_v) const {
 		if (y == p_v.y) {
 			if (z == p_v.z) {
 				return w <= p_v.w;
-			} else {
-				return z < p_v.z;
 			}
-		} else {
-			return y < p_v.y;
+			return z < p_v.z;
 		}
-	} else {
-		return x < p_v.x;
+		return y < p_v.y;
 	}
+	return x < p_v.x;
 }
 
 bool Vector4::operator>=(const Vector4 &p_v) const {
@@ -269,15 +278,12 @@ bool Vector4::operator>=(const Vector4 &p_v) const {
 		if (y == p_v.y) {
 			if (z == p_v.z) {
 				return w >= p_v.w;
-			} else {
-				return z > p_v.z;
 			}
-		} else {
-			return y > p_v.y;
+			return z > p_v.z;
 		}
-	} else {
-		return x > p_v.x;
+		return y > p_v.y;
 	}
+	return x > p_v.x;
 }
 
 _FORCE_INLINE_ Vector4 operator*(const float p_scalar, const Vector4 &p_vec) {
@@ -298,4 +304,4 @@ _FORCE_INLINE_ Vector4 operator*(const int64_t p_scalar, const Vector4 &p_vec) {
 
 } // namespace godot
 
-#endif // GODOT_VECTOR3_HPP
+#endif // GODOT_VECTOR4_HPP

--- a/include/godot_cpp/variant/vector4i.hpp
+++ b/include/godot_cpp/variant/vector4i.hpp
@@ -45,6 +45,8 @@ class Vector4i {
 	friend class Variant;
 
 public:
+	static const int AXIS_COUNT = 4;
+
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,
@@ -64,10 +66,12 @@ public:
 	};
 
 	_FORCE_INLINE_ const int32_t &operator[](const int p_axis) const {
+		DEV_ASSERT((unsigned int)p_axis < 4);
 		return coord[p_axis];
 	}
 
 	_FORCE_INLINE_ int32_t &operator[](const int p_axis) {
+		DEV_ASSERT((unsigned int)p_axis < 4);
 		return coord[p_axis];
 	}
 
@@ -137,11 +141,11 @@ double Vector4i::length() const {
 }
 
 Vector4i Vector4i::abs() const {
-	return Vector4i(ABS(x), ABS(y), ABS(z), ABS(w));
+	return Vector4i(Math::abs(x), Math::abs(y), Math::abs(z), Math::abs(w));
 }
 
 Vector4i Vector4i::sign() const {
-	return Vector4i(SIGN(x), SIGN(y), SIGN(z), SIGN(w));
+	return Vector4i(Math::sign(x), Math::sign(y), Math::sign(z), Math::sign(w));
 }
 
 /* Operators */

--- a/src/variant/vector2.cpp
+++ b/src/variant/vector2.cpp
@@ -184,6 +184,10 @@ bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y);
 }
 
+bool Vector2::is_zero_approx() const {
+	return Math::is_zero_approx(x) && Math::is_zero_approx(y);
+}
+
 Vector2::operator String() const {
 	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ")";
 }

--- a/src/variant/vector3.cpp
+++ b/src/variant/vector3.cpp
@@ -47,16 +47,6 @@ Vector3 Vector3::rotated(const Vector3 &p_axis, const real_t p_angle) const {
 	return r;
 }
 
-void Vector3::set_axis(const int p_axis, const real_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 3);
-	coord[p_axis] = p_value;
-}
-
-real_t Vector3::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 3, 0);
-	return operator[](p_axis);
-}
-
 Vector3 Vector3::clamp(const Vector3 &p_min, const Vector3 &p_max) const {
 	return Vector3(
 			CLAMP(x, p_min.x, p_max.x),
@@ -119,16 +109,36 @@ Vector3 Vector3::octahedron_decode(const Vector2 &p_oct) {
 	return n.normalized();
 }
 
-Basis Vector3::outer(const Vector3 &p_with) const {
-	Vector3 row0(x * p_with.x, x * p_with.y, x * p_with.z);
-	Vector3 row1(y * p_with.x, y * p_with.y, y * p_with.z);
-	Vector3 row2(z * p_with.x, z * p_with.y, z * p_with.z);
+Vector2 Vector3::octahedron_tangent_encode(const float sign) const {
+	Vector2 res = this->octahedron_encode();
+	res.y = res.y * 0.5f + 0.5f;
+	res.y = sign >= 0.0f ? res.y : 1 - res.y;
+	return res;
+}
 
-	return Basis(row0, row1, row2);
+Vector3 Vector3::octahedron_tangent_decode(const Vector2 &p_oct, float *sign) {
+	Vector2 oct_compressed = p_oct;
+	oct_compressed.y = oct_compressed.y * 2 - 1;
+	*sign = oct_compressed.y >= 0.0f ? 1.0f : -1.0f;
+	oct_compressed.y = Math::abs(oct_compressed.y);
+	Vector3 res = Vector3::octahedron_decode(oct_compressed);
+	return res;
+}
+
+Basis Vector3::outer(const Vector3 &p_with) const {
+	Basis basis;
+	basis.rows[0] = Vector3(x * p_with.x, x * p_with.y, x * p_with.z);
+	basis.rows[1] = Vector3(y * p_with.x, y * p_with.y, y * p_with.z);
+	basis.rows[2] = Vector3(z * p_with.x, z * p_with.y, z * p_with.z);
+	return basis;
 }
 
 bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 	return Math::is_equal_approx(x, p_v.x) && Math::is_equal_approx(y, p_v.y) && Math::is_equal_approx(z, p_v.z);
+}
+
+bool Vector3::is_zero_approx() const {
+	return Math::is_zero_approx(x) && Math::is_zero_approx(y) && Math::is_zero_approx(z);
 }
 
 Vector3::operator String() const {

--- a/src/variant/vector3i.cpp
+++ b/src/variant/vector3i.cpp
@@ -35,16 +35,6 @@
 
 namespace godot {
 
-void Vector3i::set_axis(const int p_axis, const int32_t p_value) {
-	ERR_FAIL_INDEX(p_axis, 3);
-	coord[p_axis] = p_value;
-}
-
-int32_t Vector3i::get_axis(const int p_axis) const {
-	ERR_FAIL_INDEX_V(p_axis, 3, 0);
-	return operator[](p_axis);
-}
-
 Vector3i::Axis Vector3i::min_axis_index() const {
 	return x < y ? (x < z ? Vector3i::AXIS_X : Vector3i::AXIS_Z) : (y < z ? Vector3i::AXIS_Y : Vector3i::AXIS_Z);
 }

--- a/src/variant/vector4.cpp
+++ b/src/variant/vector4.cpp
@@ -30,13 +30,41 @@
 
 #include <godot_cpp/variant/vector4.hpp>
 
-#include <godot_cpp/variant/basis.hpp>
+#include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/vector4i.hpp>
 
 namespace godot {
 
+Vector4::Axis Vector4::min_axis_index() const {
+	uint32_t min_index = 0;
+	real_t min_value = x;
+	for (uint32_t i = 1; i < 4; i++) {
+		if (operator[](i) <= min_value) {
+			min_index = i;
+			min_value = operator[](i);
+		}
+	}
+	return Vector4::Axis(min_index);
+}
+
+Vector4::Axis Vector4::max_axis_index() const {
+	uint32_t max_index = 0;
+	real_t max_value = x;
+	for (uint32_t i = 1; i < 4; i++) {
+		if (operator[](i) > max_value) {
+			max_index = i;
+			max_value = operator[](i);
+		}
+	}
+	return Vector4::Axis(max_index);
+}
+
 bool Vector4::is_equal_approx(const Vector4 &p_vec4) const {
 	return Math::is_equal_approx(x, p_vec4.x) && Math::is_equal_approx(y, p_vec4.y) && Math::is_equal_approx(z, p_vec4.z) && Math::is_equal_approx(w, p_vec4.w);
+}
+
+bool Vector4::is_zero_approx() const {
+	return Math::is_zero_approx(x) && Math::is_zero_approx(y) && Math::is_zero_approx(z) && Math::is_zero_approx(w);
 }
 
 real_t Vector4::length() const {
@@ -44,15 +72,40 @@ real_t Vector4::length() const {
 }
 
 void Vector4::normalize() {
-	*this /= length();
+	real_t lengthsq = length_squared();
+	if (lengthsq == 0) {
+		x = y = z = w = 0;
+	} else {
+		real_t length = Math::sqrt(lengthsq);
+		x /= length;
+		y /= length;
+		z /= length;
+		w /= length;
+	}
 }
 
 Vector4 Vector4::normalized() const {
-	return *this / length();
+	Vector4 v = *this;
+	v.normalize();
+	return v;
 }
 
 bool Vector4::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); // use less epsilon
+	return Math::is_equal_approx(length_squared(), (real_t)1, (real_t)UNIT_EPSILON);
+}
+
+real_t Vector4::distance_to(const Vector4 &p_to) const {
+	return (p_to - *this).length();
+}
+
+real_t Vector4::distance_squared_to(const Vector4 &p_to) const {
+	return (p_to - *this).length_squared();
+}
+
+Vector4 Vector4::direction_to(const Vector4 &p_to) const {
+	Vector4 ret(p_to.x - x, p_to.y - y, p_to.z - z, p_to.w - w);
+	ret.normalize();
+	return ret;
 }
 
 Vector4 Vector4::abs() const {
@@ -75,10 +128,6 @@ Vector4 Vector4::round() const {
 	return Vector4(Math::round(x), Math::round(y), Math::round(z), Math::round(w));
 }
 
-Vector4 Vector4::inverse() const {
-	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
-}
-
 Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
 	return Vector4(
 			x + (p_weight * (p_to.x - x)),
@@ -87,28 +136,47 @@ Vector4 Vector4::lerp(const Vector4 &p_to, const real_t p_weight) const {
 			w + (p_weight * (p_to.w - w)));
 }
 
-Vector4::Axis Vector4::min_axis_index() const {
-	uint32_t min_index = 0;
-	real_t min_value = x;
-	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) < min_value) {
-			min_index = i;
-			min_value = operator[](i);
-		}
-	}
-	return Vector4::Axis(min_index);
+Vector4 Vector4::cubic_interpolate(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight) const {
+	Vector4 res = *this;
+	res.x = Math::cubic_interpolate(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight);
+	res.y = Math::cubic_interpolate(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight);
+	res.z = Math::cubic_interpolate(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight);
+	res.w = Math::cubic_interpolate(res.w, p_b.w, p_pre_a.w, p_post_b.w, p_weight);
+	return res;
 }
 
-Vector4::Axis Vector4::max_axis_index() const {
-	uint32_t max_index = 0;
-	real_t max_value = x;
-	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) > max_value) {
-			max_index = i;
-			max_value = operator[](i);
-		}
-	}
-	return Vector4::Axis(max_index);
+Vector4 Vector4::cubic_interpolate_in_time(const Vector4 &p_b, const Vector4 &p_pre_a, const Vector4 &p_post_b, const real_t p_weight, const real_t &p_b_t, const real_t &p_pre_a_t, const real_t &p_post_b_t) const {
+	Vector4 res = *this;
+	res.x = Math::cubic_interpolate_in_time(res.x, p_b.x, p_pre_a.x, p_post_b.x, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.y = Math::cubic_interpolate_in_time(res.y, p_b.y, p_pre_a.y, p_post_b.y, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.z = Math::cubic_interpolate_in_time(res.z, p_b.z, p_pre_a.z, p_post_b.z, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	res.w = Math::cubic_interpolate_in_time(res.w, p_b.w, p_pre_a.w, p_post_b.w, p_weight, p_b_t, p_pre_a_t, p_post_b_t);
+	return res;
+}
+
+Vector4 Vector4::posmod(const real_t p_mod) const {
+	return Vector4(Math::fposmod(x, p_mod), Math::fposmod(y, p_mod), Math::fposmod(z, p_mod), Math::fposmod(w, p_mod));
+}
+
+Vector4 Vector4::posmodv(const Vector4 &p_modv) const {
+	return Vector4(Math::fposmod(x, p_modv.x), Math::fposmod(y, p_modv.y), Math::fposmod(z, p_modv.z), Math::fposmod(w, p_modv.w));
+}
+
+void Vector4::snap(const Vector4 &p_step) {
+	x = Math::snapped(x, p_step.x);
+	y = Math::snapped(y, p_step.y);
+	z = Math::snapped(z, p_step.z);
+	w = Math::snapped(w, p_step.w);
+}
+
+Vector4 Vector4::snapped(const Vector4 &p_step) const {
+	Vector4 v = *this;
+	v.snap(p_step);
+	return v;
+}
+
+Vector4 Vector4::inverse() const {
+	return Vector4(1.0f / x, 1.0f / y, 1.0f / z, 1.0f / w);
 }
 
 Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {
@@ -122,5 +190,7 @@ Vector4 Vector4::clamp(const Vector4 &p_min, const Vector4 &p_max) const {
 Vector4::operator String() const {
 	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ", " + String::num_real(w, false) + ")";
 }
+
+static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
 
 } // namespace godot

--- a/src/variant/vector4i.cpp
+++ b/src/variant/vector4i.cpp
@@ -49,7 +49,7 @@ Vector4i::Axis Vector4i::min_axis_index() const {
 	uint32_t min_index = 0;
 	int32_t min_value = x;
 	for (uint32_t i = 1; i < 4; i++) {
-		if (operator[](i) < min_value) {
+		if (operator[](i) <= min_value) {
 			min_index = i;
 			min_value = operator[](i);
 		}
@@ -86,10 +86,12 @@ Vector4i::operator Vector4() const {
 }
 
 Vector4i::Vector4i(const Vector4 &p_vec4) {
-	x = p_vec4.x;
-	y = p_vec4.y;
-	z = p_vec4.z;
-	w = p_vec4.w;
+	x = (int32_t)p_vec4.x;
+	y = (int32_t)p_vec4.y;
+	z = (int32_t)p_vec4.z;
+	w = (int32_t)p_vec4.w;
 }
+
+static_assert(sizeof(Vector4i) == 4 * sizeof(int32_t));
 
 } // namespace godot


### PR DESCRIPTION
This PR updates godot-cpp with recent changes to Vector2/2i/3/3i/4/4i in the engine.