### PR TITLE
Change behavior of Math::sign to match Godot builtin

### DIFF
--- a/include/godot_cpp/core/math.hpp
+++ b/include/godot_cpp/core/math.hpp
@@ -433,7 +433,7 @@ inline T max(T a, T b) {
 
 template <typename T>
 inline T sign(T x) {
-	return static_cast<T>(x < 0 ? -1 : 1);
+	return static_cast<T>(SIGN(x));
 }
 
 template <typename T>


### PR DESCRIPTION
- Fixes #551.
- Supersedes #553.