### PR TITLE
Include OP_COALESCE for parity with godotengine/godot#76843

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2249,6 +2249,7 @@ def get_operator_id_name(op):
         "not": "not",
         "and": "and",
         "in": "in",
+        "??": "coalesce",
     }
     return op_id_map[op]
 

--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -135,6 +135,8 @@ typedef enum {
 
 	/* containment */
 	GDEXTENSION_VARIANT_OP_IN,
+	/* coalesce */
+	GDEXTENSION_VARIANT_OP_COALESCE,
 	GDEXTENSION_VARIANT_OP_MAX
 
 } GDExtensionVariantOperator;

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -136,6 +136,8 @@ public:
 		OP_NOT,
 		// containment
 		OP_IN,
+		// coalesce
+		OP_COALESCE,
 		OP_MAX
 	};
 


### PR DESCRIPTION
The PR over https://github.com/godotengine/godot/pull/76843 adds a new Variant Operator called "Nullabe Coalesce" (OP_COALESCE or "??" or "coalesce"), this PR reflects that change as to allow it to be merged.