### PR TITLE
Use `int64_t` for `BitField` as in Godot itself

### DIFF
--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -240,14 +240,14 @@ inline StringName __constant_get_enum_name(T param, StringName p_constant) {
 
 template <class T>
 class BitField {
-	uint32_t value = 0;
+	int64_t value = 0;
 
 public:
 	_FORCE_INLINE_ void set_flag(T p_flag) { value |= p_flag; }
 	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & p_flag; }
 	_FORCE_INLINE_ void clear_flag(T p_flag) { return value &= ~p_flag; }
-	_FORCE_INLINE_ BitField(uint32_t p_value) { value = p_value; }
-	_FORCE_INLINE_ operator uint32_t() const { return value; }
+	_FORCE_INLINE_ BitField(int64_t p_value) { value = p_value; }
+	_FORCE_INLINE_ operator int64_t() const { return value; }
 	_FORCE_INLINE_ operator Variant() const { return value; }
 };
 


### PR DESCRIPTION
In Godot, Bitfields have long been updated to `int64_t`
https://github.com/godotengine/godot/blob/cd855f6516d48ff960cd904d29abbb324149f3c8/core/variant/type_info.h#L285-L296
