### PR TITLE
Fix crash using Object* as parameter

### DIFF
--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -168,7 +168,9 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <class T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)), godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(
+				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
+				godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -179,7 +181,9 @@ struct PtrToArg<T *> {
 template <class T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(godot::internal::gde_interface->object_get_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)), godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<const T *>(godot::internal::gde_interface->object_get_instance_binding(
+				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
+				godot::internal::token, &T::___binding_callbacks));
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {


### PR DESCRIPTION
Fixes #1020, fixes #1025 (only for `Object*` parameter crash, `Ref<Object>` crash reported recently is a different issue).

`*reinterpret_cast<GDExtensionObjectPtr *>` -> `reinterpret_cast<GDExtensionObjectPtr>` as the real type of `p_ptr` is `Object*` not `Object**`.



