### PR TITLE
Fix virtual GDExtension method Ref<T> conversion

### DIFF
--- a/godot-headers/godot/gdextension_interface.h
+++ b/godot-headers/godot/gdextension_interface.h
@@ -154,6 +154,8 @@ typedef const void *GDExtensionMethodBindPtr;
 typedef int64_t GDExtensionInt;
 typedef uint8_t GDExtensionBool;
 typedef uint64_t GDObjectInstanceID;
+typedef void *GDExtensionRefPtr;
+typedef const void *GDExtensionConstRefPtr;
 
 /* VARIANT DATA I/O */
 
@@ -550,6 +552,11 @@ typedef struct {
 	GDExtensionObjectPtr (*object_cast_to)(GDExtensionConstObjectPtr p_object, void *p_class_tag);
 	GDExtensionObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);
 	GDObjectInstanceID (*object_get_instance_id)(GDExtensionConstObjectPtr p_object);
+
+	/* REFERENCE */
+
+	GDExtensionObjectPtr (*ref_get_object)(GDExtensionConstRefPtr p_ref);
+	void (*ref_set_object)(GDExtensionRefPtr p_ref, GDExtensionObjectPtr p_object);
 
 	/* SCRIPT INSTANCE */
 

--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -240,13 +240,24 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)), godot::internal::token, &T::___binding_callbacks)));
+		GDExtensionRefPtr ref = (GDExtensionRefPtr)p_ptr;
+		ERR_FAIL_NULL_V(ref, Ref<T>());
+
+		T *obj = reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(godot::internal::gde_interface->ref_get_object(ref), godot::internal::token, &T::___binding_callbacks));
+		return Ref<T>(obj);
 	}
 
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static void encode(Ref<T> p_val, void *p_ptr) {
-		*reinterpret_cast<const GodotObject **>(p_ptr) = p_val->_owner;
+		GDExtensionRefPtr ref = (GDExtensionRefPtr)p_ptr;
+		ERR_FAIL_NULL(ref);
+
+		// This code assumes that p_ptr points to an unset Ref<T> variable on the Godot side
+		// so we only set it if we have an object to set.
+		if (p_val.is_valid()) {
+			godot::internal::gde_interface->ref_set_object(ref, p_val->_owner);
+		}
 	}
 };
 


### PR DESCRIPTION
The godot-cpp side of https://github.com/godotengine/godot/pull/69902

This uses the two new functions introduced in Godot so we can properly handle Godot supplied `Ref<T>` pointers and get/set our objects.