### PR TITLE
Fix namespace isolation in GDCLASS macro

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -99,8 +99,8 @@ private:                                                                        
 	friend class ::godot::ClassDB;                                                                                                                       \
                                                                                                                                                          \
 protected:                                                                                                                                               \
-	virtual const StringName *_get_extension_class_name() const override {                                                                               \
-		static StringName string_name = get_class_static();                                                                                              \
+	virtual const ::godot::StringName *_get_extension_class_name() const override {                                                                      \
+		static ::godot::StringName string_name = get_class_static();                                                                                     \
 		return &string_name;                                                                                                                             \
 	}                                                                                                                                                    \
                                                                                                                                                          \
@@ -159,12 +159,12 @@ public:                                                                         
 		initialized = true;                                                                                                                              \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static StringName &get_class_static() {                                                                                                              \
-		static StringName string_name = StringName(#m_class);                                                                                            \
+	static ::godot::StringName &get_class_static() {                                                                                                     \
+		static ::godot::StringName string_name = ::godot::StringName(#m_class);                                                                          \
 		return string_name;                                                                                                                              \
 	}                                                                                                                                                    \
                                                                                                                                                          \
-	static StringName &get_parent_class_static() {                                                                                                       \
+	static ::godot::StringName &get_parent_class_static() {                                                                                              \
 		return m_inherits::get_class_static();                                                                                                           \
 	}                                                                                                                                                    \
                                                                                                                                                          \
@@ -322,11 +322,11 @@ protected:                                                                      
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
-	static bool (Wrapped::*_get_set())(const StringName &p_name, const Variant &p_property) {                      \
+	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {             \
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
-	static bool (Wrapped::*_get_get())(const StringName &p_name, Variant &r_ret) const {                           \
+	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                  \
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
@@ -334,11 +334,11 @@ protected:                                                                      
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
-	static bool (Wrapped::*_get_property_can_revert())(const StringName &p_name) {                                 \
+	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) {                        \
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
-	static bool (Wrapped::*_get_property_get_revert())(const StringName &p_name, Variant &) {                      \
+	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) {             \
 		return nullptr;                                                                                            \
 	}                                                                                                              \
                                                                                                                    \
@@ -349,12 +349,12 @@ protected:                                                                      
 public:                                                                                                            \
 	static void initialize_class() {}                                                                              \
                                                                                                                    \
-	static StringName &get_class_static() {                                                                        \
-		static StringName string_name = StringName(#m_class);                                                      \
+	static ::godot::StringName &get_class_static() {                                                               \
+		static ::godot::StringName string_name = ::godot::StringName(#m_class);                                    \
 		return string_name;                                                                                        \
 	}                                                                                                              \
                                                                                                                    \
-	static StringName &get_parent_class_static() {                                                                 \
+	static ::godot::StringName &get_parent_class_static() {                                                        \
 		return m_inherits::get_class_static();                                                                     \
 	}                                                                                                              \
                                                                                                                    \


### PR DESCRIPTION
fix #918 

Note the second commit in this PR modify the test to remove the use of `using namespace godot;`, from my point of view this has both pros and cons:
- pros: help detect namespace isolation leak like we saw here ^^
- pros: further show the difference between macros and regular functions (given macros are totally separated from namespace), this is important for `D_METHOD` which looks like a macro but is in fact a method (hence the `GDCLASS(...)` vs `godot::D_METHOD(...)`)
- cons: the example is more verbose and less idiotic which is not great given it is the primary example one will refer to when learning Godot-CPP...

So what do you think ?
I guess the best of both worlds would be to have two separates folders: one for example and another for test (the latter typically being also run in the CI, which is something not currently done). However I'm personally too lazy for this change :smile: 