### PR TITLE
Add lower-case "*.cache" in ".gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ AppPackages/
 
 # Others
 sql/
-*.Cache
+*.[Cc]ache
 ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*


### PR DESCRIPTION
Pretty much self-explanatory. I had issues where I had multiple new files added from ".cache", where only ".Cache" was ignored.