### PR TITLE
Revert "Fix Object::cast_to<T>() for custom classes"

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -142,7 +142,7 @@ T *Object::cast_to(Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return dynamic_cast<T *>((Object *)internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return reinterpret_cast<T *>(internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
 template <class T>
@@ -155,7 +155,7 @@ const T *Object::cast_to(const Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return dynamic_cast<const T *>((Object *)internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return reinterpret_cast<const T *>(internal::gde_interface->object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
 }
 
 } // namespace godot


### PR DESCRIPTION
This reverts PR #1037

I think I've got a way to fix the regressions and maintain the fixes from PR #1037, but it's kind of involved (requires a change on the Godot engine side, and a new generated file in godot-cpp) and so will probably require a bunch of review and back-and-forth. With the 4.0 stable release coming soon, let's just revert this for now, and I can finish a proper fix after 4.0 :-)

Fixes #1042
Fixes #1043

Re-opens #995
Re-opens https://github.com/godotengine/godot/issues/71332
