### PR TITLE
Fix use-after-free when deleting objects from extension terminator

### DIFF
--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -79,11 +79,12 @@ void GDExtensionBinding::initialize_level(void *userdata, GDNativeInitialization
 
 void GDExtensionBinding::deinitialize_level(void *userdata, GDNativeInitializationLevel p_level) {
 	ClassDB::current_level = p_level;
-	ClassDB::deinitialize(p_level);
 
 	if (terminate_callback) {
 		terminate_callback(static_cast<ModuleInitializationLevel>(p_level));
 	}
+
+	ClassDB::deinitialize(p_level);
 }
 
 void GDExtensionBinding::InitObject::register_initializer(Callback p_init) const {


### PR DESCRIPTION
Fixes #890.

Flipping the order of `ClassDB::deinitialize` and `terminate_callback` seems to fix the issue, and mirrors what's already happening in [`GDExtensionBinding::initialize_level`](https://github.com/godotengine/godot-cpp/blob/6696bebfa6b57d529172bf6ad679ed1b793fccb3/src/godot.cpp#L70-L78).