### PR TITLE
Allow method binds to take Object subclasses as arguments

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -86,21 +86,36 @@ namespace godot {
 template <class T>
 struct VariantCaster {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
-		return p_variant;
+		using TStripped = std::remove_pointer_t<T>;
+		if constexpr (std::is_base_of<Object, TStripped>::value) {
+			return Object::cast_to<TStripped>(p_variant);
+		} else {
+			return p_variant;
+		}
 	}
 };
 
 template <class T>
 struct VariantCaster<T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
-		return p_variant;
+		using TStripped = std::remove_pointer_t<T>;
+		if constexpr (std::is_base_of<Object, TStripped>::value) {
+			return Object::cast_to<TStripped>(p_variant);
+		} else {
+			return p_variant;
+		}
 	}
 };
 
 template <class T>
 struct VariantCaster<const T &> {
 	static _FORCE_INLINE_ T cast(const Variant &p_variant) {
-		return p_variant;
+		using TStripped = std::remove_pointer_t<T>;
+		if constexpr (std::is_base_of<Object, TStripped>::value) {
+			return Object::cast_to<TStripped>(p_variant);
+		} else {
+			return p_variant;
+		}
 	}
 };
 

--- a/test/demo/main.gd
+++ b/test/demo/main.gd
@@ -33,6 +33,7 @@ func _ready():
 	var ret_ref = $Example.return_extended_ref()
 	prints("  returned ref", ret_ref.get_instance_id(), ", id:", ret_ref.get_id())
 	prints("  returned ", $Example.get_v4())
+	prints("  test node argument", $Example.test_node_argument($Example))
 
 	prints("VarArg method calls")
 	var ref = ExampleRef.new()

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -122,6 +122,7 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("test_tarray_arg", "array"), &Example::test_tarray_arg);
 	ClassDB::bind_method(D_METHOD("test_tarray"), &Example::test_tarray);
 	ClassDB::bind_method(D_METHOD("test_dictionary"), &Example::test_dictionary);
+	ClassDB::bind_method(D_METHOD("test_node_argument"), &Example::test_node_argument);
 
 	ClassDB::bind_method(D_METHOD("def_args", "a", "b"), &Example::def_args, DEFVAL(100), DEFVAL(200));
 
@@ -210,6 +211,11 @@ ExampleRef *Example::return_extended_ref() const {
 	// and it will be destroyed when all references are destroyed. If you store this pointer you run the risk of having a pointer
 	// to a destroyed object.
 	return memnew(ExampleRef());
+}
+
+Example *Example::test_node_argument(Example *p_node) const {
+	UtilityFunctions::print("  Test node argument called with ", p_node ? String::num(p_node->get_instance_id()) : "null");
+	return p_node;
 }
 
 Ref<ExampleRef> Example::extended_ref_checks(Ref<ExampleRef> p_ref) const {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -100,6 +100,7 @@ public:
 	void test_tarray_arg(const TypedArray<int64_t> &p_array);
 	TypedArray<Vector2> test_tarray() const;
 	Dictionary test_dictionary() const;
+	Example *test_node_argument(Example *p_node) const;
 
 	// Property.
 	void set_custom_position(const Vector2 &pos);


### PR DESCRIPTION
As done in upstream Godot via GH-57205.

Add a test that ensures it works also for "gdextended" objects.

See godotengine/godot#57205