### PR TITLE
Fix use-after-free at shutdown

### DIFF
--- a/godot-headers/godot/gdextension_interface.h
+++ b/godot-headers/godot/gdextension_interface.h
@@ -544,6 +544,7 @@ typedef struct {
 
 	void *(*object_get_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, const GDExtensionInstanceBindingCallbacks *p_callbacks);
 	void (*object_set_instance_binding)(GDExtensionObjectPtr p_o, void *p_token, void *p_binding, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+	void (*object_clear_instance_binding)(GDExtensionObjectPtr p_o, void *p_token);
 
 	void (*object_set_instance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
 


### PR DESCRIPTION
Fixes #889.

Depends on https://github.com/godotengine/godot/pull/67285.

This PR adds a local static struct instance to the generated singleton getters, which has its destructor called when the extension library unloads. This allows the singleton bindings to be cleared and deallocated through `gdn_interface->object_clear_instance_binding` before the underlying singletons gets destroyed, thereby preventing the use-after-free described in the issue.

To help with the case where the extension library unload happens _after_ a singleton is destroyed, and thereby making `singleton_obj` stale, I've also added a `*_destroyed` bool that gets set in the bindings destructor.

Here is an example of what the generated singleton bindings would look like:

```diff
+static bool OS_singleton_destroyed = false;
+
 OS *OS::get_singleton() {
     static GDNativeObjectPtr singleton_obj = internal::gdn_interface->global_get_singleton("OS");
 #ifdef DEBUG_ENABLED
     ERR_FAIL_COND_V(singleton_obj == nullptr, nullptr);
 #endif // DEBUG_ENABLED
     static OS *singleton = reinterpret_cast<OS *>(internal::gdn_interface->object_get_instance_binding(singleton_obj, internal::token, &OS::___binding_callbacks));
+    static struct OS_BindingCleanup {
+        ~OS_BindingCleanup() {
+            if (!OS_singleton_destroyed) {
+                internal::gdn_interface->object_clear_instance_binding(singleton_obj, internal::token);
+            }
+        }
+    } binding_cleanup;
     return singleton;
 }
+
+OS::~OS() {
+    OS_singleton_destroyed = true;
+}
```