### PR TITLE
Use enum type in GDExtension info structs for better readability

### DIFF
--- a/godot-headers/godot/gdnative_interface.h
+++ b/godot-headers/godot/gdnative_interface.h
@@ -201,18 +201,18 @@ typedef GDNativeBool (*GDNativeExtensionClassGet)(GDExtensionClassInstancePtr p_
 typedef uint64_t (*GDNativeExtensionClassGetRID)(GDExtensionClassInstancePtr p_instance);
 
 typedef struct {
-	uint32_t type;
+	GDNativeVariantType type;
 	const char *name;
 	const char *class_name;
-	uint32_t hint;
+	uint32_t hint; // Bitfield of `PropertyHint` (defined in `extension_api.json`)
 	const char *hint_string;
-	uint32_t usage;
+	uint32_t usage; // Bitfield of `PropertyUsageFlags` (defined in `extension_api.json`)
 } GDNativePropertyInfo;
 
 typedef struct {
 	const char *name;
 	GDNativePropertyInfo return_value;
-	uint32_t flags; // From GDNativeExtensionClassMethodFlags
+	uint32_t flags; // Bitfield of `GDNativeExtensionClassMethodFlags`
 	int32_t id;
 	GDNativePropertyInfo *arguments;
 	uint32_t argument_count;
@@ -293,7 +293,7 @@ typedef struct {
 	void *method_userdata;
 	GDNativeExtensionClassMethodCall call_func;
 	GDNativeExtensionClassMethodPtrCall ptrcall_func;
-	uint32_t method_flags; /* GDNativeExtensionClassMethodFlags */
+	uint32_t method_flags; // Bitfield of `GDNativeExtensionClassMethodFlags`
 	uint32_t argument_count;
 	GDNativeBool has_return_value;
 	GDNativeExtensionClassMethodGetArgumentType get_argument_type_func;

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -219,7 +219,7 @@ public:                                                                         
 				cls->plist = reinterpret_cast<GDNativePropertyInfo *>(memalloc(sizeof(GDNativePropertyInfo) * list.size()));                             \
 				cls->plist_size = 0;                                                                                                                     \
 				for (const ::godot::PropertyInfo &E : list) {                                                                                            \
-					cls->plist[cls->plist_size].type = E.type;                                                                                           \
+					cls->plist[cls->plist_size].type = static_cast<GDNativeVariantType>(E.type);                                                         \
 					cls->plist[cls->plist_size].name = _alloc_and_copy_cstr(E.name.utf8().get_data());                                                   \
 					cls->plist[cls->plist_size].hint = E.hint;                                                                                           \
 					cls->plist[cls->plist_size].hint_string = _alloc_and_copy_cstr(E.hint_string.utf8().get_data());                                     \

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -182,7 +182,7 @@ public:
 			for (int i = 0; i < p_method_info.arguments.size(); i++) {
 				names.push_back(p_method_info.arguments[i].name.utf8().get_data());
 				arguments.push_back(GDNativePropertyInfo{
-						static_cast<uint32_t>(p_method_info.arguments[i].type), // uint32_t type;
+						static_cast<GDNativeVariantType>(p_method_info.arguments[i].type), // GDNativeVariantType type;
 						_alloc_and_copy_cstr(p_method_info.arguments[i].name.utf8().get_data()), // const char *name;
 						_alloc_and_copy_cstr(p_method_info.arguments[i].class_name.utf8().get_data()), // const char *class_name;
 						p_method_info.arguments[i].hint, // NONE //uint32_t hint;

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -95,7 +95,7 @@ void ClassDB::add_property(const char *p_class, const PropertyInfo &p_pinfo, con
 
 	// register with Godot
 	GDNativePropertyInfo prop_info = {
-		static_cast<uint32_t>(p_pinfo.type), // uint32_t type;
+		static_cast<GDNativeVariantType>(p_pinfo.type), // GDNativeVariantType type;
 		_alloc_and_copy_cstr(p_pinfo.name.utf8().get_data()), // const char *name;
 		_alloc_and_copy_cstr(p_pinfo.class_name.utf8().get_data()), // const char *class_name;
 		p_pinfo.hint, // NONE //uint32_t hint;
@@ -241,7 +241,7 @@ void ClassDB::add_signal(const char *p_class, const MethodInfo &p_signal) {
 
 	for (const PropertyInfo &par : p_signal.arguments) {
 		parameters.push_back(GDNativePropertyInfo{
-				static_cast<uint32_t>(par.type), // uint32_t type;
+				static_cast<GDNativeVariantType>(par.type), // GDNativeVariantType type;
 				_alloc_and_copy_cstr(par.name.utf8().get_data()), // const char *name;
 				_alloc_and_copy_cstr(par.class_name.utf8().get_data()), // const char *class_name;
 				par.hint, // NONE //uint32_t hint;


### PR DESCRIPTION
This is related the fix for once https://github.com/godotengine/godot/pull/67138 is merged