### PR TITLE
Fix global enum cast and add `Varint::Type`'s cast.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1621,7 +1621,13 @@ def generate_global_constant_binds(api, output_dir):
         if enum_def["name"].startswith("Variant."):
             continue
 
-        header.append(f'VARIANT_ENUM_CAST(godot::{enum_def["name"]});')
+        if enum_def["is_bitfield"]:
+            header.append(f'VARIANT_BITFIELD_CAST(godot::{enum_def["name"]});')
+        else:
+            header.append(f'VARIANT_ENUM_CAST(godot::{enum_def["name"]});')
+
+    # Variant::Type is not a global enum, but only one line, it is worth to place in this file instead of creating new file.
+    header.append(f"VARIANT_ENUM_CAST(godot::Variant::Type);")
 
     header.append("")
 


### PR DESCRIPTION
Fix another issue about compile error of missing `godot::ArgToPrt<godot::BitField<godot::PropertyUsageFlags>>` and  `godot::ArgToPrt<godot::Variant::Type>`.

Occur in `EditorInspectorPlugin::_parse_property(Object *object, Variant::Type type, const String &name, PropertyHint hint_type, const String &hint_string, BitField<PropertyUsageFlags> usage_flags, bool wide)`.