### PR TITLE
Moved cmake_minimum_required() call to top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@
 # Todo
 # Test build for Windows, Mac and mingw.
 
-project(godot-cpp LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.12)
+project(godot-cpp LANGUAGES CXX)
 
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)
 option(GODOT_CPP_SYSTEM_HEADERS "Expose headers as SYSTEM." ON)


### PR DESCRIPTION
`
CMake Warning (dev) at CMakeLists.txt:40 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
`