### PR TITLE
Fix #1064 and LINKFLAGS typo for "-static"

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -46,8 +46,7 @@ def generate(env):
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
 
-        # These options are for a release build even using target=template_debug
-        env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])
+        env.Append(CCFLAGS=["-Wwrite-strings"])
         env.Append(
             LINKFLAGS=[
                 "-static",
@@ -74,8 +73,7 @@ def generate(env):
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
 
-        # These options are for a release build even using target=template_debug
-        env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])
+        env.Append(CCFLAGS=["-Wwrite-strings"])
         env.Append(
             LINKFLAGS=[
                 "-static",

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -45,13 +45,27 @@ def generate(env):
         env["SHLIBPREFIX"] = ""
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
+
+        # These options are for a release build even using target=template_debug
+        env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])
+        env.Append(
+            LINKFLAGS=[
+                "-static",
+                "-Wl,--no-undefined",
+                "-static-libgcc",
+                "-static-libstdc++",
+            ]
+        )
+
         # Long line hack. Use custom spawn, quick AR append (to avoid files with the same names to override each other).
         my_spawn.configure(env)
 
     else:
         env["use_mingw"] = True
         # Cross-compilation using MinGW
-        prefix = "i686" if env["arch"] == "x86_32" else env["arch"]
+        prefix = "i686"
+        if env["arch"] == "x86_64":
+            prefix = "x86_64"
         env["CXX"] = prefix + "-w64-mingw32-g++"
         env["CC"] = prefix + "-w64-mingw32-gcc"
         env["AR"] = prefix + "-w64-mingw32-ar"
@@ -60,11 +74,11 @@ def generate(env):
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
 
-        # These options are for a release build even using target=debug
+        # These options are for a release build even using target=template_debug
         env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])
         env.Append(
             LINKFLAGS=[
-                "--static",
+                "-static",
                 "-Wl,--no-undefined",
                 "-static-libgcc",
                 "-static-libstdc++",


### PR DESCRIPTION
This PR closes #1064, and #976 if it happens to MinGW only.
I suggest applying PR #1059 's patch before test this one.

Statically linked DLL will not depend on external MinGW DLLs (like libgcc_s_seh-1.dll, libstdc++-6.dll and libwinpthread-1.dll), thus it can be loaded by itself.

BTW, "--static" should be "-static".

FYI:
[gcc: -static](https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/Link-Options.html#index-s)
[ld: -static](https://sourceware.org/binutils/docs/ld/Options.html#index-_002dstatic)