### PR TITLE
Support typed array default values in extension API 

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2129,6 +2129,8 @@ def correct_default_value(value, type_name):
         return value_map[value]
     if value == "":
         return f"{type_name}()"
+    if value.startswith("Array["):
+        return f"{{}}"
     return value
 
 

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -108,7 +108,7 @@ public:
 
 template <class T>
 void memdelete(T *p_class, typename std::enable_if<!std::is_base_of_v<godot::Wrapped, T>>::type * = nullptr) {
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		p_class->~T();
 	}
 
@@ -122,7 +122,7 @@ void memdelete(T *p_class) {
 
 template <class T, class A>
 void memdelete_allocator(T *p_class) {
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		p_class->~T();
 	}
 
@@ -145,7 +145,7 @@ T *memnew_arr_template(size_t p_elements, const char *p_descr = "") {
 	ERR_FAIL_COND_V(!mem, failptr);
 	*(mem - 1) = p_elements;
 
-	if (!__has_trivial_constructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		T *elems = (T *)mem;
 
 		/* call operator new */
@@ -161,7 +161,7 @@ template <typename T>
 void memdelete_arr(T *p_class) {
 	uint64_t *ptr = (uint64_t *)p_class;
 
-	if (!__has_trivial_destructor(T)) {
+	if (!std::is_trivially_destructible<T>::value) {
 		uint64_t elem_count = *(ptr - 1);
 
 		for (uint64_t i = 0; i < elem_count; i++) {


### PR DESCRIPTION
The API JSON has changed syntax for default values of typed arrays. This detects the new format and use initializer lists (currently empty since the TypedArray class does not support initializer list construction and
default values are always empty arrays).

The format is changed by https://github.com/godotengine/godot/pull/69248 **Note:** This PR works with both the old and new format, so it won't break anything even if merged before the change in Godot.

I snuck in a change in the `memory.hpp` to remove an annoying compiler warning. It just does what has been done in Godot a while ago.