### PR TITLE
Fix PtrToArg<Ref<T>> crash

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -240,11 +240,11 @@ public:
 template <class T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		GDExtensionRefPtr ref = (GDExtensionRefPtr)p_ptr;
-		ERR_FAIL_NULL_V(ref, Ref<T>());
-
-		T *obj = reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(godot::internal::gde_interface->ref_get_object(ref), godot::internal::token, &T::___binding_callbacks));
-		return Ref<T>(obj);
+		// Important: p_ptr is T*, not Ref<T>*, since Object* is what engine gives to ptrcall.
+		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(
+				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
+				godot::internal::token, &T::___binding_callbacks)));
 	}
 
 	typedef Ref<T> EncodeT;
@@ -266,7 +266,10 @@ struct PtrToArg<const Ref<T> &> {
 	typedef Ref<T> EncodeT;
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
-		return Ref<T>(reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)), godot::internal::token, &T::___binding_callbacks)));
+		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(
+				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
+				godot::internal::token, &T::___binding_callbacks)));
 	}
 };
 


### PR DESCRIPTION
Fixes #1021 #1024 which are exactly the same issue.

In [GDScript VM](https://github.com/godotengine/godot/blob/aa6ec763179e5bf1d1300aa72dc5f4172d810efa/modules/gdscript/gdscript_vm.cpp#L1863) we have


```c++
const void **argptrs = call_args_ptr;
for (int i = 0; i < argc; i++) {
  GET_INSTRUCTION_ARG(v, i); 
  argptrs[i] = VariantInternal::get_opaque_pointer((const Variant *)v);
} 
GET_INSTRUCTION_ARG(ret, argc + 1);
VariantInternal::initialize(ret, Variant::m_type); 
void *ret_opaque = VariantInternal::OP_GET_##m_type(ret);
method->ptrcall(base_obj, argptrs, ret_opaque);
```

It extracts the underlying data pointers from parameter variants -- ,  `Object*` for objects -- and call `ptrcall`.

In our GDExtension code, we may declare a method like this
```c++
void do_something(Ref<Foo> foo) const;
```

Godot-cpp will generate the code that binds it with GDExtension API.
For example, it could use (in  `binder_common.hpp`)
```c++
template <class T, class... P, size_t... Is>
void call_with_ptr_argsc_helper(T *p_instance, void (T::*p_method)(P...) const, const GDExtensionConstTypePtr *p_args, IndexSequence<Is...>) {
	(p_instance->*p_method)(PtrToArg<P>::convert(p_args[Is])...);
}
```

And for `Ref<Foo>` it calls
https://github.com/godotengine/godot-cpp/blob/f5133c08a529d027e3232d593b0f6c3ca45a0545/include/godot_cpp/classes/ref.hpp#L268

```c++
_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
  return Ref<T>(reinterpret_cast<T *>(godot::internal::gde_interface->object_get_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)), godot::internal::token, &T::___binding_callbacks)));
}
```

Now here is the problem. 
The engine-provided `p_ptr` is `Foo*`, while `godot-cpp` assumes it is `Ref<Foo>*` and tries to get `Foo*` from `Ref<Foo>::ptr()`, which naturally causes a crash.

This issue comes from the attempt to fix `Ref` return issue. See #958.
It turns out that only `encode` needs to be changed to set `Ref` on the engine side, `convert` should remains the same working with raw object pointers.

Hilariously, the previous implementation of `convert` before #958 was also wrong. It treated `p_ptr` as `Object**`, same as the issue in #1044.

