### PR TITLE
Fix Basis::scaled_orthogonal using incorrect abs function.

### DIFF
--- a/src/variant/basis.cpp
+++ b/src/variant/basis.cpp
@@ -261,7 +261,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	Basis b;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
+			dots[j] += s[i] * Math::abs(m.get_column(i).normalized().dot(b.get_column(j)));
 		}
 	}
 	m.scale_local(Vector3(1, 1, 1) + dots);


### PR DESCRIPTION
Spotted by clang with `-Wall -Wextra`:

```
/media/SSD/Code/git/godot-cpp-dev/src/variant/basis.cpp:264:22: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
                        dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
                                          ^
/media/SSD/Code/git/godot-cpp-dev/src/variant/basis.cpp:264:22: note: use function 'std::abs' instead
                        dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
                                          ^~~
                                          std::abs
```