### PR TITLE
Basic static analysis fixes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -52,12 +52,12 @@ protected:
 	virtual const StringName *_get_extension_class_name() const; // This is needed to retrieve the class name before the godot object has its _extension and _extension_instance members assigned.
 	virtual const GDNativeInstanceBindingCallbacks *_get_bindings_callbacks() const = 0;
 
-	void _notification(int p_what){};
-	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
-	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
-	void _get_property_list(List<PropertyInfo> *p_list) const {};
-	bool _property_can_revert(const StringName &p_name) const { return false; };
-	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; };
+	void _notification(int p_what) {}
+	bool _set(const StringName &p_name, const Variant &p_property) { return false; }
+	bool _get(const StringName &p_name, Variant &r_property) const { return false; }
+	void _get_property_list(List<PropertyInfo> *p_list) const {}
+	bool _property_can_revert(const StringName &p_name) const { return false; }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
 	String _to_string() const { return "[" + String(get_class_static()) + ":" + itos(get_instance_id()) + "]"; }
 
 	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what) {}

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -107,7 +107,7 @@ public:
 };
 
 template <class T>
-void memdelete(T *p_class, typename std::enable_if<!std::is_base_of_v<godot::Wrapped, T>>::type * = 0) {
+void memdelete(T *p_class, typename std::enable_if<!std::is_base_of_v<godot::Wrapped, T>>::type * = nullptr) {
 	if (!__has_trivial_destructor(T)) {
 		p_class->~T();
 	}

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -98,7 +98,7 @@ public:
 	_FORCE_INLINE_ StringName get_instance_class() const { return instance_class; }
 	_FORCE_INLINE_ void set_instance_class(StringName p_class) { instance_class = p_class; }
 
-	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
+	_FORCE_INLINE_ int get_argument_count() const { return argument_count; }
 	_FORCE_INLINE_ bool is_const() const { return _is_const; }
 	_FORCE_INLINE_ bool is_static() const { return _static; }
 	_FORCE_INLINE_ bool is_vararg() const { return _vararg; }

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -72,7 +72,7 @@ public:
 		InitObject(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization) :
 				gdn_interface(p_interface),
 				library(p_library),
-				initialization(r_initialization){};
+				initialization(r_initialization) {}
 
 		void register_initializer(Callback p_init) const;
 		void register_terminator(Callback p_init) const;

--- a/include/godot_cpp/templates/cowdata.hpp
+++ b/include/godot_cpp/templates/cowdata.hpp
@@ -190,7 +190,7 @@ public:
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
-	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); };
+	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
 };
 
 template <class T>

--- a/include/godot_cpp/templates/hashfuncs.hpp
+++ b/include/godot_cpp/templates/hashfuncs.hpp
@@ -228,7 +228,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, 
 			k1 = hash_rotl32(k1, 15);
 			k1 *= c2;
 			h1 ^= k1;
-	};
+	}
 
 	// Finalize with additional bit mixing.
 	h1 ^= length;

--- a/include/godot_cpp/templates/rb_set.hpp
+++ b/include/godot_cpp/templates/rb_set.hpp
@@ -77,7 +77,7 @@ public:
 		}
 		const T &get() const {
 			return value;
-		};
+		}
 		Element() {}
 	};
 

--- a/include/godot_cpp/templates/rid_owner.hpp
+++ b/include/godot_cpp/templates/rid_owner.hpp
@@ -37,7 +37,7 @@
 #include <godot_cpp/templates/spin_lock.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 #include <typeinfo>
 
 namespace godot {

--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -233,7 +233,7 @@ struct _NO_DISCARD_ Basis {
 
 	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
 
-	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); };
+	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); }
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }
 
 	Basis(const Vector3 &p_axis, real_t p_angle) { set_axis_angle(p_axis, p_angle); }

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -43,7 +43,7 @@ struct _NO_DISCARD_ Plane {
 	real_t d = 0;
 
 	void set_normal(const Vector3 &p_normal);
-	_FORCE_INLINE_ Vector3 get_normal() const { return normal; };
+	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }
 
 	void normalize();
 	Plane normalized() const;

--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -67,7 +67,7 @@ struct _NO_DISCARD_ Quaternion {
 
 	Vector3 get_euler_xyz() const;
 	Vector3 get_euler_yxz() const;
-	Vector3 get_euler() const { return get_euler_yxz(); };
+	Vector3 get_euler() const { return get_euler_yxz(); }
 
 	Quaternion slerp(const Quaternion &p_to, const real_t &p_weight) const;
 	Quaternion slerpni(const Quaternion &p_to, const real_t &p_weight) const;

--- a/src/variant/basis.cpp
+++ b/src/variant/basis.cpp
@@ -488,7 +488,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = 0.0f;
 			}
 			return euler;
-		} break;
+		}
 		case EULER_ORDER_XZY: {
 			// Euler angles in XZY convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -517,7 +517,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = -Math_PI / 2.0f;
 			}
 			return euler;
-		} break;
+		}
 		case EULER_ORDER_YXZ: {
 			// Euler angles in YXZ convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -555,7 +555,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			}
 
 			return euler;
-		} break;
+		}
 		case EULER_ORDER_YZX: {
 			// Euler angles in YZX convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -584,7 +584,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = Math_PI / 2.0f;
 			}
 			return euler;
-		} break;
+		}
 		case EULER_ORDER_ZXY: {
 			// Euler angles in ZXY convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -612,7 +612,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = 0;
 			}
 			return euler;
-		} break;
+		}
 		case EULER_ORDER_ZYX: {
 			// Euler angles in ZYX convention.
 			// See https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
@@ -640,7 +640,7 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 				euler.z = -Math::atan2(rows[0][1], rows[1][1]);
 			}
 			return euler;
-		} break;
+		}
 		default: {
 			ERR_FAIL_V_MSG(Vector3(), "Invalid parameter for get_euler(order)");
 		}

--- a/src/variant/projection.cpp
+++ b/src/variant/projection.cpp
@@ -183,7 +183,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_FAR: {
 			Plane new_plane = Plane(matrix[3] - matrix[2],
 					matrix[7] - matrix[6],
@@ -193,7 +193,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_LEFT: {
 			Plane new_plane = Plane(matrix[3] + matrix[0],
 					matrix[7] + matrix[4],
@@ -203,7 +203,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_TOP: {
 			Plane new_plane = Plane(matrix[3] - matrix[1],
 					matrix[7] - matrix[5],
@@ -213,7 +213,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_RIGHT: {
 			Plane new_plane = Plane(matrix[3] - matrix[0],
 					matrix[7] - matrix[4],
@@ -223,7 +223,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 		case PLANE_BOTTOM: {
 			Plane new_plane = Plane(matrix[3] + matrix[1],
 					matrix[7] + matrix[5],
@@ -233,7 +233,7 @@ Plane Projection::get_projection_plane(Planes p_plane) const {
 			new_plane.normal = -new_plane.normal;
 			new_plane.normalize();
 			return new_plane;
-		} break;
+		}
 	}
 
 	return Plane();


### PR DESCRIPTION
- remove extraneous semicolons
- use "nullptr" instead of "0"
- remove "break" after "return"
- use &lt;cstdio&gt; instead of &lt;stdio.h&gt;