### PR TITLE
Add support for adding/removing editor plugins

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1376,6 +1376,24 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
     result.append("};")
     result.append("")
 
+    if class_name == "EditorPlugin":
+        result.append("class EditorPlugins {")
+        result.append("public:")
+        result.append("")
+
+        result.append("\ttemplate <class T>")
+        result.append("\tstatic void add_by_type() {")
+        result.append("\t\tinternal::gdextension_interface_editor_add_plugin(T::get_class_static()._native_ptr());")
+        result.append("\t}")
+
+        result.append("\ttemplate <class T>")
+        result.append("\tstatic void remove_by_type() {")
+        result.append("\t\tinternal::gdextension_interface_editor_remove_plugin(T::get_class_static()._native_ptr());")
+        result.append("\t}")
+
+        result.append("};")
+        result.append("")
+
     result.append("} // namespace godot")
     result.append("")
 

--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -2106,6 +2106,26 @@ typedef void (*GDExtensionInterfaceClassdbUnregisterExtensionClass)(GDExtensionC
  */
 typedef void (*GDExtensionInterfaceGetLibraryPath)(GDExtensionClassLibraryPtr p_library, GDExtensionStringPtr r_path);
 
+/**
+ * @name editor_add_plugin
+ *
+ * Adds an editor plugin.
+ *
+ * It's safe to call during initialization.
+ *
+ * @param p_class_name A pointer to a StringName with the name of a class (descending from EditorPlugin) which is already registered with ClassDB.
+ */
+typedef void (*GDExtensionInterfaceEditorAddPlugin)(GDExtensionConstStringNamePtr p_class_name);
+
+/**
+ * @name editor_remove_plugin
+ *
+ * Removes an editor plugin.
+ *
+ * @param p_class_name A pointer to a StringName with the name of a class that was previously added as an editor plugin.
+ */
+typedef void (*GDExtensionInterfaceEditorRemovePlugin)(GDExtensionConstStringNamePtr p_class_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -177,6 +177,8 @@ extern "C" GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup gde
 extern "C" GDExtensionInterfaceClassdbRegisterExtensionClassSignal gdextension_interface_classdb_register_extension_class_signal;
 extern "C" GDExtensionInterfaceClassdbUnregisterExtensionClass gdextension_interface_classdb_unregister_extension_class;
 extern "C" GDExtensionInterfaceGetLibraryPath gdextension_interface_get_library_path;
+extern "C" GDExtensionInterfaceEditorAddPlugin gdextension_interface_editor_add_plugin;
+extern "C" GDExtensionInterfaceEditorRemovePlugin gdextension_interface_editor_remove_plugin;
 
 } // namespace internal
 

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -181,6 +181,8 @@ GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup gdextension_in
 GDExtensionInterfaceClassdbRegisterExtensionClassSignal gdextension_interface_classdb_register_extension_class_signal = nullptr;
 GDExtensionInterfaceClassdbUnregisterExtensionClass gdextension_interface_classdb_unregister_extension_class = nullptr;
 GDExtensionInterfaceGetLibraryPath gdextension_interface_get_library_path = nullptr;
+GDExtensionInterfaceEditorAddPlugin gdextension_interface_editor_add_plugin = nullptr;
+GDExtensionInterfaceEditorRemovePlugin gdextension_interface_editor_remove_plugin = nullptr;
 
 } // namespace internal
 
@@ -360,6 +362,8 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	LOAD_PROC_ADDRESS(classdb_register_extension_class_signal, GDExtensionInterfaceClassdbRegisterExtensionClassSignal);
 	LOAD_PROC_ADDRESS(classdb_unregister_extension_class, GDExtensionInterfaceClassdbUnregisterExtensionClass);
 	LOAD_PROC_ADDRESS(get_library_path, GDExtensionInterfaceGetLibraryPath);
+	LOAD_PROC_ADDRESS(editor_add_plugin, GDExtensionInterfaceEditorAddPlugin);
+	LOAD_PROC_ADDRESS(editor_remove_plugin, GDExtensionInterfaceEditorRemovePlugin);
 
 	// Load the Godot version.
 	internal::gdextension_interface_get_godot_version(&internal::godot_version);


### PR DESCRIPTION
This depends on https://github.com/godotengine/godot/pull/77010

It allows adding or removing editor plugins from GDExtension, in a way that's very similar to adding them in a Godot module.

Here's some example code from a test GDExtension:

```cpp
void initialize_summator_types(ModuleInitializationLevel p_level)
{
	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
		ClassDB::register_class<Summator>();
	}

	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
		ClassDB::register_class<MyEditorPlugin>();
		EditorPlugins::add_by_type<MyEditorPlugin>();
	}
}

void uninitialize_summator_types(ModuleInitializationLevel p_level) {
	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
		EditorPlugins::remove_by_type<MyEditorPlugin>();
	}
}
```

Please let me know what you think!

Fixes #640