### PR TITLE
Add functionality to pass custom files to the main SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -85,6 +85,11 @@ if env.GetOption("num_jobs") == altered_num_jobs:
 
 # Custom options and profile flags.
 customs = ["custom.py"]
+try:
+    customs += Import("customs")
+except:
+    pass
+
 profile = ARGUMENTS.get("profile", "")
 if profile:
     if os.path.isfile(profile):
@@ -267,7 +272,8 @@ if env["precision"] == "double":
 # compile_commands.json
 if env.get("compiledb", False):
     env.Tool("compilation_db")
-    env.Alias("compiledb", env.CompilationDatabase(normalize_path(env["compiledb_file"])))
+    compilation_db = env.CompilationDatabase(normalize_path(env["compiledb_file"]))
+    env.Alias("compiledb", compilation_db)
 
 # Generate bindings
 env.Append(BUILDERS={"GenerateBindings": Builder(action=scons_generate_bindings, emitter=scons_emit_files)})
@@ -316,6 +322,10 @@ library_name = "libgodot-cpp{}{}".format(suffix, env["LIBSUFFIX"])
 
 if env["build_library"]:
     library = env.StaticLibrary(target=env.File("bin/%s" % library_name), source=sources)
+
+    if env.get("compiledb", False):
+        Depends(compilation_db, library)
+
     Default(library)
 
 env.Append(LIBPATH=[env.Dir("bin")])

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -23,3 +23,6 @@ mono_crash.*.json
 # System/tool-specific ignores
 .directory
 *~
+
+# Build configuarion.
+/custom.py

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -2,7 +2,10 @@
 import os
 import sys
 
-env = SConscript("../SConstruct")
+customs = ["custom.py"]
+env = SConscript("../SConstruct", {
+    "customs": [os.path.abspath(custom) for custom in customs]
+})
 
 # For the reference:
 # - CCFLAGS are compilation flags shared between C and C++


### PR DESCRIPTION
Makes it possible for a project to use the godot-cpp SConstruct and still use locally a custom.py file.

Update the test project to pass a customs array to the main SConstruct.