### PR TITLE
Expose ClassDB::classes

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -101,6 +101,10 @@ public:
 		ClassInfo *parent_ptr = nullptr;
 	};
 
+	static const std::unordered_map<StringName, ClassInfo> get_custom_classes() {
+		return classes;
+	}
+
 private:
 	// This may only contain custom classes, not Godot classes
 	static std::unordered_map<StringName, ClassInfo> classes;


### PR DESCRIPTION
Small but needed change, which provides access to the reflection info of all registered classes.

This is essentially a boiled down version of https://github.com/godotengine/godot-cpp/pull/936, since it pretty does the same thing but without a fancy singleton wrapper.