### PR TITLE
Identifiers containing double underscore are reserved according to the C++ standard

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -219,7 +219,7 @@ public:
 
 	// Used exclusively in the bindings to recreate the Ref Godot encapsulates in return values,
 	// without adding to the refcount.
-	inline static Ref<T> ___internal_constructor(Object *obj) {
+	inline static Ref<T> _gde_internal_constructor(Object *obj) {
 		Ref<T> r;
 		r.reference = (T *)obj;
 		return r;

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -109,7 +109,7 @@ protected:                                                                      
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	virtual const GDExtensionInstanceBindingCallbacks *_get_bindings_callbacks() const override {                                                                                      \
-		return &___binding_callbacks;                                                                                                                                                  \
+		return &_gde_binding_callbacks;                                                                                                                                                \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static void (*_get_bind_methods())() {                                                                                                                                             \
@@ -288,97 +288,97 @@ public:                                                                         
 		}                                                                                                                                                                              \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
-	static void *___binding_create_callback(void *p_token, void *p_instance) {                                                                                                         \
+	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                                                                                       \
 		return nullptr;                                                                                                                                                                \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
-	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                                           \
+	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                                         \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
-	static GDExtensionBool ___binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) {                                                               \
+	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) {                                                             \
 		return true;                                                                                                                                                                   \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
-	static constexpr GDExtensionInstanceBindingCallbacks ___binding_callbacks = {                                                                                                      \
-		___binding_create_callback,                                                                                                                                                    \
-		___binding_free_callback,                                                                                                                                                      \
-		___binding_reference_callback,                                                                                                                                                 \
+	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                                                                                    \
+		_gde_binding_create_callback,                                                                                                                                                  \
+		_gde_binding_free_callback,                                                                                                                                                    \
+		_gde_binding_reference_callback,                                                                                                                                               \
 	};
 
 // Don't use this for your classes, use GDCLASS() instead.
-#define GDEXTENSION_CLASS(m_class, m_inherits)                                                                           \
-private:                                                                                                                 \
-	void operator=(const m_class &p_rval) {}                                                                             \
-                                                                                                                         \
-protected:                                                                                                               \
-	virtual const GDExtensionInstanceBindingCallbacks *_get_bindings_callbacks() const override {                        \
-		return &___binding_callbacks;                                                                                    \
-	}                                                                                                                    \
-                                                                                                                         \
-	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                    \
-	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                 \
-                                                                                                                         \
-	static void (*_get_bind_methods())() {                                                                               \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static void (Wrapped::*_get_notification())(int) {                                                                   \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {                   \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                        \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) {                              \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) {                   \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-	static String (Wrapped::*_get_to_string())() {                                                                       \
-		return nullptr;                                                                                                  \
-	}                                                                                                                    \
-                                                                                                                         \
-public:                                                                                                                  \
-	static void initialize_class() {}                                                                                    \
-                                                                                                                         \
-	static ::godot::StringName &get_class_static() {                                                                     \
-		static ::godot::StringName string_name = ::godot::StringName(#m_class);                                          \
-		return string_name;                                                                                              \
-	}                                                                                                                    \
-                                                                                                                         \
-	static ::godot::StringName &get_parent_class_static() {                                                              \
-		return m_inherits::get_class_static();                                                                           \
-	}                                                                                                                    \
-                                                                                                                         \
-	static void *___binding_create_callback(void *p_token, void *p_instance) {                                           \
-		/* Do not call memnew here, we don't want the postinitializer to be called */                                    \
-		return new ("") m_class((GodotObject *)p_instance);                                                              \
-	}                                                                                                                    \
-	static void ___binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                             \
-		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                       \
-		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                              \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                     \
-	}                                                                                                                    \
-	static GDExtensionBool ___binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) { \
-		return true;                                                                                                     \
-	}                                                                                                                    \
-	static constexpr GDExtensionInstanceBindingCallbacks ___binding_callbacks = {                                        \
-		___binding_create_callback,                                                                                      \
-		___binding_free_callback,                                                                                        \
-		___binding_reference_callback,                                                                                   \
-	};                                                                                                                   \
+#define GDEXTENSION_CLASS(m_class, m_inherits)                                                                             \
+private:                                                                                                                   \
+	void operator=(const m_class &p_rval) {}                                                                               \
+                                                                                                                           \
+protected:                                                                                                                 \
+	virtual const GDExtensionInstanceBindingCallbacks *_get_bindings_callbacks() const override {                          \
+		return &_gde_binding_callbacks;                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                      \
+	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                   \
+                                                                                                                           \
+	static void (*_get_bind_methods())() {                                                                                 \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static void (Wrapped::*_get_notification())(int) {                                                                     \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {                     \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                          \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                  \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) {                                \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) {                     \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static String (Wrapped::*_get_to_string())() {                                                                         \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+public:                                                                                                                    \
+	static void initialize_class() {}                                                                                      \
+                                                                                                                           \
+	static ::godot::StringName &get_class_static() {                                                                       \
+		static ::godot::StringName string_name = ::godot::StringName(#m_class);                                            \
+		return string_name;                                                                                                \
+	}                                                                                                                      \
+                                                                                                                           \
+	static ::godot::StringName &get_parent_class_static() {                                                                \
+		return m_inherits::get_class_static();                                                                             \
+	}                                                                                                                      \
+                                                                                                                           \
+	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                           \
+		/* Do not call memnew here, we don't want the post-initializer to be called */                                     \
+		return new ("") m_class((GodotObject *)p_instance);                                                                \
+	}                                                                                                                      \
+	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                             \
+		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                         \
+		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                                \
+		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                       \
+	}                                                                                                                      \
+	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) { \
+		return true;                                                                                                       \
+	}                                                                                                                      \
+	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                        \
+		_gde_binding_create_callback,                                                                                      \
+		_gde_binding_free_callback,                                                                                        \
+		_gde_binding_reference_callback,                                                                                   \
+	};                                                                                                                     \
 	m_class() : m_class(#m_class) {}
 
 #endif // GODOT_WRAPPED_HPP

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -150,22 +150,22 @@ public:
 	godot::ClassDB::bind_integer_constant(get_class_static(), "", #m_constant, m_constant);
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	godot::ClassDB::bind_integer_constant(get_class_static(), godot::__constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
+	godot::ClassDB::bind_integer_constant(get_class_static(), godot::_gde_constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
 
 #define BIND_BITFIELD_FLAG(m_constant) \
-	godot::ClassDB::bind_integer_constant(get_class_static(), godot::__constant_get_bitfield_name(m_constant, #m_constant), #m_constant, m_constant, true);
+	godot::ClassDB::bind_integer_constant(get_class_static(), godot::_gde_constant_get_bitfield_name(m_constant, #m_constant), #m_constant, m_constant, true);
 
-#define BIND_VIRTUAL_METHOD(m_class, m_method)                                                                                                  \
-	{                                                                                                                                           \
-		auto ___call##m_method = [](GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr p_ret) -> void { \
-			call_with_ptr_args(reinterpret_cast<m_class *>(p_instance), &m_class::m_method, p_args, p_ret);                                     \
-		};                                                                                                                                      \
-		godot::ClassDB::bind_virtual_method(m_class::get_class_static(), #m_method, ___call##m_method);                                         \
+#define BIND_VIRTUAL_METHOD(m_class, m_method)                                                                                                \
+	{                                                                                                                                         \
+		auto _call##m_method = [](GDExtensionObjectPtr p_instance, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr p_ret) -> void { \
+			call_with_ptr_args(reinterpret_cast<m_class *>(p_instance), &m_class::m_method, p_args, p_ret);                                   \
+		};                                                                                                                                    \
+		godot::ClassDB::bind_virtual_method(m_class::get_class_static(), #m_method, _call##m_method);                                         \
 	}
 
 template <class T, bool is_abstract>
 void ClassDB::_register_class(bool p_virtual) {
-	instance_binding_callbacks[T::get_class_static()] = &T::___binding_callbacks;
+	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
 
 	// Register this class within our plugin
 	ClassInfo cl;
@@ -221,7 +221,7 @@ void ClassDB::register_abstract_class() {
 
 template <class T>
 void ClassDB::register_engine_class() {
-	instance_binding_callbacks[T::get_class_static()] = &T::___binding_callbacks;
+	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
 }
 
 template <class N, class M, typename... VarArgs>

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -268,8 +268,8 @@ MethodBind *create_vararg_method_bind(R (T::*p_method)(const Variant **, GDExten
 }
 
 #ifndef TYPED_METHOD_BIND
-class ___UnexistingClass;
-#define MB_T ___UnexistingClass
+class _gde_UnexistingClass;
+#define MB_T _gde_UnexistingClass
 #else
 #define MB_T T
 #endif

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -241,7 +241,7 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 	TEMPL_MAKE_ENUM_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
-inline StringName __constant_get_enum_name(T param, StringName p_constant) {
+inline StringName _gde_constant_get_enum_name(T param, StringName p_constant) {
 	if (GetTypeInfo<T>::VARIANT_TYPE == Variant::NIL) {
 		ERR_PRINT(("Missing VARIANT_ENUM_CAST for constant's enum: " + String(p_constant)).utf8().get_data());
 	}
@@ -288,7 +288,7 @@ public:
 	TEMPL_MAKE_BITFIELD_TYPE_INFO(m_enum, const m_enum &)
 
 template <typename T>
-inline StringName __constant_get_bitfield_name(T param, StringName p_constant) {
+inline StringName _gde_constant_get_bitfield_name(T param, StringName p_constant) {
 	if (GetTypeInfo<T>::VARIANT_TYPE == Variant::NIL) {
 		ERR_PRINT(("Missing VARIANT_ENUM_CAST for constant's bitfield: " + String(p_constant)).utf8().get_data());
 	}

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -54,7 +54,7 @@ Object *get_object_instance_binding(GodotObject *p_engine_object) {
 		binding_callbacks = ClassDB::get_instance_binding_callbacks(class_name);
 	}
 	if (binding_callbacks == nullptr) {
-		binding_callbacks = &Object::___binding_callbacks;
+		binding_callbacks = &Object::_gde_binding_callbacks;
 	}
 
 	return reinterpret_cast<Object *>(gdextension_interface_object_get_instance_binding(p_engine_object, token, binding_callbacks));


### PR DESCRIPTION
https://timsong-cpp.github.io/cppwp/n3337/global.names

https://en.cppreference.com/w/cpp/language/identifiers

Identifiers appearing as a token or preprocessing token (i.e., not in user-defined-string-literal like operator ""id) (since C++11) of one of the following forms are reserved:
 - identifiers with a double underscore anywhere;
 - identifiers that begin with an underscore followed by an uppercase letter;
 - in the global namespace, identifiers that begin with an underscore.