### PR TITLE
Use `struct` instead of `class` for core structures

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -362,7 +362,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
     result.append("")
 
     for type_name in used_classes:
-        if is_native_struct(type_name):
+        if is_struct_type(type_name):
             result.append(f"struct {type_name};")
         else:
             result.append(f"class {type_name};")
@@ -1109,7 +1109,7 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
     result.append("")
 
     for type_name in used_classes:
-        if is_native_struct(type_name):
+        if is_struct_type(type_name):
             result.append(f"struct {type_name};")
         else:
             result.append(f"class {type_name};")
@@ -1826,15 +1826,18 @@ def is_pod_type(type_name):
 
 
 def is_included_type(type_name):
-    """
-    Those are types for which we already have a class file implemented.
-    """
+    # Types which we already have implemented.
+    return is_included_struct_type(type_name) or type_name in ["ObjectID"]
+
+
+def is_included_struct_type(type_name):
+    # Struct types which we already have implemented.
     return type_name in [
         "AABB",
         "Basis",
         "Color",
-        "ObjectID",
         "Plane",
+        "Projection",
         "Quaternion",
         "Rect2",
         "Rect2i",
@@ -1846,7 +1849,6 @@ def is_included_type(type_name):
         "Vector3i",
         "Vector4",
         "Vector4i",
-        "Projection",
     ]
 
 
@@ -1922,9 +1924,10 @@ def is_engine_class(type_name):
     return type_name == "Object" or type_name in engine_classes
 
 
-def is_native_struct(type_name):
+def is_struct_type(type_name):
+    # This is used to determine which keyword to use for forward declarations.
     global native_structures
-    return type_name in native_structures
+    return is_included_struct_type(type_name) or type_name in native_structures
 
 
 def is_refcounted(type_name):

--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -72,6 +72,10 @@
 #endif
 #endif
 
+#ifndef _NO_DISCARD_
+#define _NO_DISCARD_ [[nodiscard]]
+#endif
+
 // Windows badly defines a lot of stuff we'll never use. Undefine it.
 #ifdef _WIN32
 #undef min // override standard definition

--- a/include/godot_cpp/variant/aabb.hpp
+++ b/include/godot_cpp/variant/aabb.hpp
@@ -43,12 +43,7 @@
 
 namespace godot {
 
-class AABB {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ AABB {
 	Vector3 position;
 	Vector3 size;
 

--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -37,12 +37,7 @@
 
 namespace godot {
 
-class Basis {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Basis {
 	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),

--- a/include/godot_cpp/variant/color.hpp
+++ b/include/godot_cpp/variant/color.hpp
@@ -37,12 +37,7 @@ namespace godot {
 
 class String;
 
-class Color {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Color {
 	union {
 		struct {
 			float r;

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -37,12 +37,7 @@
 
 namespace godot {
 
-class Plane {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Plane {
 	Vector3 normal;
 	real_t d = 0;
 

--- a/include/godot_cpp/variant/projection.hpp
+++ b/include/godot_cpp/variant/projection.hpp
@@ -39,18 +39,13 @@
 
 namespace godot {
 
-class AABB;
-class Plane;
-class Rect2;
-class Transform3D;
-class Vector2;
+struct AABB;
+struct Plane;
+struct Rect2;
+struct Transform3D;
+struct Vector2;
 
-class Projection {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Projection {
 	enum Planes {
 		PLANE_NEAR,
 		PLANE_FAR,

--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -36,12 +36,7 @@
 
 namespace godot {
 
-class Quaternion {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Quaternion {
 	union {
 		struct {
 			real_t x;

--- a/include/godot_cpp/variant/rect2.hpp
+++ b/include/godot_cpp/variant/rect2.hpp
@@ -37,16 +37,11 @@
 
 namespace godot {
 
-class Rect2i;
 class String;
-class Transform2D;
+struct Rect2i;
+struct Transform2D;
 
-class Rect2 {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Rect2 {
 	Point2 position;
 	Size2 size;
 

--- a/include/godot_cpp/variant/rect2i.hpp
+++ b/include/godot_cpp/variant/rect2i.hpp
@@ -37,15 +37,10 @@
 
 namespace godot {
 
-class Rect2;
 class String;
+struct Rect2;
 
-class Rect2i {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Rect2i {
 	Point2i position;
 	Size2i size;
 

--- a/include/godot_cpp/variant/transform2d.hpp
+++ b/include/godot_cpp/variant/transform2d.hpp
@@ -39,12 +39,7 @@
 
 namespace godot {
 
-class Transform2D {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of columns array, the basis matrix looks like "on paper":
 	// M = (columns[0][0] columns[1][0])
 	//     (columns[0][1] columns[1][1])

--- a/include/godot_cpp/variant/transform3d.hpp
+++ b/include/godot_cpp/variant/transform3d.hpp
@@ -39,12 +39,7 @@
 
 namespace godot {
 
-class Transform3D {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Transform3D {
 	Basis basis;
 	Vector3 origin;
 

--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -37,14 +37,9 @@
 namespace godot {
 
 class String;
-class Vector2i;
+struct Vector2i;
 
-class Vector2 {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector2 {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -37,14 +37,9 @@
 namespace godot {
 
 class String;
-class Vector2;
+struct Vector2;
 
-class Vector2i {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector2i {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -36,17 +36,12 @@
 
 namespace godot {
 
-class Basis;
 class String;
-class Vector2;
-class Vector3i;
+struct Basis;
+struct Vector2;
+struct Vector3i;
 
-class Vector3 {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector3 {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -37,14 +37,9 @@
 namespace godot {
 
 class String;
-class Vector3;
+struct Vector3;
 
-class Vector3i {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector3i {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -38,12 +38,7 @@ namespace godot {
 
 class String;
 
-class Vector4 {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector4 {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector4i.hpp
+++ b/include/godot_cpp/variant/vector4i.hpp
@@ -37,14 +37,9 @@
 namespace godot {
 
 class String;
-class Vector4;
+struct Vector4;
 
-class Vector4i {
-	_FORCE_INLINE_ GDNativeTypePtr _native_ptr() const { return (void *)this; }
-
-	friend class Variant;
-
-public:
+struct _NO_DISCARD_ Vector4i {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -107,67 +107,67 @@ Variant::Variant(const String &v) {
 }
 
 Variant::Variant(const Vector2 &v) {
-	from_type_constructor[VECTOR2](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR2](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Vector2i &v) {
-	from_type_constructor[VECTOR2I](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR2I](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Rect2 &v) {
-	from_type_constructor[RECT2](_native_ptr(), v._native_ptr());
+	from_type_constructor[RECT2](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Rect2i &v) {
-	from_type_constructor[RECT2I](_native_ptr(), v._native_ptr());
+	from_type_constructor[RECT2I](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Vector3 &v) {
-	from_type_constructor[VECTOR3](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR3](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Vector3i &v) {
-	from_type_constructor[VECTOR3I](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR3I](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Transform2D &v) {
-	from_type_constructor[TRANSFORM2D](_native_ptr(), v._native_ptr());
+	from_type_constructor[TRANSFORM2D](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Vector4 &v) {
-	from_type_constructor[VECTOR4](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR4](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Vector4i &v) {
-	from_type_constructor[VECTOR4I](_native_ptr(), v._native_ptr());
+	from_type_constructor[VECTOR4I](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Plane &v) {
-	from_type_constructor[PLANE](_native_ptr(), v._native_ptr());
+	from_type_constructor[PLANE](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Quaternion &v) {
-	from_type_constructor[QUATERNION](_native_ptr(), v._native_ptr());
+	from_type_constructor[QUATERNION](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const godot::AABB &v) {
-	from_type_constructor[AABB](_native_ptr(), v._native_ptr());
+	from_type_constructor[AABB](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Basis &v) {
-	from_type_constructor[BASIS](_native_ptr(), v._native_ptr());
+	from_type_constructor[BASIS](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Transform3D &v) {
-	from_type_constructor[TRANSFORM3D](_native_ptr(), v._native_ptr());
+	from_type_constructor[TRANSFORM3D](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Projection &v) {
-	from_type_constructor[PROJECTION](_native_ptr(), v._native_ptr());
+	from_type_constructor[PROJECTION](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const Color &v) {
-	from_type_constructor[COLOR](_native_ptr(), v._native_ptr());
+	from_type_constructor[COLOR](_native_ptr(), (GDNativeTypePtr)&v);
 }
 
 Variant::Variant(const StringName &v) {
@@ -289,97 +289,97 @@ Variant::operator String() const {
 
 Variant::operator Vector2() const {
 	Vector2 result;
-	to_type_constructor[VECTOR2](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR2]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Vector2i() const {
 	Vector2i result;
-	to_type_constructor[VECTOR2I](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR2I]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Rect2() const {
 	Rect2 result;
-	to_type_constructor[RECT2](result._native_ptr(), _native_ptr());
+	to_type_constructor[RECT2]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Rect2i() const {
 	Rect2i result;
-	to_type_constructor[RECT2I](result._native_ptr(), _native_ptr());
+	to_type_constructor[RECT2I]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Vector3() const {
 	Vector3 result;
-	to_type_constructor[VECTOR3](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR3]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Vector3i() const {
 	Vector3i result;
-	to_type_constructor[VECTOR3I](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR3I]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Transform2D() const {
 	Transform2D result;
-	to_type_constructor[TRANSFORM2D](result._native_ptr(), _native_ptr());
+	to_type_constructor[TRANSFORM2D]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Vector4() const {
 	Vector4 result;
-	to_type_constructor[VECTOR4](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR4]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Vector4i() const {
 	Vector4i result;
-	to_type_constructor[VECTOR4I](result._native_ptr(), _native_ptr());
+	to_type_constructor[VECTOR4I]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Plane() const {
 	Plane result;
-	to_type_constructor[PLANE](result._native_ptr(), _native_ptr());
+	to_type_constructor[PLANE]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Quaternion() const {
 	Quaternion result;
-	to_type_constructor[QUATERNION](result._native_ptr(), _native_ptr());
+	to_type_constructor[QUATERNION]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator godot::AABB() const {
 	godot::AABB result;
-	to_type_constructor[AABB](result._native_ptr(), _native_ptr());
+	to_type_constructor[AABB]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Basis() const {
 	Basis result;
-	to_type_constructor[BASIS](result._native_ptr(), _native_ptr());
+	to_type_constructor[BASIS]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Transform3D() const {
 	Transform3D result;
-	to_type_constructor[TRANSFORM3D](result._native_ptr(), _native_ptr());
+	to_type_constructor[TRANSFORM3D]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Projection() const {
 	Projection result;
-	to_type_constructor[PROJECTION](result._native_ptr(), _native_ptr());
+	to_type_constructor[PROJECTION]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 
 Variant::operator Color() const {
 	Color result;
-	to_type_constructor[COLOR](result._native_ptr(), _native_ptr());
+	to_type_constructor[COLOR]((GDNativeTypePtr)&result, _native_ptr());
 	return result;
 }
 


### PR DESCRIPTION
This PR does three things:

* Change `class` to `struct` for the core data structures and adjusts the bindings generator to handle this.
* Add `_NO_DISCARD_` to core data structures to match the engine.
* Remove `_native_ptr` from core data structures to match the engine (it's just a void pointer cast).

Why change `class` to `struct`? Here are several reasons:

* It matches what the core engine uses.
* `struct`'s default visibility is `public`, which all members are now that `_native_ptr` has been removed.
* `class` and `struct` are actually different things on MSVC. With godot-cpp's types defined with `class`, any forward declarations copied from an engine module like `struct Vector2;` will not work correctly on MSVC. This is actually something that I discovered after starting work on this PR, and it makes the case for it stronger.
* It sets the expectation for users that this is a data structure. This point is purely cosmetic.