### PR TITLE
Make build_library=no usable at godot-cpp's root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
         if: ${{ matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes' }}
         uses: egor-tensin/setup-mingw@v2
 
+      - name: Generate godot-cpp sources only
+        run: |
+          scons platform=${{ matrix.platform }} build_library=no ${{ matrix.flags }}
+          scons -c
+
       - name: Build godot-cpp (debug)
         run: |
           scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }}

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -141,8 +141,9 @@ def print_file_list(api_filepath, output_dir, headers=False, sources=False):
 
 def scons_emit_files(target, source, env):
     files = [env.File(f) for f in get_file_list(str(source[0]), target[0].abspath, True, True)]
-    env.Clean(files, target)
-    return [target[0]] + files, source
+    env.Clean(target, files)
+    env["godot_cpp_gen_dir"] = target[0].abspath
+    return files, source
 
 
 def scons_generate_bindings(target, source, env):
@@ -151,7 +152,7 @@ def scons_generate_bindings(target, source, env):
         env["generate_template_get_node"],
         "32" if "32" in env["arch"] else "64",
         "double" if (env["float"] == "64") else "float",
-        target[0].abspath,
+        env["godot_cpp_gen_dir"],
     )
     return None
 


### PR DESCRIPTION
Hello,

Currently, `build_library=no` does not work at the repository's root. (It generates a dependency cycle and scons refuses to generate anything).

To reproduce:
`scons generate_bindings=yes build_library=no` in `godot-cpp` 
Or `rm gen -r` before `scons build_library=no` in `godot-cpp`
Should give something like:
```
scons: *** Found dependency cycle(s):
  gen -> gen/include/godot_cpp/classes/text_server_manager.hpp -> gen/include/godot_cpp/classes -> gen/include/godot_cpp -> gen/include -> gen
```

This PR solves this, by not stating that `gen/` is a target itself.
Also invert arguments to env.Clean, to call it as is documented in https://scons.org/doc/4.4.0/HTML/scons-user/apd.html.
I added a CI step to check this does not regress. I clean the generated sources before the actual build, to make sure the build step includes generation so the dependency handling should not regress either.