### PR TITLE
Implement vararg methods of builtin classes.

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -334,6 +334,8 @@ String vformat(const String &p_text, const VarArgs... p_args) {
 	return p_text % args_array;
 }
 
+#include <godot_cpp/variant/builtin_vararg_methods.hpp>
+
 } // namespace godot
 
 #endif // GODOT_VARIANT_HPP


### PR DESCRIPTION
Implement builtin classes' vararg methods.

Need [#76047](https://github.com/godotengine/godot/pull/76047).

Now, `call()`, `call_deferred()`, `rpc()`, `rpc_id()`, `bind()` in `Callable`, and `Signal::emit()` can be called with any count of arguments.

Fixes #802
Fixes #1093