### PR TITLE
[3.x] Bump Ubuntu version on CI from 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - name: 🐧 Linux (GCC)
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             platform: linux
             artifact-name: godot-cpp-linux-glibc2.27-x86_64-release
             artifact-path: bin/libgodot-cpp.linux.release.64.a
@@ -52,7 +52,7 @@ jobs:
             cache-name: macos-unversal
 
           - name: 🤖 Android (arm64)
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             platform: android
             artifact-name: godot-cpp-android-arm64-release
             artifact-path: bin/libgodot-cpp.android.release.arm64v8.a


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

The Ubuntu 18.04 image was deprecated and removed last year. 3.x CI checks won't run without this PR.