### PR TITLE
[SCons] Platform agnostic default toolchain (GNU).

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -28,7 +28,9 @@ elif ARGUMENTS.get("platform", ""):
 else:
     raise ValueError("Could not detect platform automatically, please specify with platform=<platform>")
 
-env = Environment(tools=["default"])
+# Default tools with no platform defaults to gnu toolchain.
+# We apply platform specific toolchains via our custom tools.
+env = Environment(tools=["default"], PLATFORM="")
 
 # Default num_jobs to local cpu count if not user specified.
 # SCons has a peculiarity where user-specified options won't be overridden

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -23,7 +23,12 @@ def generate(env):
         elif env["arch"] == "x86_32":
             env["TARGET_ARCH"] = "x86"
         env["is_msvc"] = True
+
+        # MSVC, linker, and archiver.
         msvc.generate(env)
+        env.Tool("mslib")
+        env.Tool("mslink")
+
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
         env.Append(CCFLAGS=["/EHsc"])
         env.Append(LINKFLAGS=["/WX"])


### PR DESCRIPTION
Create the SCons Environment with an empty PLATFORM variable to force the default tools to use the GNU toolchain.

Platform specific toolchains are then setup in our custom tools.

Fixes #937