### PR TITLE
Fix GDCLASS needs explicit ClassDB fwd declaration

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -41,6 +41,8 @@
 
 namespace godot {
 
+class ClassDB;
+
 typedef void GodotObject;
 
 // Base for all engine classes, to contain the pointer to the engine instance.


### PR DESCRIPTION
The `GDCLASS` macro requires declaration of `::godot::ClassDB` to satisfy `friend class ::godot::ClassDB`.

Currently all GDExtension/modules client code that I know of that uses this macro, needs to include `<godot_cpp/core/class_db.hpp>` on top of the wrapped object that it wishes to inherit (e.g Object with `#include <godot_cpp/classes/node.hpp>`).

I feel that this is confusing that this is required to satisfy a macro implementation detail and it is easily fixed using a forward declaration.

It is especially worse when not choosing to use `using namespace godot;` and having to forward declare in client code within the `godot` namespace.

EDIT: Could mode the declaration just above the macro definition for readability