### PR TITLE
godot .scons_env.json equivalent for godot-cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ logs/
 
 # for projects that use SCons for building: http://http://www.scons.org/
 .sconf_temp
+.scons_env.json
 .sconsign.dblite
 *.pyc
 

--- a/SConstruct
+++ b/SConstruct
@@ -38,6 +38,11 @@ def get_api_file(env):
     return normalize_path(env.get("custom_api_file", os.path.join(get_gdextension_dir(env), "extension_api.json")))
 
 
+def dump_env(env):
+    with open(".scons_env.json", "w", encoding="utf-8") as f:
+        f.writelines(env.Dump(format="json"))
+
+
 # Try to detect the host platform automatically.
 # This is used if no `platform` argument is passed
 if sys.platform.startswith("linux"):
@@ -259,4 +264,5 @@ if env["build_library"]:
 
 env.Append(LIBPATH=[env.Dir("bin")])
 env.Append(LIBS=library_name)
+dump_env(env)
 Return("env")


### PR DESCRIPTION
Brings over the environment variable dump functionality from the main godot repository.

Because we're already enforcing version ≥4.0 for SCons, we can utilize its native dumping method for a cleaner implementaion with the same effect. The only thing lost in doing so is a `<<non-serializable: %s>>` wrapper, which should be fine as json already truncates non-serialized data.