### PR TITLE
Fix variant call compiler error

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -262,7 +262,7 @@ public:
 		Variant result;
 		GDExtensionCallError error;
 		std::array<GDExtensionConstVariantPtr, sizeof...(Args)> call_args = { Variant(args)... };
-		call(method, call_args.data(), call_args.size(), result, error);
+		call(method, call_args.data(), static_cast<int<(call_args.size()), result, error);
 		return result;
 	}
 
@@ -273,7 +273,7 @@ public:
 		Variant result;
 		GDExtensionCallError error;
 		std::array<GDExtensionConstVariantPtr, sizeof...(Args)> call_args = { Variant(args)... };
-		call_static(type, method, call_args.data(), call_args.size(), result, error);
+		call_static(type, method, call_args.data(), static_cast<int>(call_args.size()), result, error);
 		return result;
 	}
 


### PR DESCRIPTION
Fixes #1015, the compiler gets confused because the function arguments are too similar