### PR TITLE
Fix variant call compiler error

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -38,6 +38,7 @@
 
 #include <gdextension_interface.h>
 
+#include <algorithm>
 #include <array>
 
 namespace godot {
@@ -255,25 +256,33 @@ public:
 	bool operator!=(const Variant &other) const;
 	bool operator<(const Variant &other) const;
 
-	void call(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error);
+	void callp(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error);
 
 	template <class... Args>
 	Variant call(const StringName &method, Args... args) {
+		std::array<Variant, sizeof...(args)> vargs = { args... };
+		std::array<const Variant *, sizeof...(args)> argptrs;
+		std::transform(vargs.begin(), vargs.end(), argptrs.begin(), [](Variant &arg) -> Variant * {
+			return &arg;
+		});
 		Variant result;
 		GDExtensionCallError error;
-		std::array<GDExtensionConstVariantPtr, sizeof...(Args)> call_args = { Variant(args)... };
-		call(method, call_args.data(), call_args.size(), result, error);
+		callp(method, argptrs.data(), argptrs.size(), result, error);
 		return result;
 	}
 
-	static void call_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error);
+	static void callp_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error);
 
 	template <class... Args>
 	static Variant call_static(Variant::Type type, const StringName &method, Args... args) {
+		std::array<Variant, sizeof...(args)> vargs = { args... };
+		std::array<const Variant *, sizeof...(args)> argptrs;
+		std::transform(vargs.begin(), vargs.end(), argptrs.begin(), [](Variant &arg) -> Variant * {
+			return &arg;
+		});
 		Variant result;
 		GDExtensionCallError error;
-		std::array<GDExtensionConstVariantPtr, sizeof...(Args)> call_args = { Variant(args)... };
-		call_static(type, method, call_args.data(), call_args.size(), result, error);
+		callp_static(type, method, argptrs.data(), argptrs.size(), sizeof...(args), result, error);
 		return result;
 	}
 

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -548,11 +548,11 @@ bool Variant::operator<(const Variant &other) const {
 	return result.operator bool();
 }
 
-void Variant::call(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error) {
+void Variant::callp(const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error) {
 	internal::gde_interface->variant_call(_native_ptr(), method._native_ptr(), reinterpret_cast<GDExtensionConstVariantPtr *>(args), argcount, r_ret._native_ptr(), &r_error);
 }
 
-void Variant::call_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error) {
+void Variant::callp_static(Variant::Type type, const StringName &method, const Variant **args, int argcount, Variant &r_ret, GDExtensionCallError &r_error) {
 	internal::gde_interface->variant_call_static(static_cast<GDExtensionVariantType>(type), method._native_ptr(), reinterpret_cast<GDExtensionConstVariantPtr *>(args), argcount, r_ret._native_ptr(), &r_error);
 }
 


### PR DESCRIPTION
Fixes #1015, the compiler gets confused because the function wasn't using `Variant **`. I tried to keep it as true to the original by using `std::array` but I had to rename functions like `call` -> `callp`.