### PR TITLE
Add platform macros

### DIFF
--- a/tools/android.py
+++ b/tools/android.py
@@ -100,3 +100,5 @@ def generate(env):
     )
     env.Append(CCFLAGS=arch_info["ccflags"])
     env.Append(LINKFLAGS=["--target=" + arch_info["target"] + env["android_api_level"], "-march=" + arch_info["march"]])
+
+    env.Append(CPPDEFINES=["ANDROID_ENABLED", "UNIX_ENABLED"])

--- a/tools/ios.py
+++ b/tools/ios.py
@@ -79,3 +79,5 @@ def generate(env):
 
     env.Append(CCFLAGS=["-isysroot", env["IOS_SDK_PATH"]])
     env.Append(LINKFLAGS=["-isysroot", env["IOS_SDK_PATH"], "-F" + env["IOS_SDK_PATH"]])
+
+    env.Append(CPPDEFINES=["IOS_ENABLED", "UNIX_ENABLED"])

--- a/tools/javascript.py
+++ b/tools/javascript.py
@@ -43,3 +43,5 @@ def generate(env):
         env.Append(CCFLAGS=["-O0", "-g"])
     elif env["target"] == "release":
         env.Append(CCFLAGS=["-O3"])
+
+    env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -32,3 +32,5 @@ def generate(env):
     elif env["arch"] == "rv64":
         env.Append(CCFLAGS=["-march=rv64gc"])
         env.Append(LINKFLAGS=["-march=rv64gc"])
+
+    env.Append(CPPDEFINES=["LINUX_ENABLED", "UNIX_ENABLED"])

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -48,3 +48,5 @@ def generate(env):
             "-Wl,-undefined,dynamic_lookup",
         ]
     )
+
+    env.Append(CPPDEFINES=["MACOS_ENABLED", "UNIX_ENABLED"])

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -70,3 +70,5 @@ def generate(env):
                 "-static-libstdc++",
             ]
         )
+
+    env.Append(CPPDEFINES=["WINDOWS_ENABLED"])


### PR DESCRIPTION
Add platform macros, like `LINUX_ENABLED` and `UNIX_ENABLED` on Linux, `MACOS_ENABLED`, `UNIX_ENABLED`, ~~`COREAUDIO_ENABLED`, `COREMIDI_ENABLED`~~ on macos, and `WINDOWS_ENABLED`, ~~`WASAPI_ENABLED`, `WINMIDI_ENABLED`~~ on Windows.