### PR TITLE
Fixing #1127 by making return types of auto-generated functions dynamic

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1799,7 +1799,10 @@ def generate_utility_functions(api, output_dir):
                     arguments.append(arg_name)
                 function_call += ", ".join(arguments)
         else:
-            source.append("\tVariant ret;")
+            if has_return:
+                source.append(f'\t{get_gdextension_type(correct_type(function["return_type"]))} ret;')
+            else:
+                source.append("\tVariant ret;")
             function_call += "___function(&ret, reinterpret_cast<GDExtensionConstVariantPtr *>(args), arg_count"
 
         function_call += ");"

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -77,6 +77,9 @@ func _ready():
 	# String += operator
 	assert_equal($Example.test_string_ops(), "ABCĎE")
 
+	# UtilityFunctions::str()
+	assert_equal(example.test_str_utility(), "Hello, World! The answer is 42")
+
 	# PackedArray iterators
 	assert_equal($Example.test_vector_ops(), 105)
 

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -127,6 +127,7 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("test_dictionary"), &Example::test_dictionary);
 	ClassDB::bind_method(D_METHOD("test_node_argument"), &Example::test_node_argument);
 	ClassDB::bind_method(D_METHOD("test_string_ops"), &Example::test_string_ops);
+	ClassDB::bind_method(D_METHOD("test_str_utility"), &Example::test_str_utility);
 	ClassDB::bind_method(D_METHOD("test_vector_ops"), &Example::test_vector_ops);
 
 	ClassDB::bind_method(D_METHOD("test_bitfield", "flags"), &Example::test_bitfield);
@@ -278,6 +279,10 @@ String Example::test_string_ops() const {
 	s += char32_t(0x010E);
 	s = s + "E";
 	return s;
+}
+
+String Example::test_str_utility() const {
+	return UtilityFunctions::str("Hello, ", "World", "! The answer is ", 42);
 }
 
 int Example::test_vector_ops() const {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -114,6 +114,7 @@ public:
 	Dictionary test_dictionary() const;
 	Example *test_node_argument(Example *p_node) const;
 	String test_string_ops() const;
+	String test_str_utility() const;
 	int test_vector_ops() const;
 
 	BitField<Flags> test_bitfield(BitField<Flags> flags);


### PR DESCRIPTION
This should fix #1127 by changing the type of the return variable to match the actual type of the returned value.