### PR TITLE
Bind enums in built-in types and expose bindings for global constants

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -579,4 +579,7 @@ void call_with_ptr_args_static_method_ret(R (*p_method)(P...), const GDNativeTyp
 
 } // namespace godot
 
+#include <godot_cpp/classes/global_constants_binds.hpp>
+#include <godot_cpp/variant/builtin_binds.hpp>
+
 #endif // ! GODOT_CPP_BINDER_COMMON_HPP


### PR DESCRIPTION
Fixes #868.

This issue also manifests when implementing `PhysicsServer3DExtension` due to its interface relying on `Vector3::Axis` which currently has no binding.

This PR replicates what is [already happening](https://github.com/godotengine/godot/blob/61021c08f80856f8d99dfbe9fd3d338ef5f41999/core/variant/binder_common.h#L132-L163) on the editor side of things with regards to binding global and built-in enums.

It adds a new generated file called `<godot_cpp/variant/builtin_binds.hpp>` that contains a `VARIANT_CAST_ENUM` for every enum in every _included_ built-in type. This file is then included in `binder_common.hpp` to emulate the set of hardcoded `VARIANT_CAST_ENUM` that currently exists on the editor side of things (see link above).

This PR also changes `<godot_cpp/classes/global_constants_binds.hpp>` to be exposed in a similar way. Previously this file was only included inside of generated `*.cpp` files and was not being exposed to the end-user, leading to cryptic compiler errors like the one described in #868.