### PR TITLE
Don't call parent _get_property_list when a class doesn't define it (for internal binding).

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -188,7 +188,7 @@ void ClassDB::_register_class(bool p_virtual) {
 		is_abstract, // GDExtensionBool is_abstract;
 		T::set_bind, // GDExtensionClassSet set_func;
 		T::get_bind, // GDExtensionClassGet get_func;
-		T::get_property_list_bind, // GDExtensionClassGetPropertyList get_property_list_func;
+		T::has_get_property_list() ? T::get_property_list_bind : nullptr, // GDExtensionClassGetPropertyList get_property_list_func;
 		T::free_property_list_bind, // GDExtensionClassFreePropertyList free_property_list_func;
 		T::property_can_revert_bind, // GDExtensionClassPropertyCanRevert property_can_revert_func;
 		T::property_get_revert_bind, // GDExtensionClassPropertyGetRevert property_get_revert_func;

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -60,4 +60,33 @@ void postinitialize_handler(Wrapped *p_wrapped) {
 	p_wrapped->_postinitialize();
 }
 
+namespace internal {
+
+GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::PropertyInfo> &plist_cpp, uint32_t *r_size) {
+	GDExtensionPropertyInfo *plist = nullptr;
+	// Linked list size can be expensive to get so we cache it
+	const uint32_t plist_size = plist_cpp.size();
+	if (r_size != nullptr) {
+		*r_size = plist_size;
+	}
+	plist = reinterpret_cast<GDExtensionPropertyInfo *>(memalloc(sizeof(GDExtensionPropertyInfo) * plist_size));
+	unsigned int i = 0;
+	for (const ::godot::PropertyInfo &E : plist_cpp) {
+		plist[i].type = static_cast<GDExtensionVariantType>(E.type);
+		plist[i].name = E.name._native_ptr();
+		plist[i].hint = E.hint;
+		plist[i].hint_string = E.hint_string._native_ptr();
+		plist[i].class_name = E.class_name._native_ptr();
+		plist[i].usage = E.usage;
+		++i;
+	}
+	return plist;
+}
+
+void free_c_property_list(GDExtensionPropertyInfo *plist) {
+	memfree(plist);
+}
+
+} // namespace internal
+
 } // namespace godot


### PR DESCRIPTION
Fixes part of #1183
Related to https://github.com/godotengine/godot/pull/79683, the pair fixes #1183 completely.

Godot is already supposed to call `_get_property_list` of parent classes, so the binding function (`get_property_list_bind`) must really only return procedural properties of the class it belongs to, and not parent or child classes, just like core does.
So in fact, it is possible to simply pass null to Godot when `_get_property_list` is not defined in the class.

I also found out a few members of `Wrapped` weren't necessary, and was able to move some of the code away from the `GDCLASS` macro.

I believe there is a way to also not need `plist_owned` inside `Wrapped`, maybe storing it in a `thread_local`, which would also fix potential issues if `get_property_list` is called from multiple threads. Maybe it even allows to move more things away from the macro, but I haven't gone to that extent in this PR.

There is also an issue with `GDExtensionClassFreePropertyList`: it is pretty much the "free" for the non-const pointer returned by `GDExtensionClassGetPropertyList`, but it receives the pointer as `const`, so it can't be freed without `const_cast`, looks like an oversight.
