### PR TITLE
"Wrapped" has virtual functions so it should have a virtual destructor.

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -77,6 +77,7 @@ protected:
 
 	Wrapped(const StringName p_godot_class);
 	Wrapped(GodotObject *p_godot_object);
+	virtual ~Wrapped() {}
 
 public:
 	static StringName &get_class_static() {


### PR DESCRIPTION
Deleting an object through a pointer to a base class is undefined behaviour unless the destructor in the base class is virtual.