### PR TITLE
added missing link flags for mingw build

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -45,6 +45,15 @@ def generate(env):
         env["SHLIBPREFIX"] = ""
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
+        env.Append(CCFLAGS=["-O2", "-Wwrite-strings"])
+        env.Append(
+            LINKFLAGS=[
+                "--static",
+                "-Wl,--no-undefined",
+                "-static-libgcc",
+                "-static-libstdc++",
+            ]
+        )
         # Long line hack. Use custom spawn, quick AR append (to avoid files with the same names to override each other).
         my_spawn.configure(env)
 


### PR DESCRIPTION
Story: When I compiled my GDExtension using mingw engine reported missing libraries, but it didn't for msvc. After some searching and debugging I found that LINKFLAGS didn't have flag for static linking. Plus the path that build system goes to build using mingw is the path msys build should go.

FIx; I just copied lines 64-72. It will affect msys builds but should not broke them, actually it should help.

When compiling in git bash `sys.platform == "win32"` is true so both msys and mingw builds go into elif starting at line 40.
When I tried to remove above condition to differentiate mingw and msys builds, last block of setup(else starting at line 51/60), fails with weird error and I don't have time to invest fixing it.

With condition untouched I don't know how we can access else(so does static analysis that is shipped with vscode python extension). It seems like dead code to me. I can delete this if there is no objection.