### PR TITLE
Prepend PATH to scons env to allow use of buildroot

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -54,6 +54,7 @@ else:
 # Default tools with no platform defaults to gnu toolchain.
 # We apply platform specific toolchains via our custom tools.
 env = Environment(tools=["default"], PLATFORM="")
+env.PrependENVPath("PATH", os.getenv("PATH"))
 
 # Default num_jobs to local cpu count if not user specified.
 # SCons has a peculiarity where user-specified options won't be overridden


### PR DESCRIPTION
Currently if you try to use buildroot the same way you would for the engine, it will not work. It just dose not use it. After looking into it for awhile I noticed the engine prepends the os PATH to the scons env while godot-cpp does not. I tested it and this change allows the use of buildroot for godot-cpp.