### PR TITLE
Fix Object::cast_to<T>() for custom classes

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -142,7 +142,7 @@ T *Object::cast_to(Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<T *>(internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return dynamic_cast<T *>((Object *)internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
 template <class T>
@@ -155,7 +155,7 @@ const T *Object::cast_to(const Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<const T *>(internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return dynamic_cast<const T *>((Object *)internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
 } // namespace godot


### PR DESCRIPTION
Fixes #995 and https://github.com/godotengine/godot/issues/71332

I tried a bunch of different variations on this, including using `p_object->is_class(class_name)` to check if the object was the right type, AND making changes in the Godot engine itself in `gdextension_object_cast_to()` (which would break the GDExtension ABI, but Remi actually said that would be fine while GDExtension is experimental :-)).

However, assuming there isn't some case where this won't work that I didn't think of, I like the version in this PR the best so far!

It's switching to `dynamic_cast<T>` at the end, which means C++ will check if the final class matches the requested type using RTTI. This should be much faster than `p_object->is_class(class_name)` (since that relies on walking up the inheritance chain and comparing strings).

Anyway, it's working in my testing with SG Physics 2D!