### PR TITLE
Check that GDExtension is opened by compatible Godot version

### DIFF
--- a/test/project/project.godot
+++ b/test/project/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="GDExtension Test Project"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [native_extensions]


### PR DESCRIPTION
This builds on PR #1193 and adds something that we discussed on issue #1195:

That is, godot-cpp will compare the version of Godot it was built for (based on the `extension_api.json` that was used) with the version of Godot that is loading it, and ensure that they are compatible, ie. the version of Godot is equal to or greater than the version godot-cpp was built for.

In order to do this, it also:

- Updates the `extension_api.json` in the repo for Godot 4.2-dev3, since we still had the one from 4.1.1 in there.
- Fixes up the way that we're printing early error messages that happen before godot-cpp is fully initialized. In my testing, I was getting crashes, which I think were caused by the older method using `String`, because we made some small incompatible changes to `String` in 4.2. This highlights the need to abort early if an older Godot tries to load a newer GDExtension!