### PR TITLE
Add missing bindings for GDNativePtr<void>.

### DIFF
--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -211,6 +211,7 @@ struct PtrToArg<const T *> {
 		}                                                                           \
 	}
 
+GDVIRTUAL_NATIVE_PTR(void);
 GDVIRTUAL_NATIVE_PTR(bool);
 GDVIRTUAL_NATIVE_PTR(char);
 GDVIRTUAL_NATIVE_PTR(char16_t);


### PR DESCRIPTION
Re-synced with [upstream](https://github.com/godotengine/godot/blob/master/core/variant/native_ptr.h#L127) (where we should move `AudioFrame` out of core and into servers, since that's auto-generated).