### PR TITLE
Update typed array API to match "GDScript: Fix typed arrays".

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -696,6 +696,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
         result.append("\tconst Variant &operator[](int p_index) const;")
         result.append("\tVariant &operator[](int p_index);")
         result.append("\tvoid set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);")
+        result.append("\tvoid _ref(const Array &p_from) const;")
 
     if class_name == "Dictionary":
         result.append("\tconst Variant &operator[](const Variant &p_key) const;")

--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -551,6 +551,7 @@ typedef struct {
 
 	GDExtensionVariantPtr (*array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
 	GDExtensionVariantPtr (*array_operator_index_const)(GDExtensionConstTypePtr p_self, GDExtensionInt p_index); // p_self should be an Array ptr
+	void (*array_ref)(GDExtensionTypePtr p_self, GDExtensionConstTypePtr p_from); // p_self should be an Array ptr
 	void (*array_set_typed)(GDExtensionTypePtr p_self, uint32_t p_type, GDExtensionConstStringNamePtr p_class_name, GDExtensionConstVariantPtr p_script); // p_self should be an Array ptr
 
 	/* Dictionary functions */

--- a/include/godot_cpp/variant/typed_array.hpp
+++ b/include/godot_cpp/variant/typed_array.hpp
@@ -39,14 +39,9 @@ namespace godot {
 template <class T>
 class TypedArray : public Array {
 public:
-	template <class U>
-	_FORCE_INLINE_ void operator=(const TypedArray<U> &p_array) {
-		static_assert(__is_base_of(T, U));
-		typed_assign(p_array);
-	}
-
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
-		typed_assign(p_array);
+		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
+		_ref(p_array);
 	}
 	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
 			Array(p_variant.operator Array(), Variant::OBJECT, T::get_class_static(), Variant()) {
@@ -61,22 +56,23 @@ public:
 
 // specialization for the rest of variant types
 
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                             \
-	template <>                                                                              \
-	class TypedArray<m_type> : public Array {                                                \
-	public:                                                                                  \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                \
-			typed_assign(p_array);                                                           \
-		}                                                                                    \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                \
-				Array(p_variant.operator Array(), m_variant_type, StringName(), Variant()) { \
-		}                                                                                    \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) :                                    \
-				Array(p_array, m_variant_type, StringName(), Variant()) {                    \
-		}                                                                                    \
-		_FORCE_INLINE_ TypedArray() {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                              \
-		}                                                                                    \
+#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
+	template <>                                                                                                  \
+	class TypedArray<m_type> : public Array {                                                                    \
+	public:                                                                                                      \
+		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
+			_ref(p_array);                                                                                       \
+		}                                                                                                        \
+		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
+				Array(p_variant.operator Array(), m_variant_type, StringName(), Variant()) {                     \
+		}                                                                                                        \
+		_FORCE_INLINE_ TypedArray(const Array &p_array) :                                                        \
+				Array(p_array, m_variant_type, StringName(), Variant()) {                                        \
+		}                                                                                                        \
+		_FORCE_INLINE_ TypedArray() {                                                                            \
+			set_typed(m_variant_type, StringName(), Variant());                                                  \
+		}                                                                                                        \
 	};
 
 MAKE_TYPED_ARRAY(bool, Variant::BOOL)

--- a/src/variant/packed_arrays.cpp
+++ b/src/variant/packed_arrays.cpp
@@ -212,6 +212,10 @@ void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Var
 	internal::gde_interface->array_set_typed((GDExtensionTypePtr *)this, p_type, (GDExtensionConstStringNamePtr)&p_class_name, (GDExtensionConstVariantPtr)&p_script);
 }
 
+void Array::_ref(const Array &p_from) const {
+	internal::gde_interface->array_ref((GDExtensionTypePtr *)this, (GDExtensionConstTypePtr *)&p_from);
+}
+
 const Variant &Dictionary::operator[](const Variant &p_key) const {
 	const Variant *var = (const Variant *)internal::gde_interface->dictionary_operator_index_const((GDExtensionTypePtr *)this, (GDExtensionVariantPtr)&p_key);
 	return *var;


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/pull/69248