### PR TITLE
Add more static checks and move to separate file to match main repo

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,31 +1,40 @@
-# Commented out parameters are those with the same value as base LLVM style
+# Commented out parameters are those with the same value as base LLVM style.
 # We can uncomment them if we want to change their value, or enforce the
-# chosen value in case the base style changes (last sync: Clang 6.0.1).
+# chosen value in case the base style changes (last sync: Clang 14.0).
 ---
 ### General config, applies to all languages ###
 BasedOnStyle:  LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
-# AlignConsecutiveAssignments: false
-# AlignConsecutiveDeclarations: false
+# AlignArrayOfStructures: None
+# AlignConsecutiveMacros: None
+# AlignConsecutiveAssignments: None
+# AlignConsecutiveBitFields: None
+# AlignConsecutiveDeclarations: None
 # AlignEscapedNewlines: Right
-# AlignOperands:   true
+AlignOperands:   DontAlign
 AlignTrailingComments: false
+# AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-# AllowShortBlocksOnASingleLine: false
+# AllowShortEnumsOnASingleLine: true
+# AllowShortBlocksOnASingleLine: Never
 # AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-# AllowShortIfStatementsOnASingleLine: false
+# AllowShortFunctionsOnASingleLine: All
+# AllowShortLambdasOnASingleLine: All
+# AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None
 # AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
-# AlwaysBreakTemplateDeclarations: false
+# AlwaysBreakTemplateDeclarations: MultiLine
+# AttributeMacros:
+#   - __capability
 # BinPackArguments: true
 # BinPackParameters: true
 # BraceWrapping:
+#   AfterCaseLabel:  false
 #   AfterClass:      false
-#   AfterControlStatement: false
+#   AfterControlStatement: Never
 #   AfterEnum:       false
 #   AfterFunction:   false
 #   AfterNamespace:  false
@@ -35,32 +44,44 @@ AllowShortFunctionsOnASingleLine: Inline
 #   AfterExternBlock: false
 #   BeforeCatch:     false
 #   BeforeElse:      false
+#   BeforeLambdaBody: false
+#   BeforeWhile:     false
 #   IndentBraces:    false
 #   SplitEmptyFunction: true
 #   SplitEmptyRecord: true
 #   SplitEmptyNamespace: true
 # BreakBeforeBinaryOperators: None
+# BreakBeforeConceptDeclarations: true
 # BreakBeforeBraces: Attach
 # BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: false
+# BreakInheritanceList: BeforeColon
+# BreakBeforeTernaryOperators: true
 # BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
 # BreakStringLiterals: true
 ColumnLimit:     0
 # CommentPragmas:  '^ IWYU pragma:'
+# QualifierAlignment: Leave
 # CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: false
+# DeriveLineEnding: true
 # DerivePointerAlignment: false
 # DisableFormat:   false
+# EmptyLineAfterAccessModifier: Never
+# EmptyLineBeforeAccessModifier: LogicalBlock
 # ExperimentalAutoDetectBinPacking: false
+# PackConstructorInitializers: BinPack
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# AllowAllConstructorInitializersOnNextLine: true
 # FixNamespaceComments: true
 # ForEachMacros:
 #   - foreach
 #   - Q_FOREACH
 #   - BOOST_FOREACH
+# IfMacros:
+#   - KJ_IF_MAYBE
 # IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '".*"'
@@ -70,13 +91,21 @@ IncludeCategories:
   - Regex:           '^<.*'
     Priority:        3
 # IncludeIsMainRegex: '(Test)?$'
+# IncludeIsMainSourceRegex: ''
+# IndentAccessModifiers: false
 IndentCaseLabels: true
+# IndentCaseBlocks: false
+# IndentGotoLabels: true
 # IndentPPDirectives: None
+# IndentExternBlock: AfterExternBlock
+# IndentRequires:  false
 IndentWidth:     4
 # IndentWrappedFunctionNames: false
+# InsertTrailingCommas: None
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+# LambdaBodyIndentation: Signature
 # MacroBlockBegin: ''
 # MacroBlockEnd:   ''
 # MaxEmptyLinesToKeep: 1
@@ -85,39 +114,81 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 # PenaltyBreakBeforeFirstCallParameter: 19
 # PenaltyBreakComment: 300
 # PenaltyBreakFirstLessLess: 120
+# PenaltyBreakOpenParenthesis: 0
 # PenaltyBreakString: 1000
+# PenaltyBreakTemplateDeclaration: 10
 # PenaltyExcessCharacter: 1000000
 # PenaltyReturnTypeOnItsOwnLine: 60
+# PenaltyIndentedWhitespace: 0
 # PointerAlignment: Right
-# RawStringFormats:
-#   - Delimiter:       pb
-#     Language:        TextProto
-#     BasedOnStyle:    google
+# PPIndentWidth:   -1
+# ReferenceAlignment: Pointer
 # ReflowComments:  true
-# SortIncludes:    true
+# RemoveBracesLLVM: false
+# SeparateDefinitionBlocks: Leave
+# ShortNamespaceLines: 1
+# SortIncludes:    CaseSensitive
+# SortJavaStaticImport: Before
 # SortUsingDeclarations: true
 # SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
 # SpaceAfterTemplateKeyword: true
 # SpaceBeforeAssignmentOperators: true
+# SpaceBeforeCaseColon: false
+# SpaceBeforeCpp11BracedList: false
+# SpaceBeforeCtorInitializerColon: true
+# SpaceBeforeInheritanceColon: true
 # SpaceBeforeParens: ControlStatements
+# SpaceBeforeParensOptions:
+#   AfterControlStatements: true
+#   AfterForeachMacros: true
+#   AfterFunctionDefinitionName: false
+#   AfterFunctionDeclarationName: false
+#   AfterIfMacros:   true
+#   AfterOverloadedOperator: false
+#   BeforeNonEmptyParentheses: false
+# SpaceAroundPointerQualifiers: Default
+# SpaceBeforeRangeBasedForLoopColon: true
+# SpaceInEmptyBlock: false
 # SpaceInEmptyParentheses: false
 # SpacesBeforeTrailingComments: 1
-# SpacesInAngles:  false
+# SpacesInAngles:  Never
+# SpacesInConditionalStatement: false
 # SpacesInContainerLiterals: true
 # SpacesInCStyleCastParentheses: false
+## Godot TODO: We'll want to use a min of 1, but we need to see how to fix
+## our comment capitalization at the same time.
+SpacesInLineCommentPrefix:
+  Minimum:         0
+  Maximum:         -1
 # SpacesInParentheses: false
 # SpacesInSquareBrackets: false
+# SpaceBeforeSquareBrackets: false
+# BitFieldColonSpacing: Both
+# StatementAttributeLikeMacros:
+#   - Q_EMIT
+# StatementMacros:
+#   - Q_UNUSED
+#   - QT_REQUIRE_VERSION
 TabWidth:        4
+# UseCRLF:         false
 UseTab:          Always
+# WhitespaceSensitiveMacros:
+#   - STRINGIZE
+#   - PP_STRINGIZE
+#   - BOOST_PP_STRINGIZE
+#   - NS_SWIFT_NAME
+#   - CF_SWIFT_NAME
 ---
 ### C++ specific config ###
 Language:        Cpp
-Standard:        Cpp11
+Standard:        c++17
 ---
 ### ObjC specific config ###
 Language:        ObjC
-Standard:        Cpp11
+# ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
+# ObjCBreakBeforeNestedBlockParam: true
 # ObjCSpaceAfterProperty: false
 # ObjCSpaceBeforeProtocolList: true
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,35 +192,3 @@ jobs:
         run: |
           cd test && cmake -DCMAKE_BUILD_TYPE=Release -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -G"Visual Studio 16 2019" .
           cmake --build . --verbose
-
-  static-checks:
-    name: 📊 Static Checks (clang-format)
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Make apt sources.list use the default Ubuntu repositories
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
-          sudo apt-get update
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -qq dos2unix recode clang-format-11
-          sudo update-alternatives --remove-all clang-format
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 100
-          python -m pip install black==22.3.0
-
-      - name: Style checks via clang-format
-        run: |
-          bash ./misc/scripts/clang_format.sh
-
-      - name: Python style checks via black (black_format.sh)
-        run: |
-          bash ./misc/scripts/black_format.sh
-
-      - name: Bindings generation checks (ensures get_file_list returns all generated files)
-        run: |
-          python ./misc/scripts/check_get_file_list.py

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,54 @@
+name: 📊 Static Checks
+on: [push, pull_request]
+
+concurrency:
+  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-static
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: Format (clang-format, black format, file format)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Azure repositories are not reliable, we need to prevent Azure giving us packages.
+      - name: Make apt sources.list use the default Ubuntu repositories
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
+          sudo apt-get update
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -qq dos2unix recode clang-format-13 libxml2-utils python3-pip moreutils
+          sudo update-alternatives --remove-all clang-format || true
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-13 100
+          sudo pip3 install black==22.3.0 pygments pytest==7.1.2 mypy==0.971
+
+      - name: File formatting checks (file_format.sh)
+        run: |
+          bash ./misc/scripts/file_format.sh
+
+      - name: Header guards formatting checks (header_guards.sh)
+        run: |
+          bash ./misc/scripts/header_guards.sh
+
+      - name: Python style checks via black (black_format.sh)
+        run: |
+          bash ./misc/scripts/black_format.sh
+
+      - name: Python scripts static analysis (mypy_check.sh)
+        run: |
+          bash ./misc/scripts/mypy_check.sh
+
+      - name: Bindings generation checks (ensures get_file_list returns all generated files)
+        run: |
+          python ./misc/scripts/check_get_file_list.py
+
+      - name: Style checks via clang-format (clang_format.sh)
+        run: |
+          bash ./misc/scripts/clang_format.sh

--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_REF_HPP
-#define GODOT_CPP_REF_HPP
+#ifndef GODOT_REF_HPP
+#define GODOT_REF_HPP
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -281,4 +281,4 @@ struct GetTypeInfo<const Ref<T> &, typename EnableIf<TypeInherits<RefCounted, T>
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_REF_HPP
+#endif // GODOT_REF_HPP

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_WRAPPED_HPP
-#define GODOT_CPP_WRAPPED_HPP
+#ifndef GODOT_WRAPPED_HPP
+#define GODOT_WRAPPED_HPP
 
 #include <godot_cpp/core/memory.hpp>
 
@@ -384,4 +384,4 @@ public:                                                                         
 	};                                                                                                             \
 	m_class() : m_class(#m_class) {}
 
-#endif // ! GODOT_CPP_WRAPPED_HPP
+#endif // GODOT_WRAPPED_HPP

--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_BINDER_COMMON_HPP
-#define GODOT_CPP_BINDER_COMMON_HPP
+#ifndef GODOT_BINDER_COMMON_HPP
+#define GODOT_BINDER_COMMON_HPP
 
 #include <godot/gdnative_interface.h>
 
@@ -582,4 +582,4 @@ void call_with_ptr_args_static_method_ret(R (*p_method)(P...), const GDNativeTyp
 #include <godot_cpp/classes/global_constants_binds.hpp>
 #include <godot_cpp/variant/builtin_binds.hpp>
 
-#endif // ! GODOT_CPP_BINDER_COMMON_HPP
+#endif // GODOT_BINDER_COMMON_HPP

--- a/include/godot_cpp/core/builtin_ptrcall.hpp
+++ b/include/godot_cpp/core/builtin_ptrcall.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_BUILTIN_PTRCALL_HPP
-#define GODOT_CPP_BUILTIN_PTRCALL_HPP
+#ifndef GODOT_BUILTIN_PTRCALL_HPP
+#define GODOT_BUILTIN_PTRCALL_HPP
 
 #include <godot/gdnative_interface.h>
 
@@ -77,4 +77,4 @@ T _call_builtin_ptr_getter(const GDNativePtrGetter getter, const GDNativeTypePtr
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_BUILTIN_PTRCALL_HPP
+#endif // GODOT_BUILTIN_PTRCALL_HPP

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CLASS_DB_HPP
-#define CLASS_DB_HPP
+#ifndef GODOT_CLASS_DB_HPP
+#define GODOT_CLASS_DB_HPP
 
 #include <godot/gdnative_interface.h>
 
@@ -254,4 +254,4 @@ MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, const char *p_name, M 
 
 } // namespace godot
 
-#endif // ! CLASS_DB_HPP
+#endif // GODOT_CLASS_DB_HPP

--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef DEFS_H
-#define DEFS_H
+#ifndef GODOT_DEFS_HPP
+#define GODOT_DEFS_HPP
 
 #include <cstddef>
 #include <cstdint>
@@ -127,4 +127,4 @@ struct BuildIndexSequence : BuildIndexSequence<N - 1, N - 1, Is...> {};
 template <size_t... Is>
 struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 
-#endif // ! DEFS_H
+#endif // GODOT_DEFS_HPP

--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_ENGINE_PTRCALL_HPP
-#define GODOT_CPP_ENGINE_PTRCALL_HPP
+#ifndef GODOT_ENGINE_PTRCALL_HPP
+#define GODOT_ENGINE_PTRCALL_HPP
 
 #include <godot/gdnative_interface.h>
 
@@ -94,4 +94,4 @@ void _call_utility_no_ret(const GDNativePtrUtilityFunction func, const Args &...
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_ENGINE_PTRCALL_HPP
+#endif // GODOT_ENGINE_PTRCALL_HPP

--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_ERROR_MACROS_HPP
-#define GODOT_CPP_ERROR_MACROS_HPP
+#ifndef GODOT_ERROR_MACROS_HPP
+#define GODOT_ERROR_MACROS_HPP
 
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/variant/string.hpp>
@@ -614,4 +614,4 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define CHECK_METHOD_BIND(m_mb)
 #endif
 
-#endif // ! GODOT_CPP_ERROR_MACROS_HPP
+#endif // GODOT_ERROR_MACROS_HPP

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_MEMORY_HPP
-#define GODOT_CPP_MEMORY_HPP
+#ifndef GODOT_MEMORY_HPP
+#define GODOT_MEMORY_HPP
 
 #include <cstddef>
 #include <cstdint>
@@ -187,4 +187,4 @@ struct _GlobalNilClass {
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_MEMORY_HPP
+#endif // GODOT_MEMORY_HPP

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_METHOD_BIND_HPP
-#define GODOT_CPP_METHOD_BIND_HPP
+#ifndef GODOT_METHOD_BIND_HPP
+#define GODOT_METHOD_BIND_HPP
 
 #include <godot_cpp/core/binder_common.hpp>
 #include <godot_cpp/core/type_info.hpp>
@@ -734,4 +734,4 @@ MethodBind *create_static_method_bind(R (*p_method)(P...)) {
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_METHOD_BIND_HPP
+#endif // GODOT_METHOD_BIND_HPP

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_METHOD_PTRCALL_HPP
-#define GODOT_CPP_METHOD_PTRCALL_HPP
+#ifndef GODOT_METHOD_PTRCALL_HPP
+#define GODOT_METHOD_PTRCALL_HPP
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -230,4 +230,4 @@ GDVIRTUAL_NATIVE_PTR(double);
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_METHOD_PTRCALL_HPP
+#endif // GODOT_METHOD_PTRCALL_HPP

--- a/include/godot_cpp/core/mutex_lock.hpp
+++ b/include/godot_cpp/core/mutex_lock.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MUTEX_LOCK_HPP
-#define MUTEX_LOCK_HPP
+#ifndef GODOT_MUTEX_LOCK_HPP
+#define GODOT_MUTEX_LOCK_HPP
 
 #include <godot_cpp/classes/mutex.hpp>
 
@@ -56,4 +56,4 @@ public:
 
 } // namespace godot
 
-#endif // ! MUTEX_LOCK_HPP
+#endif // GODOT_MUTEX_LOCK_HPP

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -158,4 +158,4 @@ const T *Object::cast_to(const Object *p_object) {
 
 } // namespace godot
 
-#endif // ! GODOT_OBJECT_HPP
+#endif // GODOT_OBJECT_HPP

--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -72,4 +72,4 @@ struct PropertyInfo {
 
 } // namespace godot
 
-#endif // ! GODOT_OBJECT_HPP
+#endif // GODOT_PROPERTY_INFO_HPP

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -66,7 +66,7 @@ struct TypeInherits {
 	static char (&test(...))[2];
 
 	static bool const value = sizeof(test(get_d())) == sizeof(char) &&
-							  !TypesAreSame<B volatile const, void volatile const>::value;
+			!TypesAreSame<B volatile const, void volatile const>::value;
 };
 
 static GDNativePropertyInfo make_property_info(GDNativeVariantType p_type, const char *p_name, uint32_t p_hint = PROPERTY_HINT_NONE, const char *p_hint_string = "", uint32_t p_usage = PROPERTY_USAGE_DEFAULT, const char *p_class_name = "") {
@@ -389,4 +389,4 @@ MAKE_TYPED_ARRAY_INFO(Vector<Color>, Variant::PACKED_COLOR_ARRAY)
 
 } // namespace godot
 
-#endif // ! GODOT_TYPE_INFO_HPP
+#endif // GODOT_TYPE_INFO_HPP

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_HPP
-#define GODOT_HPP
+#ifndef GODOT_GODOT_HPP
+#define GODOT_GODOT_HPP
 
 #include <godot/gdnative_interface.h>
 
@@ -84,4 +84,4 @@ public:
 
 } // namespace godot
 
-#endif // ! GODOT_HPP
+#endif // GODOT_GODOT_HPP

--- a/include/godot_cpp/templates/cowdata.hpp
+++ b/include/godot_cpp/templates/cowdata.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef COWDATA_HPP
-#define COWDATA_HPP
+#ifndef GODOT_COWDATA_HPP
+#define GODOT_COWDATA_HPP
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -389,4 +389,4 @@ CowData<T>::~CowData() {
 
 } // namespace godot
 
-#endif // ! COWDATA_HPP
+#endif // GODOT_COWDATA_HPP

--- a/include/godot_cpp/templates/hash_map.hpp
+++ b/include/godot_cpp/templates/hash_map.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef HASH_MAP_HPP
-#define HASH_MAP_HPP
+#ifndef GODOT_HASH_MAP_HPP
+#define GODOT_HASH_MAP_HPP
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -588,4 +588,4 @@ public:
 
 } // namespace godot
 
-#endif // HASH_MAP_HPP
+#endif // GODOT_HASH_MAP_HPP

--- a/include/godot_cpp/templates/hash_set.hpp
+++ b/include/godot_cpp/templates/hash_set.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef HASH_SET_HPP
-#define HASH_SET_HPP
+#ifndef GODOT_HASH_SET_HPP
+#define GODOT_HASH_SET_HPP
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -474,4 +474,4 @@ public:
 
 } // namespace godot
 
-#endif // HASH_SET_HPP
+#endif // GODOT_HASH_SET_HPP

--- a/include/godot_cpp/templates/hashfuncs.hpp
+++ b/include/godot_cpp/templates/hashfuncs.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef HASHFUNCS_HPP
-#define HASHFUNCS_HPP
+#ifndef GODOT_HASHFUNCS_HPP
+#define GODOT_HASHFUNCS_HPP
 
 // Needed for fastmod.
 #if defined(_MSC_VER)
@@ -523,4 +523,4 @@ static _FORCE_INLINE_ uint32_t fastmod(const uint32_t n, const uint64_t c, const
 
 } // namespace godot
 
-#endif // HASHFUNCS_HPP
+#endif // GODOT_HASHFUNCS_HPP

--- a/include/godot_cpp/templates/list.hpp
+++ b/include/godot_cpp/templates/list.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef LIST_HPP
-#define LIST_HPP
+#ifndef GODOT_LIST_HPP
+#define GODOT_LIST_HPP
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -766,4 +766,4 @@ public:
 
 } // namespace godot
 
-#endif // ! LIST_HPP
+#endif // GODOT_LIST_HPP

--- a/include/godot_cpp/templates/pair.hpp
+++ b/include/godot_cpp/templates/pair.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef PAIR_HPP
-#define PAIR_HPP
+#ifndef GODOT_PAIR_HPP
+#define GODOT_PAIR_HPP
 
 namespace godot {
 
@@ -104,4 +104,4 @@ struct KeyValueSort {
 
 } // namespace godot
 
-#endif // ! PAIR_HPP
+#endif // GODOT_PAIR_HPP

--- a/include/godot_cpp/templates/rb_map.hpp
+++ b/include/godot_cpp/templates/rb_map.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RB_MAP_HPP
-#define RB_MAP_HPP
+#ifndef GODOT_RB_MAP_HPP
+#define GODOT_RB_MAP_HPP
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -762,4 +762,4 @@ public:
 
 } // namespace godot
 
-#endif // MAP_HPP
+#endif // GODOT_RB_MAP_HPP

--- a/include/godot_cpp/templates/rb_set.hpp
+++ b/include/godot_cpp/templates/rb_set.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RB_SET_HPP
-#define RB_SET_HPP
+#ifndef GODOT_RB_SET_HPP
+#define GODOT_RB_SET_HPP
 
 #include <godot_cpp/core/memory.hpp>
 
@@ -711,4 +711,4 @@ public:
 
 } // namespace godot
 
-#endif // SET_HPP
+#endif // GODOT_RB_SET_HPP

--- a/include/godot_cpp/templates/rid_owner.hpp
+++ b/include/godot_cpp/templates/rid_owner.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef RID_OWNER_HPP
-#define RID_OWNER_HPP
+#ifndef GODOT_RID_OWNER_HPP
+#define GODOT_RID_OWNER_HPP
 
 #include <godot_cpp/core/memory.hpp>
 #include <godot_cpp/godot.hpp>
@@ -462,4 +462,4 @@ public:
 
 } // namespace godot
 
-#endif // ! RID_OWNER_HPP
+#endif // GODOT_RID_OWNER_HPP

--- a/include/godot_cpp/templates/safe_refcount.hpp
+++ b/include/godot_cpp/templates/safe_refcount.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SAFE_REFCOUNT_HPP
-#define SAFE_REFCOUNT_HPP
+#ifndef GODOT_SAFE_REFCOUNT_HPP
+#define GODOT_SAFE_REFCOUNT_HPP
 
 #if !defined(NO_THREADS)
 
@@ -323,4 +323,4 @@ public:
 
 } // namespace godot
 
-#endif // ! SAFE_REFCOUNT_HPP
+#endif // GODOT_SAFE_REFCOUNT_HPP

--- a/include/godot_cpp/templates/search_array.hpp
+++ b/include/godot_cpp/templates/search_array.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SEARCH_ARRAY_HPP
-#define SEARCH_ARRAY_HPP
+#ifndef GODOT_SEARCH_ARRAY_HPP
+#define GODOT_SEARCH_ARRAY_HPP
 
 #include <godot_cpp/templates/sort_array.hpp>
 
@@ -68,4 +68,4 @@ public:
 
 } // namespace godot
 
-#endif // ! SEARCH_ARRAY_HPP
+#endif // GODOT_SEARCH_ARRAY_HPP

--- a/include/godot_cpp/templates/self_list.hpp
+++ b/include/godot_cpp/templates/self_list.hpp
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SELF_LIST_HPP
-#define SELF_LIST_HPP
+#ifndef GODOT_SELF_LIST_HPP
+#define GODOT_SELF_LIST_HPP
 
-#include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/core/error_macros.hpp>
 
 namespace godot {
 
@@ -140,4 +140,4 @@ public:
 
 } // namespace godot
 
-#endif // SELF_LIST_HPP
+#endif // GODOT_SELF_LIST_HPP

--- a/include/godot_cpp/templates/sort_array.hpp
+++ b/include/godot_cpp/templates/sort_array.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SORT_ARRAY_HPP
-#define SORT_ARRAY_HPP
+#ifndef GODOT_SORT_ARRAY_HPP
+#define GODOT_SORT_ARRAY_HPP
 
 #include <godot_cpp/core/error_macros.hpp>
 
@@ -320,4 +320,4 @@ public:
 
 } // namespace godot
 
-#endif // ! SORT_ARRAY_HPP
+#endif // GODOT_SORT_ARRAY_HPP

--- a/include/godot_cpp/templates/spin_lock.hpp
+++ b/include/godot_cpp/templates/spin_lock.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SPIN_LOCK_HPP
-#define SPIN_LOCK_HPP
+#ifndef GODOT_SPIN_LOCK_HPP
+#define GODOT_SPIN_LOCK_HPP
 
 #include <atomic>
 
@@ -51,4 +51,4 @@ public:
 
 } // namespace godot
 
-#endif // ! SPIN_LOCK_HPP
+#endif // GODOT_SPIN_LOCK_HPP

--- a/include/godot_cpp/templates/thread_work_pool.hpp
+++ b/include/godot_cpp/templates/thread_work_pool.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef THREAD_WORK_POOL_HPP
-#define THREAD_WORK_POOL_HPP
+#ifndef GODOT_THREAD_WORK_POOL_HPP
+#define GODOT_THREAD_WORK_POOL_HPP
 
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/semaphore.hpp>
@@ -202,4 +202,4 @@ public:
 
 } // namespace godot
 
-#endif // ! THREAD_WORK_POOL_HPP
+#endif // GODOT_THREAD_WORK_POOL_HPP

--- a/include/godot_cpp/templates/vector.hpp
+++ b/include/godot_cpp/templates/vector.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VECTOR_HPP
-#define VECTOR_HPP
+#ifndef GODOT_VECTOR_HPP
+#define GODOT_VECTOR_HPP
 
 /**
  * @class Vector
@@ -318,4 +318,4 @@ void Vector<T>::fill(T p_elem) {
 
 } // namespace godot
 
-#endif // ! VECTOR_HPP
+#endif // GODOT_VECTOR_HPP

--- a/include/godot_cpp/templates/vmap.hpp
+++ b/include/godot_cpp/templates/vmap.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VMAP_HPP
-#define VMAP_HPP
+#ifndef GODOT_VMAP_HPP
+#define GODOT_VMAP_HPP
 
 #include <godot_cpp/templates/cowdata.hpp>
 
@@ -201,4 +201,4 @@ public:
 
 } // namespace godot
 
-#endif // ! VMAP_H
+#endif // GODOT_VMAP_HPP

--- a/include/godot_cpp/templates/vset.hpp
+++ b/include/godot_cpp/templates/vset.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef VSET_HPP
-#define VSET_HPP
+#ifndef GODOT_VSET_HPP
+#define GODOT_VSET_HPP
 
 #include <godot_cpp/templates/vector.hpp>
 
@@ -142,4 +142,4 @@ public:
 
 } // namespace godot
 
-#endif // VSET_H
+#endif // GODOT_VSET_HPP

--- a/include/godot_cpp/variant/char_string.hpp
+++ b/include/godot_cpp/variant/char_string.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_CHAR_STRING_HPP
-#define GODOT_CPP_CHAR_STRING_HPP
+#ifndef GODOT_CHAR_STRING_HPP
+#define GODOT_CHAR_STRING_HPP
 
 #include <cstddef>
 #include <cstdint>
@@ -110,4 +110,4 @@ public:
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_CHAR_STRING_HPP
+#endif // GODOT_CHAR_STRING_HPP

--- a/include/godot_cpp/variant/char_utils.hpp
+++ b/include/godot_cpp/variant/char_utils.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CHAR_UTILS_HPP
-#define CHAR_UTILS_HPP
+#ifndef GODOT_CHAR_UTILS_HPP
+#define GODOT_CHAR_UTILS_HPP
 
 static _FORCE_INLINE_ bool is_ascii_upper_case(char32_t c) {
 	return (c >= 'A' && c <= 'Z');
@@ -87,4 +87,4 @@ static _FORCE_INLINE_ bool is_underscore(char32_t p_char) {
 	return (p_char == '_');
 }
 
-#endif // CHAR_UTILS_HPP
+#endif // GODOT_CHAR_UTILS_HPP

--- a/include/godot_cpp/variant/typed_array.hpp
+++ b/include/godot_cpp/variant/typed_array.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_TYPED_ARRAY_HPP
-#define GODOT_CPP_TYPED_ARRAY_HPP
+#ifndef GODOT_TYPED_ARRAY_HPP
+#define GODOT_TYPED_ARRAY_HPP
 
 #include <godot_cpp/variant/array.hpp>
 #include <godot_cpp/variant/variant.hpp>
@@ -123,4 +123,4 @@ MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
 
 } // namespace godot
 
-#endif // GODOT_CPP_TYPED_ARRAY_HPP
+#endif // GODOT_TYPED_ARRAY_HPP

--- a/include/godot_cpp/variant/ucaps.hpp
+++ b/include/godot_cpp/variant/ucaps.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef UCAPS_HPP
-#define UCAPS_HPP
+#ifndef GODOT_UCAPS_HPP
+#define GODOT_UCAPS_HPP
 
 // satan invented unicode?
 #define CAPS_LEN 666
@@ -1412,4 +1412,4 @@ static int _find_lower(int ch) {
 	return ch;
 }
 
-#endif // UCAPS_HPP
+#endif // GODOT_UCAPS_HPP

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef GODOT_CPP_VARIANT_HPP
-#define GODOT_CPP_VARIANT_HPP
+#ifndef GODOT_VARIANT_HPP
+#define GODOT_VARIANT_HPP
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -320,4 +320,4 @@ struct VariantComparator {
 
 } // namespace godot
 
-#endif // ! GODOT_CPP_VARIANT_HPP
+#endif // GODOT_VARIANT_HPP

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -6,8 +6,7 @@
 set -uo pipefail
 
 # Loops through all code files tracked by Git.
-git ls-files -- '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' '*.java' '*.glsl' \
-                ':!:.git/*' ':!:thirdparty/*' ':!:platform/android/java/lib/src/com/google/*' ':!:*-so_wrap.*' |
+git ls-files -- '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' |
 while read -r f; do
     # Run clang-format.
     clang-format --Wno-error=unknown -i "$f"

--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -15,29 +15,6 @@ IFS=$'\n\t'
 # Loops through all text files tracked by Git.
 git grep -zIl '' |
 while IFS= read -rd '' f; do
-    # Exclude some types of files.
-    if [[ "$f" == *"csproj" ]]; then
-        continue
-    elif [[ "$f" == *"sln" ]]; then
-        continue
-    elif [[ "$f" == *".bat" ]]; then
-        continue
-    elif [[ "$f" == *".out" ]]; then
-        # GDScript integration testing files.
-        continue
-    elif [[ "$f" == *"patch" ]]; then
-        continue
-    elif [[ "$f" == *"pot" ]]; then
-        continue
-    elif [[ "$f" == *"po" ]]; then
-        continue
-    elif [[ "$f" == "thirdparty"* ]]; then
-        continue
-    elif [[ "$f" == "platform/android/java/lib/src/com/google"* ]]; then
-        continue
-    elif [[ "$f" == *"-so_wrap."* ]]; then
-        continue
-    fi
     # Ensure that files are UTF-8 formatted.
     recode UTF-8 "$f" 2> /dev/null
     # Ensure that files have LF line endings and do not contain a BOM.

--- a/misc/scripts/header_guards.sh
+++ b/misc/scripts/header_guards.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ ! -f "SConstruct" ]; then
+  echo "Warning: This script is intended to be run from the root of the Godot repository."
+  echo "Some of the paths checks may not work as intended from a different folder."
+fi
+
+files_invalid_guard=""
+
+for file in $(find . -name "*.hpp" -print); do
+  # Skip generated files.
+  if [[ "$file" == "./gen/"* || "$file" == "./include/gen/"* ]]; then continue; fi
+  # Skip the test project.
+  if [[ "$file" == "./test/"* ]]; then continue; fi
+
+  bname=$(basename $file .hpp)
+
+  # NOTE: The "GODOT_CPP_" prefix is already used by the generated
+  # bindings, so we can't use that. We'll use "GODOT_" instead.
+  prefix="GODOT_"
+
+  # ^^ is bash builtin for UPPERCASE.
+  guard="${prefix}${bname^^}_HPP"
+
+  # Replaces guards to use computed name.
+  # We also add some \n to make sure there's a proper separation.
+  sed -i $file -e "0,/ifndef/s/#ifndef.*/\n#ifndef $guard/"
+  sed -i $file -e "0,/define/s/#define.*/#define $guard\n/"
+  sed -i $file -e "$ s/#endif.*/\n#endif \/\/ $guard/"
+  # Removes redundant \n added before, if they weren't needed.
+  sed -i $file -e "/^$/N;/^\n$/D"
+
+  # Check that first ifndef (should be header guard) is at the expected position.
+  # If not it can mean we have some code before the guard that should be after.
+  # "31" is the expected line with the copyright header.
+  first_ifndef=$(grep -n -m 1 "ifndef" $file | sed 's/\([0-9]*\).*/\1/')
+  if [[ "$first_ifndef" != "31" ]]; then
+    files_invalid_guard+="$file\n"
+  fi
+done
+
+if [[ ! -z "$files_invalid_guard" ]]; then
+  echo -e "The following files were found to have potentially invalid header guard:\n"
+  echo -e "$files_invalid_guard"
+fi
+
+diff=$(git diff --color)
+
+# If no diff has been generated all is OK, clean up, and exit.
+if [ -z "$diff" ] ; then
+    printf "Files in this commit comply with the header guards formatting rules.\n"
+    exit 0
+fi
+
+# A diff has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the header guards formatting rules:\n\n"
+echo "$diff"
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+exit 1

--- a/misc/scripts/mypy.ini
+++ b/misc/scripts/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+ignore_missing_imports = true
+disallow_any_generics = True
+pretty = True
+show_column_numbers = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unreachable = True
+
+namespace_packages = True
+explicit_package_bases = True

--- a/misc/scripts/mypy_check.sh
+++ b/misc/scripts/mypy_check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+echo -e "Python: mypy static analysis..."
+mypy --config-file=./misc/scripts/mypy.ini .

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -21,7 +21,7 @@ func _ready():
 	prints("Property list")
 	$Example.property_from_list = Vector3(100, 200, 300)
 	prints("  property value ", $Example.property_from_list)
-	
+
 	# Call methods.
 	prints("Instance method calls")
 	$Example.simple_func()


### PR DESCRIPTION
The first commit does the following:
* Update the `.clang-format` file to match the main repo.
* Put static checks in their own file to match the main repo.
* Add `file_format.sh` check.
* Add `header_guards.sh` check.
* Add `mypy_check.sh` check (blind copy/paste from the engine, but it seems to work fine).

The second commit runs the scripts to format the code and make the CI checks pass.