### PR TITLE
Fix Color::find_named_color(const String &p_name)

### DIFF
--- a/src/variant/color.cpp
+++ b/src/variant/color.cpp
@@ -406,7 +406,7 @@ int Color::find_named_color(const String &p_name) {
 	name = name.replace("_", "");
 	name = name.replace("'", "");
 	name = name.replace(".", "");
-	name = name.to_upper();
+	name = name.to_lower();
 
 	int idx = 0;
 	while (named_colors[idx].name != nullptr) {


### PR DESCRIPTION
Every `Color::named_colors` elements' name are lower case, but `Color::find_named_color(const String &p_name)` will convert `p_name` as upper to match. So I fixed it.