### PR TITLE
[SCons] Remove bogus CCFLAGS from windows toolchain.

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -39,8 +39,6 @@ def generate(env):
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True
         mingw.generate(env)
-        # Still need to use C++17.
-        env.Append(CCFLAGS=["-std=c++17"])
         # Don't want lib prefixes
         env["IMPLIBPREFIX"] = ""
         env["SHLIBPREFIX"] = ""


### PR DESCRIPTION
The c++ standard is added as part of the main SConstruct.

Fixes #906