### PR TITLE
Inherited methods bindings

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -117,6 +117,9 @@ public:
 	template <class T>
 	static void register_abstract_class();
 
+	template <class C, class N, class M, typename... VarArgs>
+	static MethodBind *bind_inherited_method(N p_method_name, M p_method, VarArgs... p_args);
+
 	template <class N, class M, typename... VarArgs>
 	static MethodBind *bind_method(N p_method_name, M p_method, VarArgs... p_args);
 
@@ -210,6 +213,17 @@ void ClassDB::register_class(bool p_virtual) {
 template <class T>
 void ClassDB::register_abstract_class() {
 	ClassDB::_register_class<T, true>();
+}
+
+template <class C, class N, class M, typename... VarArgs>
+MethodBind *ClassDB::bind_inherited_method(N p_method_name, M p_method, VarArgs... p_args) {
+	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+	const Variant *argptrs[sizeof...(p_args) + 1];
+	for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+		argptrs[i] = &args[i];
+	}
+	MethodBind *bind = create_inherited_method_bind<C>(p_method);
+	return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const void **)argptrs, sizeof...(p_args));
 }
 
 template <class N, class M, typename... VarArgs>

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -345,11 +345,7 @@ public:
 
 template <class C, class T, class... P>
 MethodBind *create_inherited_method_bind(void (T::*p_method)(P...)) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindT<C, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindT<P...>)(reinterpret_cast<void (MB_T::*)(P...)>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(C::get_class_static());
 	return a;
 }
@@ -526,11 +522,7 @@ public:
 
 template <class C, class T, class R, class... P>
 MethodBind *create_inherited_method_bind(R (T::*p_method)(P...)) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTR<C, R, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTR<R, P...>)(reinterpret_cast<R (MB_T::*)(P...)>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(C::get_class_static());
 	return a;
 }
@@ -620,11 +612,7 @@ public:
 
 template <class C, class T, class R, class... P>
 MethodBind *create_inherited_method_bind(R (T::*p_method)(P...) const) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTRC<C, R, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTRC<R, P...>)(reinterpret_cast<R (MB_T::*)(P...) const>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(C::get_class_static());
 	return a;
 }

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -343,6 +343,17 @@ public:
 	}
 };
 
+template <class C, class T, class... P>
+MethodBind *create_inherited_method_bind(void (T::*p_method)(P...)) {
+#ifdef TYPED_METHOD_BIND
+	MethodBind *a = memnew((MethodBindT<C, P...>)(p_method));
+#else
+	MethodBind *a = memnew((MethodBindT<P...>)(reinterpret_cast<void (MB_T::*)(P...)>(p_method)));
+#endif // TYPED_METHOD_BIND
+	a->set_instance_class(C::get_class_static());
+	return a;
+}
+
 template <class T, class... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...)) {
 #ifdef TYPED_METHOD_BIND
@@ -418,6 +429,17 @@ public:
 		set_argument_count(sizeof...(P));
 	}
 };
+
+template <class C, class T, class... P>
+MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
+#ifdef TYPED_METHOD_BIND
+	MethodBind *a = memnew((MethodBindTC<C, P...>)(p_method));
+#else
+	MethodBind *a = memnew((MethodBindTC<P...>)(reinterpret_cast<void (MB_T::*)(P...) const>(p_method)));
+#endif // TYPED_METHOD_BIND
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
 
 template <class T, class... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
@@ -502,6 +524,17 @@ public:
 	}
 };
 
+template <class C, class T, class R, class... P>
+MethodBind *create_inherited_method_bind(R (T::*p_method)(P...)) {
+#ifdef TYPED_METHOD_BIND
+	MethodBind *a = memnew((MethodBindTR<C, R, P...>)(p_method));
+#else
+	MethodBind *a = memnew((MethodBindTR<R, P...>)(reinterpret_cast<R (MB_T::*)(P...)>(p_method)));
+#endif // TYPED_METHOD_BIND
+	a->set_instance_class(C::get_class_static());
+	return a;
+}
+
 template <class T, class R, class... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...)) {
 #ifdef TYPED_METHOD_BIND
@@ -584,6 +617,17 @@ public:
 		set_return(true);
 	}
 };
+
+template <class C, class T, class R, class... P>
+MethodBind *create_inherited_method_bind(R (T::*p_method)(P...) const) {
+#ifdef TYPED_METHOD_BIND
+	MethodBind *a = memnew((MethodBindTRC<C, R, P...>)(p_method));
+#else
+	MethodBind *a = memnew((MethodBindTRC<R, P...>)(reinterpret_cast<R (MB_T::*)(P...) const>(p_method)));
+#endif // TYPED_METHOD_BIND
+	a->set_instance_class(C::get_class_static());
+	return a;
+}
 
 template <class T, class R, class... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...) const) {

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -271,22 +271,11 @@ MethodBind *create_vararg_method_bind(R (T::*p_method)(const Variant **, GDNativ
 	return a;
 }
 
-#ifndef TYPED_METHOD_BIND
-class ___UnexistingClass;
-#define MB_T ___UnexistingClass
-#else
-#define MB_T T
-#endif
-
 // No return, not const.
 
-#ifdef TYPED_METHOD_BIND
 template <class T, class... P>
-#else
-template <class... P>
-#endif // TYPED_METHOD_BIND
 class MethodBindT : public MethodBind {
-	void (MB_T::*method)(P...);
+	void (T::*method)(P...);
 
 protected:
 // GCC raises warnings in the case P = {} as the comparison is always false...
@@ -321,22 +310,14 @@ public:
 	}
 
 	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeCallError &r_error) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_variant_args_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, r_error, get_default_arguments());
-#else
-		call_with_variant_args_dv(reinterpret_cast<MB_T *>(p_instance), method, p_args, p_argument_count, r_error, get_default_arguments());
-#endif
 		return Variant();
 	}
 	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, P...>(static_cast<T *>(p_instance), method, p_args, nullptr);
-#else
-		call_with_ptr_args<MB_T, P...>(reinterpret_cast<MB_T *>(p_instance), method, p_args, nullptr);
-#endif // TYPED_METHOD_BIND
 	}
 
-	MethodBindT(void (MB_T::*p_method)(P...)) {
+	MethodBindT(void (T::*p_method)(P...)) {
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
@@ -352,24 +333,16 @@ MethodBind *create_inherited_method_bind(void (T::*p_method)(P...)) {
 
 template <class T, class... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...)) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindT<T, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindT<P...>)(reinterpret_cast<void (MB_T::*)(P...)>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
 }
 
 // No return, const.
 
-#ifdef TYPED_METHOD_BIND
 template <class T, class... P>
-#else
-template <class... P>
-#endif // TYPED_METHOD_BIND
 class MethodBindTC : public MethodBind {
-	void (MB_T::*method)(P...) const;
+	void (T::*method)(P...) const;
 
 protected:
 // GCC raises warnings in the case P = {} as the comparison is always false...
@@ -404,22 +377,14 @@ public:
 	}
 
 	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeCallError &r_error) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_variant_argsc_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, r_error, get_default_arguments());
-#else
-		call_with_variant_argsc_dv(reinterpret_cast<MB_T *>(p_instance), method, p_args, p_argument_count, r_error, get_default_arguments());
-#endif
 		return Variant();
 	}
 	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, P...>(static_cast<T *>(p_instance), method, p_args, nullptr);
-#else
-		call_with_ptr_args<MB_T, P...>(reinterpret_cast<MB_T *>(p_instance), method, p_args, nullptr);
-#endif // TYPED_METHOD_BIND
 	}
 
-	MethodBindTC(void (MB_T::*p_method)(P...) const) {
+	MethodBindTC(void (T::*p_method)(P...) const) {
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
@@ -428,35 +393,23 @@ public:
 
 template <class C, class T, class... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTC<C, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTC<P...>)(reinterpret_cast<void (MB_T::*)(P...) const>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
 }
 
 template <class T, class... P>
 MethodBind *create_method_bind(void (T::*p_method)(P...) const) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTC<T, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTC<P...>)(reinterpret_cast<void (MB_T::*)(P...) const>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
 }
 
 // Return, not const.
 
-#ifdef TYPED_METHOD_BIND
 template <class T, class R, class... P>
-#else
-template <class R, class... P>
-#endif // TYPED_METHOD_BIND
 class MethodBindTR : public MethodBind {
-	R(MB_T::*method)
+	R(T::*method)
 	(P...);
 
 protected:
@@ -497,22 +450,14 @@ public:
 
 	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeCallError &r_error) const {
 		Variant ret;
-#ifdef TYPED_METHOD_BIND
 		call_with_variant_args_ret_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, ret, r_error, get_default_arguments());
-#else
-		call_with_variant_args_ret_dv((MB_T *)p_instance, method, p_args, p_argument_count, ret, r_error, get_default_arguments());
-#endif
 		return ret;
 	}
 	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, R, P...>(static_cast<T *>(p_instance), method, p_args, r_ret);
-#else
-		call_with_ptr_args<MB_T, R, P...>(reinterpret_cast<MB_T *>(p_instance), method, p_args, r_ret);
-#endif // TYPED_METHOD_BIND
 	}
 
-	MethodBindTR(R (MB_T::*p_method)(P...)) {
+	MethodBindTR(R (T::*p_method)(P...)) {
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
@@ -529,24 +474,16 @@ MethodBind *create_inherited_method_bind(R (T::*p_method)(P...)) {
 
 template <class T, class R, class... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...)) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTR<T, R, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTR<R, P...>)(reinterpret_cast<R (MB_T::*)(P...)>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
 }
 
 // Return, const.
 
-#ifdef TYPED_METHOD_BIND
 template <class T, class R, class... P>
-#else
-template <class R, class... P>
-#endif // TYPED_METHOD_BIND
 class MethodBindTRC : public MethodBind {
-	R(MB_T::*method)
+	R(T::*method)
 	(P...) const;
 
 protected:
@@ -587,22 +524,14 @@ public:
 
 	virtual Variant call(GDExtensionClassInstancePtr p_instance, const GDNativeVariantPtr *p_args, const GDNativeInt p_argument_count, GDNativeCallError &r_error) const {
 		Variant ret;
-#ifdef TYPED_METHOD_BIND
 		call_with_variant_args_retc_dv(static_cast<T *>(p_instance), method, p_args, (int)p_argument_count, ret, r_error, get_default_arguments());
-#else
-		call_with_variant_args_retc_dv((MB_T *)p_instance, method, p_args, p_argument_count, ret, r_error, get_default_arguments());
-#endif
 		return ret;
 	}
 	virtual void ptrcall(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret) const {
-#ifdef TYPED_METHOD_BIND
 		call_with_ptr_args<T, R, P...>(static_cast<T *>(p_instance), method, p_args, r_ret);
-#else
-		call_with_ptr_args<MB_T, R, P...>(reinterpret_cast<MB_T *>(p_instance), method, p_args, r_ret);
-#endif // TYPED_METHOD_BIND
 	}
 
-	MethodBindTRC(R (MB_T::*p_method)(P...) const) {
+	MethodBindTRC(R (T::*p_method)(P...) const) {
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
@@ -619,11 +548,7 @@ MethodBind *create_inherited_method_bind(R (T::*p_method)(P...) const) {
 
 template <class T, class R, class... P>
 MethodBind *create_method_bind(R (T::*p_method)(P...) const) {
-#ifdef TYPED_METHOD_BIND
 	MethodBind *a = memnew((MethodBindTRC<T, R, P...>)(p_method));
-#else
-	MethodBind *a = memnew((MethodBindTRC<R, P...>)(reinterpret_cast<R (MB_T::*)(P...) const>(p_method)));
-#endif // TYPED_METHOD_BIND
 	a->set_instance_class(T::get_class_static());
 	return a;
 }

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -270,3 +270,16 @@ bool Example::_has_point(const Vector2 &point) const {
 
 	return false;
 }
+
+void ExampleBaseClass::example_void_method() {
+	return;
+}
+
+int ExampleBaseClass::example_int_method() {
+	return 42;
+}
+
+void ExampleInheriting::_bind_methods() {
+	ClassDB::bind_inherited_method<ExampleInheriting>(D_METHOD("example_void_method"), &ExampleInheriting::example_void_method);
+	ClassDB::bind_inherited_method<ExampleInheriting>(D_METHOD("example_int_method"), &ExampleInheriting::example_int_method);
+}

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -121,4 +121,17 @@ protected:
 	static void _bind_methods() {}
 };
 
+class ExampleBaseClass {
+public:
+	void example_void_method();
+	int example_int_method();
+};
+
+class ExampleInheriting : public ExampleBaseClass, public Object {
+	GDCLASS(ExampleInheriting, Object)
+
+protected:
+	static void _bind_methods();
+};
+
 #endif // EXAMPLE_CLASS_H


### PR DESCRIPTION
This PR offers an implementation for binding inherited methods, using `ClassDB::bind_inherited_method<DerivedClass>(...)`.
It can avoid a lot of boilerplate code in some extensions, where the registered class has to redefine every bound method.
I wasn't sure if this would be helpful on Godot's side or even if it doesn't already work. So tell me if it would be better done there first.

The main obstacle was `TYPED_METHOD_BIND` in `include/godot_cpp/core/method_bind.hpp`: it is necessary to call the method on a derived instance to offset `this` correctly. (Without doing so, the extension compiled but the calls went nuts because `this` was wrong)

Thus I also offer to get completely rid of `TYPED_METHOD_BIND`, as in always using typed method bindings. It was introduced in https://github.com/godotengine/godot-cpp/pull/649 because it was mandatory for Windows builds, but I don't see where not using it would be required: please enlighten me if there is an example.
On top of that, it makes the file much more readable!