### PR TITLE
Add conversions between `Variant` and `ObjectID`

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -42,6 +42,8 @@
 
 namespace godot {
 
+class ObjectID;
+
 class Variant {
 	uint8_t opaque[GODOT_CPP_VARIANT_SIZE]{ 0 };
 
@@ -187,6 +189,7 @@ public:
 	Variant(const StringName &v);
 	Variant(const NodePath &v);
 	Variant(const godot::RID &v);
+	Variant(const ObjectID &v);
 	Variant(const Object *v);
 	Variant(const Callable &v);
 	Variant(const Signal &v);
@@ -230,6 +233,7 @@ public:
 	operator StringName() const;
 	operator NodePath() const;
 	operator godot::RID() const;
+	operator ObjectID() const;
 	operator Object *() const;
 	operator Callable() const;
 	operator Signal() const;

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -191,6 +191,10 @@ Variant::Variant(const Object *v) {
 	}
 }
 
+Variant::Variant(const ObjectID &p_id) :
+		Variant(p_id.operator uint64_t()) {
+}
+
 Variant::Variant(const Callable &v) {
 	from_type_constructor[CALLABLE](_native_ptr(), v._native_ptr());
 }
@@ -408,6 +412,21 @@ Variant::operator Object *() const {
 		return nullptr;
 	}
 	return reinterpret_cast<Object *>(internal::gde_interface->object_get_instance_binding(obj, internal::token, &Object::___binding_callbacks));
+}
+
+Variant::operator ObjectID() const {
+	if (get_type() == Type::INT) {
+		return ObjectID(operator uint64_t());
+	} else if (get_type() == Type::OBJECT) {
+		Object *obj = operator Object *();
+		if (obj != nullptr) {
+			return ObjectID(obj->get_instance_id());
+		} else {
+			return ObjectID();
+		}
+	} else {
+		return ObjectID();
+	}
 }
 
 Variant::operator Callable() const {


### PR DESCRIPTION
These conversions already exist in core but were missing from `godot-cpp`. We don't strictly need them because conversion between `ObjectID` and `uint64_t` exists, but it's a simple addition and it makes writing GDExtensions more convenient.

For example, trying to call the area monitor callback in a physics server GDExtension should look similar to [the way it is done in core](https://github.com/godotengine/godot/blob/57267709e665f1683e79bd5d3432be2be5db6c1d/servers/physics_2d/godot_area_2d.cpp#L237-L250). Before this PR that code would not compile in a GDExtension, and `E->key.instance_id` would have to be replaced by `(uint64_t)E->key.instance_id`.