### PR TITLE
Fix: Include method_ptrcall.hpp on simple structs.

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1183,8 +1183,9 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
         for included in used_classes:
             result.append(f"#include <godot_cpp/{get_include_path(included)}>")
 
-        if len(used_classes) > 0:
-            result.append("")
+        if len(used_classes) == 0:
+            result.append("#include <godot_cpp/core/method_ptrcall.hpp>")
+        result.append("")
 
         result.append("namespace godot {")
         result.append("")


### PR DESCRIPTION
In, for example, `gen/include/godot_cpp/classes/audio_frame.hpp`, GDVIRTUAL_NATIVE_PTR cannot be found because there's a missing include for method_ptrcall.hpp. When native structures have classes, they'll include this header by way of other files, but if a structure does not include anything it's missing this header, I assume.

The final output for this example simply adds a line after the define guard:

```cpp
#include <godot_cpp/core/method_ptrcall.hpp>
```

Which removes the error.