### PR TITLE
Fix compilation error: const GDExtensionStringPtr -> GDExtensionConst…

### DIFF
--- a/src/classes/low_level.cpp
+++ b/src/classes/low_level.cpp
@@ -48,11 +48,11 @@ void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 }
 
 WorkerThreadPool::TaskID WorkerThreadPool::add_native_task(void (*p_func)(void *), void *p_userdata, bool p_high_priority, const String &p_description) {
-	return (TaskID)internal::gde_interface->worker_thread_pool_add_native_task(_owner, p_func, p_userdata, p_high_priority, (const GDExtensionStringPtr)&p_description);
+	return (TaskID)internal::gde_interface->worker_thread_pool_add_native_task(_owner, p_func, p_userdata, p_high_priority, (GDExtensionConstStringPtr)&p_description);
 }
 
 WorkerThreadPool::GroupID WorkerThreadPool::add_native_group_task(void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks, bool p_high_priority, const String &p_description) {
-	return (GroupID)internal::gde_interface->worker_thread_pool_add_native_group_task(_owner, p_func, p_userdata, p_elements, p_tasks, p_high_priority, (const GDExtensionStringPtr)&p_description);
+	return (GroupID)internal::gde_interface->worker_thread_pool_add_native_group_task(_owner, p_func, p_userdata, p_elements, p_tasks, p_high_priority, (GDExtensionConstStringPtr)&p_description);
 }
 
 } // namespace godot

--- a/src/variant/char_string.cpp
+++ b/src/variant/char_string.cpp
@@ -353,7 +353,7 @@ String String::operator+(const char32_t p_char) {
 }
 
 String &String::operator+=(const String &p_str) {
-	internal::gde_interface->string_operator_plus_eq_string((GDExtensionStringPtr)this, (const GDExtensionStringPtr)&p_str);
+	internal::gde_interface->string_operator_plus_eq_string((GDExtensionStringPtr)this, (GDExtensionConstStringPtr)&p_str);
 	return *this;
 }
 


### PR DESCRIPTION
g++ 9.4.0 and cmake

Got these compilation errors:

```
godot-cpp/src/variant/char_string.cpp:356:115: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
  356 |  internal::gde_interface->string_operator_plus_eq_string((GDExtensionStringPtr)this, (const GDExtensionStringPtr)&p_str);

godot-cpp/src/classes/low_level.cpp:51:151: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   51 | )internal::gde_interface->worker_thread_pool_add_native_task(_owner, p_func, p_userdata, p_high_priority, (const GDExtensionStringPtr)&p_description);

godot-cpp/src/classes/low_level.cpp:55:179: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
   55 | orker_thread_pool_add_native_group_task(_owner, p_func, p_userdata, p_elements, p_tasks, p_high_priority, (const GDExtensionStringPtr)&p_description);
```

We expect `const void*` here but `const GDExtensionStringPtr` means `void* const`. We should use `GDExtensionConstStringPtr` instead.

