### PR TITLE
Rename `float=64` build option to `precision=double`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             platform: linux
             artifact-name: godot-cpp-linux-glibc2.27-x86_64-double-release
             artifact-path: bin/libgodot-cpp.linux.template_release.double.x86_64.a
-            flags: float=64
+            flags: precision=double
             cache-name: linux-x86_64-f64
 
           - name: 🏁 Windows (x86_64, MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # godot-cpp cmake arguments
 # GODOT_GDEXTENSION_DIR:	Path to the directory containing GDExtension interface header and API JSON file
 # GODOT_CUSTOM_API_FILE:	Path to a custom GDExtension API JSON file (takes precedence over `gdextension_dir`)
-# FLOAT_TYPE				Floating-point precision (32, 64)
+# FLOAT_PRECISION:			Floating-point precision level ("single", "double")
 #
 # Android cmake arguments
 # CMAKE_TOOLCHAIN_FILE:		The path to the android cmake toolchain ($ANDROID_NDK/build/cmake/android.toolchain.cmake)
@@ -45,11 +45,6 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 	set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-set(FLOAT_TYPE_FLAG "float" CACHE STRING "")
-if(FLOAT_TYPE EQUAL 64)
-	set(FLOAT_TYPE_FLAG "double" CACHE STRING "")
-endif(FLOAT_TYPE EQUAL 64)
-
 if(NOT DEFINED BITS)
 	set(BITS 32)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -60,6 +55,10 @@ endif()
 # Input from user for GDExtension interface header and the API JSON file
 set(GODOT_GDEXTENSION_DIR "gdextension" CACHE STRING "")
 set(GODOT_CUSTOM_API_FILE "" CACHE STRING "")
+set(FLOAT_PRECISION "single" CACHE STRING "")
+if ("${FLOAT_PRECISION}" STREQUAL "double")
+	add_definitions(-DREAL_T_IS_DOUBLE)
+endif()
 
 set(GODOT_GDEXTENSION_API_FILE "${GODOT_GDEXTENSION_DIR}/extension_api.json")
 if (NOT "${GODOT_CUSTOM_API_FILE}" STREQUAL "")  # User-defined override.
@@ -136,7 +135,7 @@ execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; 
 )
 
 add_custom_command(OUTPUT ${GENERATED_FILES_LIST}
-		COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_GDEXTENSION_API_FILE}\", \"${GENERATE_BINDING_PARAMETERS}\", \"${BITS}\", \"${FLOAT_TYPE_FLAG}\", \"${CMAKE_CURRENT_BINARY_DIR}\")"
+		COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings(\"${GODOT_GDEXTENSION_API_FILE}\", \"${GENERATE_BINDING_PARAMETERS}\", \"${BITS}\", \"${FLOAT_PRECISION}\", \"${CMAKE_CURRENT_BINARY_DIR}\")"
 		VERBATIM
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		MAIN_DEPENDENCY ${GODOT_GDEXTENSION_API_FILE}

--- a/SConstruct
+++ b/SConstruct
@@ -99,7 +99,7 @@ opts.Add(
 opts.Add(BoolVariable("generate_template_get_node", "Generate a template version of the Node class's get_node.", True))
 
 opts.Add(BoolVariable("build_library", "Build the godot-cpp library.", True))
-opts.Add(EnumVariable("float", "Floating-point precision", "32", ("32", "64")))
+opts.Add(EnumVariable("precision", "Set the floating-point precision level", "single", ("single", "double")))
 
 # Add platform options
 tools = {}
@@ -181,7 +181,7 @@ if env.get("is_msvc", False):
 else:
     env.Append(CXXFLAGS=["-std=c++17"])
 
-if env["float"] == "64":
+if env["precision"] == "double":
     env.Append(CPPDEFINES=["REAL_T_IS_DOUBLE"])
 
 # Generate bindings
@@ -222,7 +222,7 @@ sources.extend([f for f in bindings if str(f).endswith(".cpp")])
 suffix = ".{}.{}".format(env["platform"], env["target"])
 if env.dev_build:
     suffix += ".dev"
-if env["float"] == "64":
+if env["precision"] == "double":
     suffix += ".double"
 suffix += "." + env["arch"]
 if env["ios_simulator"]:

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -151,13 +151,13 @@ def scons_generate_bindings(target, source, env):
         str(source[0]),
         env["generate_template_get_node"],
         "32" if "32" in env["arch"] else "64",
-        "double" if (env["float"] == "64") else "float",
+        env["precision"],
         env["godot_cpp_gen_dir"],
     )
     return None
 
 
-def generate_bindings(api_filepath, use_template_get_node, bits="64", double="float", output_dir="."):
+def generate_bindings(api_filepath, use_template_get_node, bits="64", precision="single", output_dir="."):
     api = None
 
     target_dir = Path(output_dir) / "gen"
@@ -168,11 +168,12 @@ def generate_bindings(api_filepath, use_template_get_node, bits="64", double="fl
     shutil.rmtree(target_dir, ignore_errors=True)
     target_dir.mkdir(parents=True)
 
-    print("Built-in type config: " + double + "_" + bits)
+    real_t = "double" if precision == "double" else "float"
+    print("Built-in type config: " + real_t + "_" + bits)
 
     generate_global_constants(api, target_dir)
     generate_global_constant_binds(api, target_dir)
-    generate_builtin_bindings(api, target_dir, double + "_" + bits)
+    generate_builtin_bindings(api, target_dir, real_t + "_" + bits)
     generate_engine_classes_bindings(api, target_dir, use_template_get_node)
     generate_utility_functions(api, target_dir)
 

--- a/misc/scripts/check_get_file_list.py
+++ b/misc/scripts/check_get_file_list.py
@@ -10,10 +10,10 @@ from binding_generator import get_file_list, generate_bindings
 
 api_filepath = "gdextension/extension_api.json"
 bits = "64"
-double = "float"
+precision = "single"
 output_dir = "self_test"
 
-generate_bindings(api_filepath, use_template_get_node=False, bits=bits, double=double, output_dir=output_dir)
+generate_bindings(api_filepath, use_template_get_node=False, bits=bits, precision=precision, output_dir=output_dir)
 flist = get_file_list(api_filepath, output_dir, headers=True, sources=True)
 
 p = Path(output_dir) / "gen"


### PR DESCRIPTION
This makes the build system consistent with Godot again; see https://github.com/godotengine/godot/pull/67399.

~~TODO:~~
- [x] Update CMake build file.

Also fixes the CMake build to define `REAL_T_IS_DOUBLE` when needed.