### PR TITLE
[SCons] Add support to import custom variables from parent SConstruct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/gen
 
 # Build configuarion.
 /custom.py
+/test/custom.py
 
 # Misc
 logs/*

--- a/SConstruct
+++ b/SConstruct
@@ -80,6 +80,10 @@ if env.GetOption("num_jobs") == altered_num_jobs:
 
 # Custom options and profile flags.
 customs = ["custom.py"]
+try:
+    customs += Import("customs")
+except:
+    pass
 profile = ARGUMENTS.get("profile", "")
 if profile:
     if os.path.isfile(profile):

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -2,7 +2,8 @@
 import os
 import sys
 
-env = SConscript("../SConstruct")
+customs = ["custom.py"]
+env = SConscript("../SConstruct", {"customs": [os.path.abspath(custom) for custom in customs]})
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++


### PR DESCRIPTION
Makes parent SConstruct able to apply their `custom.py` values to the main SConstruct file.

Otherwise, even if the parent SConstruct has `use_llvm = True`, the main SConstruct file will ignore it unless you manually add `use_llvm=yes` in the command line.