### PR TITLE
Ensure GDExtension class is the correct type for the Godot engine class

### DIFF
--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -1880,6 +1880,19 @@ typedef void (*GDExtensionInterfaceObjectSetInstanceBinding)(GDExtensionObjectPt
 typedef void (*GDExtensionInterfaceObjectSetInstance)(GDExtensionObjectPtr p_o, GDExtensionConstStringNamePtr p_classname, GDExtensionClassInstancePtr p_instance); /* p_classname should be a registered extension class and should extend the p_o object's class. */
 
 /**
+ * @name object_get_class_name
+ *
+ * Gets the class name of an Object.
+ *
+ * @param p_object A pointer to the Object.
+ * @param p_library A pointer the library received by the GDExtension's entry point function.
+ * @param r_class_name A pointer to a String to receive the class name.
+ *
+ * @return true if successful in getting the class name; otherwise false.
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceObjectGetClassName)(GDExtensionConstObjectPtr p_object, GDExtensionClassLibraryPtr p_library, GDExtensionStringNamePtr r_class_name);
+
+/**
  * @name object_cast_to
  *
  * Casts an Object to a different type.

--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -242,9 +242,7 @@ struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 		// Important: p_ptr is T*, not Ref<T>*, since Object* is what engine gives to ptrcall.
 		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
-		return Ref<T>(reinterpret_cast<T *>(godot::internal::gdextension_interface_object_get_instance_binding(
-				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
-				godot::internal::token, &T::___binding_callbacks)));
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::get_object_instance_binding(reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)))));
 	}
 
 	typedef Ref<T> EncodeT;
@@ -267,9 +265,7 @@ struct PtrToArg<const Ref<T> &> {
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
-		return Ref<T>(reinterpret_cast<T *>(godot::internal::gdextension_interface_object_get_instance_binding(
-				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
-				godot::internal::token, &T::___binding_callbacks)));
+		return Ref<T>(reinterpret_cast<T *>(godot::internal::get_object_instance_binding(reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)))));
 	}
 };
 

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -104,6 +104,7 @@ public:
 private:
 	// This may only contain custom classes, not Godot classes
 	static std::unordered_map<StringName, ClassInfo> classes;
+	static std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *> instance_binding_callbacks;
 
 	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const void **p_defs, int p_defcount);
 	static void initialize_class(const ClassInfo &cl);
@@ -117,6 +118,8 @@ public:
 	static void register_class(bool p_virtual = false);
 	template <class T>
 	static void register_abstract_class();
+	template <class T>
+	static void register_engine_class();
 
 	template <class N, class M, typename... VarArgs>
 	static MethodBind *bind_method(N p_method_name, M p_method, VarArgs... p_args);
@@ -137,6 +140,7 @@ public:
 	static MethodBind *get_method(const StringName &p_class, const StringName &p_method);
 
 	static GDExtensionClassCallVirtual get_virtual_func(void *p_userdata, GDExtensionConstStringNamePtr p_name);
+	static const GDExtensionInstanceBindingCallbacks *get_instance_binding_callbacks(const StringName &p_class);
 
 	static void initialize(GDExtensionInitializationLevel p_level);
 	static void deinitialize(GDExtensionInitializationLevel p_level);
@@ -161,6 +165,8 @@ public:
 
 template <class T, bool is_abstract>
 void ClassDB::_register_class(bool p_virtual) {
+	instance_binding_callbacks[T::get_class_static()] = &T::___binding_callbacks;
+
 	// Register this class within our plugin
 	ClassInfo cl;
 	cl.name = T::get_class_static();
@@ -211,6 +217,11 @@ void ClassDB::register_class(bool p_virtual) {
 template <class T>
 void ClassDB::register_abstract_class() {
 	ClassDB::_register_class<T, true>();
+}
+
+template <class T>
+void ClassDB::register_engine_class() {
+	instance_binding_callbacks[T::get_class_static()] = &T::___binding_callbacks;
 }
 
 template <class N, class M, typename... VarArgs>

--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -51,7 +51,7 @@ O *_call_native_mb_ret_obj(const GDExtensionMethodBindPtr mb, void *instance, co
 	if (ret == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<O *>(internal::gdextension_interface_object_get_instance_binding(ret, internal::token, &O::___binding_callbacks));
+	return reinterpret_cast<O *>(internal::get_object_instance_binding(ret));
 }
 
 template <class R, class... Args>
@@ -81,7 +81,7 @@ Object *_call_utility_ret_obj(const GDExtensionPtrUtilityFunction func, void *in
 	GodotObject *ret = nullptr;
 	std::array<GDExtensionConstTypePtr, sizeof...(Args)> mb_args = { { (GDExtensionConstTypePtr)args... } };
 	func(&ret, mb_args.data(), mb_args.size());
-	return (Object *)internal::gdextension_interface_object_get_instance_binding(ret, internal::token, &Object::___binding_callbacks);
+	return (Object *)internal::get_object_instance_binding(ret);
 }
 
 template <class... Args>

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -33,6 +33,7 @@
 
 #include <godot_cpp/core/defs.hpp>
 
+#include <godot_cpp/core/object.hpp>
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
@@ -168,9 +169,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <class T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return reinterpret_cast<T *>(godot::internal::gdextension_interface_object_get_instance_binding(
-				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
-				godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<T *>(godot::internal::get_object_instance_binding(reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr))));
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
@@ -181,9 +180,7 @@ struct PtrToArg<T *> {
 template <class T>
 struct PtrToArg<const T *> {
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(godot::internal::gdextension_interface_object_get_instance_binding(
-				reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr)),
-				godot::internal::token, &T::___binding_callbacks));
+		return reinterpret_cast<const T *>(godot::internal::get_object_instance_binding(reinterpret_cast<GDExtensionObjectPtr>(const_cast<void *>(p_ptr))));
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -52,6 +52,12 @@
 
 namespace godot {
 
+namespace internal {
+
+Object *get_object_instance_binding(GodotObject *);
+
+} // namespace internal
+
 struct MethodInfo {
 	StringName name;
 	PropertyInfo return_val;
@@ -128,7 +134,7 @@ public:
 		if (obj == nullptr) {
 			return nullptr;
 		}
-		return reinterpret_cast<Object *>(internal::gdextension_interface_object_get_instance_binding(obj, internal::token, &Object::___binding_callbacks));
+		return internal::get_object_instance_binding(obj);
 	}
 };
 
@@ -142,7 +148,7 @@ T *Object::cast_to(Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<T *>(internal::gdextension_interface_object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return dynamic_cast<T *>(internal::get_object_instance_binding(casted));
 }
 
 template <class T>
@@ -155,7 +161,7 @@ const T *Object::cast_to(const Object *p_object) {
 	if (casted == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<const T *>(internal::gdextension_interface_object_get_instance_binding(casted, internal::token, &T::___binding_callbacks));
+	return dynamic_cast<const T *>(internal::get_object_instance_binding(casted));
 }
 
 } // namespace godot

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -159,6 +159,7 @@ extern "C" GDExtensionInterfaceGlobalGetSingleton gdextension_interface_global_g
 extern "C" GDExtensionInterfaceObjectGetInstanceBinding gdextension_interface_object_get_instance_binding;
 extern "C" GDExtensionInterfaceObjectSetInstanceBinding gdextension_interface_object_set_instance_binding;
 extern "C" GDExtensionInterfaceObjectSetInstance gdextension_interface_object_set_instance;
+extern "C" GDExtensionInterfaceObjectGetClassName gdextension_interface_object_get_class_name;
 extern "C" GDExtensionInterfaceObjectCastTo gdextension_interface_object_cast_to;
 extern "C" GDExtensionInterfaceObjectGetInstanceFromId gdextension_interface_object_get_instance_from_id;
 extern "C" GDExtensionInterfaceObjectGetInstanceId gdextension_interface_object_get_instance_id;
@@ -188,6 +189,9 @@ enum ModuleInitializationLevel {
 };
 
 class GDExtensionBinding {
+private:
+	static void register_engine_classes();
+
 public:
 	using Callback = void (*)(ModuleInitializationLevel p_level);
 

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -40,6 +40,7 @@
 namespace godot {
 
 std::unordered_map<StringName, ClassDB::ClassInfo> ClassDB::classes;
+std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *> ClassDB::instance_binding_callbacks;
 GDExtensionInitializationLevel ClassDB::current_level = GDEXTENSION_INITIALIZATION_CORE;
 
 MethodDefinition D_METHOD(StringName p_name) {
@@ -312,6 +313,12 @@ GDExtensionClassCallVirtual ClassDB::get_virtual_func(void *p_userdata, GDExtens
 	}
 
 	return nullptr;
+}
+
+const GDExtensionInstanceBindingCallbacks *ClassDB::get_instance_binding_callbacks(const StringName &p_class) {
+	std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *>::iterator callbacks_it = instance_binding_callbacks.find(p_class);
+	ERR_FAIL_COND_V_MSG(callbacks_it == instance_binding_callbacks.end(), nullptr, String("Cannot find instance binding callbacks for class '{0}'.").format(Array::make(p_class)));
+	return callbacks_it->second;
 }
 
 void ClassDB::bind_virtual_method(const StringName &p_class, const StringName &p_method, GDExtensionClassCallVirtual p_call) {

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -30,7 +30,37 @@
 
 #include <godot_cpp/core/object.hpp>
 
+#include <godot_cpp/core/class_db.hpp>
+
 namespace godot {
+
+namespace internal {
+
+Object *get_object_instance_binding(GodotObject *p_engine_object) {
+	if (p_engine_object == nullptr) {
+		return nullptr;
+	}
+
+	// Get existing instance binding, if one already exists.
+	GDExtensionObjectPtr instance = gdextension_interface_object_get_instance_binding(p_engine_object, token, nullptr);
+	if (instance != nullptr) {
+		return reinterpret_cast<Object *>(instance);
+	}
+
+	// Otherwise, try to look up the correct binding callbacks.
+	const GDExtensionInstanceBindingCallbacks *binding_callbacks = nullptr;
+	StringName class_name;
+	if (gdextension_interface_object_get_class_name(p_engine_object, library, reinterpret_cast<GDExtensionStringNamePtr>(class_name._native_ptr()))) {
+		binding_callbacks = ClassDB::get_instance_binding_callbacks(class_name);
+	}
+	if (binding_callbacks == nullptr) {
+		binding_callbacks = &Object::___binding_callbacks;
+	}
+
+	return reinterpret_cast<Object *>(gdextension_interface_object_get_instance_binding(p_engine_object, token, binding_callbacks));
+}
+
+} // namespace internal
 
 MethodInfo::MethodInfo() :
 		flags(GDEXTENSION_METHOD_FLAG_NORMAL) {}

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -163,6 +163,7 @@ GDExtensionInterfaceGlobalGetSingleton gdextension_interface_global_get_singleto
 GDExtensionInterfaceObjectGetInstanceBinding gdextension_interface_object_get_instance_binding = nullptr;
 GDExtensionInterfaceObjectSetInstanceBinding gdextension_interface_object_set_instance_binding = nullptr;
 GDExtensionInterfaceObjectSetInstance gdextension_interface_object_set_instance = nullptr;
+GDExtensionInterfaceObjectGetClassName gdextension_interface_object_get_class_name = nullptr;
 GDExtensionInterfaceObjectCastTo gdextension_interface_object_cast_to = nullptr;
 GDExtensionInterfaceObjectGetInstanceFromId gdextension_interface_object_get_instance_from_id = nullptr;
 GDExtensionInterfaceObjectGetInstanceId gdextension_interface_object_get_instance_id = nullptr;
@@ -342,6 +343,7 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	LOAD_PROC_ADDRESS(object_get_instance_binding, GDExtensionInterfaceObjectGetInstanceBinding);
 	LOAD_PROC_ADDRESS(object_set_instance_binding, GDExtensionInterfaceObjectSetInstanceBinding);
 	LOAD_PROC_ADDRESS(object_set_instance, GDExtensionInterfaceObjectSetInstance);
+	LOAD_PROC_ADDRESS(object_get_class_name, GDExtensionInterfaceObjectGetClassName);
 	LOAD_PROC_ADDRESS(object_cast_to, GDExtensionInterfaceObjectCastTo);
 	LOAD_PROC_ADDRESS(object_get_instance_from_id, GDExtensionInterfaceObjectGetInstanceFromId);
 	LOAD_PROC_ADDRESS(object_get_instance_id, GDExtensionInterfaceObjectGetInstanceId);
@@ -371,6 +373,7 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	ERR_FAIL_COND_V_MSG(init_callback == nullptr, false, "Initialization callback must be defined.");
 
 	Variant::init_bindings();
+	register_engine_classes();
 
 	return true;
 }

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -33,6 +33,7 @@
 #include <godot_cpp/godot.hpp>
 
 #include <godot_cpp/core/binder_common.hpp>
+#include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 
 #include <utility>
@@ -411,7 +412,7 @@ Variant::operator Object *() const {
 	if (obj == nullptr) {
 		return nullptr;
 	}
-	return reinterpret_cast<Object *>(internal::gdextension_interface_object_get_instance_binding(obj, internal::token, &Object::___binding_callbacks));
+	return internal::get_object_instance_binding(obj);
 }
 
 Variant::operator ObjectID() const {


### PR DESCRIPTION
As discovered after merging PR #1037 (which was later reverted), when a Godot engine class is created on the Godot side and then passed to GDExtension, the GDExtension class that is created may not be of the correct type (most often it'll be created as `godot::Object` and then be unsafely cast to the correct class, which could lead to strange/incorrect behavior later).

This is explained in detail in these two comments:

- https://github.com/godotengine/godot-cpp/issues/1042#issuecomment-1432251538
- https://github.com/godotengine/godot-cpp/issues/995#issuecomment-1434345271

This PR aims to ensure that the GDExtension class that's created to wrap a Godot engine class always matches the Godot class it wraps.

This is a draft currently, because there is still more that I'd like to do:

- ~~This isn't as efficient as it could be. We're always looking up the instance binding callbacks, even when we don't need them (which would be the case for any class created on the GDExtension side)~~
- ~~I'd like to make a utility method somewhere to correctly convert from a `GodotObject*` to a `godot::Object`, rather than have it only exist in `Variant::operator Object*()`~~
- ~~As pointed out by @zhehangd in https://github.com/godotengine/godot-cpp/issues/995#issuecomment-1434345271, there are more places in godot-cpp that need to be fixed (for which we'll use the utility function)~~

This depends on PR https://github.com/godotengine/godot/pull/73511 to the Godot engine, because a new function needs to be added to the GDExtension interface.

~~UPDATE: Back in draft, since I'm rebasing this on https://github.com/godotengine/godot/pull/76406~~

UPDATE: https://github.com/godotengine/godot/pull/76406 was merged, so I'm taking this out of draft!

Fixes #995