### PR TITLE
Change example code to properly test refcounted objects

### DIFF
--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -28,7 +28,10 @@ func _ready():
 	($Example as Example).simple_const_func() # Force use of ptrcall
 	prints("  returned", $Example.return_something("some string"))
 	prints("  returned const", $Example.return_something_const())
-	prints("  returned ref", $Example.return_extended_ref())
+	var null_ref = $Example.return_empty_ref()
+	prints("  returned empty ref", null_ref)
+	var ret_ref = $Example.return_extended_ref()
+	prints("  returned ref", ret_ref.get_instance_id(), ", id:", ret_ref.get_id())
 	prints("  returned ", $Example.get_v4())
 
 	prints("VarArg method calls")

--- a/test/demo/main.tscn
+++ b/test/demo/main.tscn
@@ -3,13 +3,15 @@
 [ext_resource type="Script" path="res://main.gd" id="1_c326s"]
 
 [node name="Node" type="Node"]
-script = ExtResource( "1_c326s" )
+script = ExtResource("1_c326s")
 
 [node name="Example" type="Example" parent="."]
 
 [node name="ExampleMin" type="ExampleMin" parent="Example"]
+layout_mode = 0
 
 [node name="Label" type="Label" parent="Example"]
+layout_mode = 0
 offset_left = 194.0
 offset_top = -2.0
 offset_right = 234.0

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -25,12 +25,20 @@ using namespace godot;
 class ExampleRef : public RefCounted {
 	GDCLASS(ExampleRef, RefCounted);
 
+private:
+	static int instance_count;
+	static int last_id;
+
+	int id;
+
 protected:
-	static void _bind_methods() {}
+	static void _bind_methods();
 
 public:
 	ExampleRef();
 	~ExampleRef();
+
+	int get_id();
 };
 
 class ExampleMin : public Control {
@@ -79,6 +87,7 @@ public:
 	void simple_const_func() const;
 	String return_something(const String &base);
 	Viewport *return_something_const() const;
+	Ref<ExampleRef> return_empty_ref() const;
 	ExampleRef *return_extended_ref() const;
 	Ref<ExampleRef> extended_ref_checks(Ref<ExampleRef> p_ref) const;
 	Variant varargs_func(const Variant **args, GDNativeInt arg_count, GDNativeCallError &error);


### PR DESCRIPTION
This changes some of the test logic to properly check `Ref<...>` scenarios.

We now check:
- return empty referenced objects
```
returned empty ref <Object#null>
```
- return an instanced object by pointer
```
ExampleRef 1 created, current instance count: 1
  returned ref -9223372010229333393 , id: 1
```
- receiving an instanced object (as well as returning an instance object by reference)
```
ExampleRef 2 created, current instance count: 2
ExampleRef 3 created, current instance count: 3
  Example ref checks called with value: -9223372010212556172, returning value: -9223372010195778844
  sending ref:  -9223372010212556172 returned ref:  -9223372010195778844
```

We also output some id's and counts on constructing/destructing `ExampleRef` so we can see if the output is correct
```
ExampleRef 3 destroyed, current instance count: 2
ExampleRef 1 destroyed, current instance count: 1
ExampleRef 2 destroyed, current instance count: 0
```
