### PR TITLE
Ensure that PtrToArg specializations for native structs are used

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1144,6 +1144,12 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
         else:
             fully_used_classes.add("Wrapped")
 
+        # In order to ensure that PtrToArg specializations for native structs are
+        # always used, let's move any of them into 'fully_used_classes'.
+        for type_name in used_classes:
+            if is_struct_type(type_name) and not is_included_struct_type(type_name):
+                fully_used_classes.add(type_name)
+
         for type_name in fully_used_classes:
             if type_name in used_classes:
                 used_classes.remove(type_name)

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -168,6 +168,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 
 template <class T>
 struct PtrToArg<T *> {
+	static_assert(std::is_base_of<Object, T>::value, "Cannot encode non-Object value as an Object");
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
 		return reinterpret_cast<T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr))));
 	}
@@ -179,6 +180,7 @@ struct PtrToArg<T *> {
 
 template <class T>
 struct PtrToArg<const T *> {
+	static_assert(std::is_base_of<Object, T>::value, "Cannot encode non-Object value as an Object");
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
 		return reinterpret_cast<const T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr))));
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1207

This changes `binding_generator.py`, so that rather than forward declaring native structures (which will have their own specialization for `PtrToArg<>`), it will always make sure to include the header.

It also adds a `static_assert()` to the `PtrToArg<>` specialization for `Object`'s in order to ensure that it isn't ever used with a type that doesn't descend from `Object`. Using the MRP from https://github.com/godotengine/godot-cpp/issues/1207, if I comment out the fix in `binding_generator.py` then it will correctly fail to compile.

