### PR TITLE
Remove unused free-standing `initialize_level` and `deinitialize_level`

### DIFF
--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -428,14 +428,3 @@ GDExtensionBool GDExtensionBinding::InitObject::init() const {
 }
 
 } // namespace godot
-
-extern "C" {
-
-void GDE_EXPORT initialize_level(void *userdata, GDExtensionInitializationLevel p_level) {
-	godot::GDExtensionBinding::initialize_level(userdata, p_level);
-}
-
-void GDE_EXPORT deinitialize_level(void *userdata, GDExtensionInitializationLevel p_level) {
-	godot::GDExtensionBinding::deinitialize_level(userdata, p_level);
-}
-}


### PR DESCRIPTION
I ran across these while I was taking a look at what symbols were being exported from my extension a while back.

As best I can tell they're not actually used anywhere in godot-cpp, nor anywhere in Godot itself, and after bringing this up in the developer chat I was advised to make a pull request for removing them, so that we could explore that all together.

Everything seems to compile and run just fine without them, so I figured maybe they're some old remnants from a bygone era.