### PR TITLE
Handle missing instance binding callbacks by finding the closest parent

### DIFF
--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -310,7 +310,18 @@ GDExtensionClassCallVirtual ClassDB::get_virtual_func(void *p_userdata, GDExtens
 
 const GDExtensionInstanceBindingCallbacks *ClassDB::get_instance_binding_callbacks(const StringName &p_class) {
 	std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *>::iterator callbacks_it = instance_binding_callbacks.find(p_class);
-	ERR_FAIL_COND_V_MSG(callbacks_it == instance_binding_callbacks.end(), nullptr, String("Cannot find instance binding callbacks for class '{0}'.").format(Array::make(p_class)));
+	if (likely(callbacks_it != instance_binding_callbacks.end())) {
+		return callbacks_it->second;
+	}
+
+	// If we don't have an instance binding callback for the given class, find the closest parent where we do.
+	StringName class_name = p_class;
+	do {
+		class_name = get_parent_class(class_name);
+		ERR_FAIL_COND_V_MSG(class_name == StringName(), nullptr, String("Cannot find instance binding callbacks for class '{0}'.").format(Array::make(p_class)));
+		callbacks_it = instance_binding_callbacks.find(class_name);
+	} while (callbacks_it == instance_binding_callbacks.end());
+
 	return callbacks_it->second;
 }
 


### PR DESCRIPTION
This attempts to solve a problem that was brought up on issue https://github.com/godotengine/godot-cpp/issues/1160 (although, this PR *doesn't* solve that issue).

Basically, the problem is that we assume we'll have the instance binding callbacks for any valid wrapper class. If we don't have the wrapper class, we output an error message and use `Object`.

However, in either of these cases:

- the class is a new class that was added to Godot after the GDExtension was created (so it won't know about it), or
- the developer explicitly excluded the class from godot-cpp

... we want to do what we're already doing for unexposed classes, which is to find the closest parent class that we _do_ know about.

This will only output an error message, if we're unable to find any ancestor classes that we know about.

This depends on PR https://github.com/godotengine/godot-cpp/pull/1164 which is currently a draft. So, marking this one as a draft too!

Fixes https://github.com/godotengine/godot-cpp/issues/1163