### PR TITLE
Add "lookup"-method to "HashMap"

### DIFF
--- a/include/godot_cpp/templates/hash_map.hpp
+++ b/include/godot_cpp/templates/hash_map.hpp
@@ -304,6 +304,17 @@ public:
 		return nullptr;
 	}
 
+	bool lookup(const TKey &p_key, TValue &r_data) const {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+
+		if (exists) {
+			r_data = &elements[pos]->data.value;
+			return true;
+		}
+		return false;
+	}
+
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		return _lookup_pos(p_key, _pos);


### PR DESCRIPTION
A little goodie from the OAHashMap-implementation, helps in removing redundant extra checks.

Otherwise there would be considerations to fully port the OAHashMap from the engines-source.