### PR TITLE
Added property info for Object's and Ref's and ported the implementation of the `check` method

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -276,7 +276,7 @@ struct GetTypeInfo<Ref<T>, typename EnableIf<TypeInherits<RefCounted, T>::value>
 	static const GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
-		return make_property_info(Variant::Type::OBJECT, T::get_class_static());
+		return make_property_info(Variant::Type::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
 	}
 };
 
@@ -286,7 +286,7 @@ struct GetTypeInfo<const Ref<T> &, typename EnableIf<TypeInherits<RefCounted, T>
 	static const GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 
 	static inline PropertyInfo get_class_info() {
-		return make_property_info(Variant::Type::OBJECT, T::get_class_static());
+		return make_property_info(Variant::Type::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
 	}
 };
 

--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -122,7 +122,13 @@ struct VariantCaster<const T &> {
 template <typename T>
 struct VariantObjectClassChecker {
 	static _FORCE_INLINE_ bool check(const Variant &p_variant) {
-		return true;
+		using TStripped = std::remove_pointer_t<T>;
+		if constexpr (std::is_base_of<Object, TStripped>::value) {
+			Object *obj = p_variant;
+			return Object::cast_to<TStripped>(p_variant) || !obj;
+		} else {
+			return true;
+		}
 	}
 };
 

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -201,7 +201,7 @@ struct GetTypeInfo<T *, typename EnableIf<TypeInherits<Object, T>::value>::type>
 	static const GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_OBJECT;
 	static const GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return make_property_info(Variant::Type::OBJECT, T::get_class_static());
+		return make_property_info(Variant::Type::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
 	}
 };
 
@@ -210,7 +210,7 @@ struct GetTypeInfo<const T *, typename EnableIf<TypeInherits<Object, T>::value>:
 	static const GDExtensionVariantType VARIANT_TYPE = GDEXTENSION_VARIANT_TYPE_OBJECT;
 	static const GDExtensionClassMethodArgumentMetadata METADATA = GDEXTENSION_METHOD_ARGUMENT_METADATA_NONE;
 	static inline PropertyInfo get_class_info() {
-		return make_property_info(Variant::Type::OBJECT, T::get_class_static());
+		return make_property_info(Variant::Type::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, T::get_class_static());
 	}
 };
 


### PR DESCRIPTION
Supersedes #810
Rebased and fixed. Also added `PropertyInfo` for `Ref<T>`
#948 is required for a successful build

![image](https://user-images.githubusercontent.com/7782218/205829744-91985882-4068-473c-a8fe-65a7b5dbb7d0.png)

![Godot_v4 0-beta7_win64_7OvHJneZs2](https://user-images.githubusercontent.com/7782218/205828584-6c007ade-f541-4ca4-a181-fbc4f4a4f494.png)

```
Constructor.
Notification: 18
Notification: 31
Notification: 32
Notification: 45
Notification: 10
Notification: 27
Notification: 13
Signal bind

To string
  Example -->  Example:[ GDExtension::Example <--> Instance ID:26541556118 ]
  ExampleMin -->  ExampleMin:[Wrapped:0]
Static method calls
  static (109) 109
  void static
Property list
  property value  (100, 200, 300)
Instance method calls
  Simple func called.
  Simple const func called.
  typed_ptr_parameter called: Example:[ GDExtension::Example <--> Instance ID:26541556118 ] <----------------------
  typed_const_ptr_parameter called: Example:[ GDExtension::Example <--> Instance ID:26541556118 ] <----------------
  Return something called.
...
```