### PR TITLE
Fix forgotten not operator

### DIFF
--- a/include/godot_cpp/templates/cowdata.hpp
+++ b/include/godot_cpp/templates/cowdata.hpp
@@ -213,7 +213,7 @@ void CowData<T>::_unref(void *p_data) {
 	}
 
 	// clean up
-	if (std::is_trivially_destructible<T>::value) {
+	if (!std::is_trivially_destructible<T>::value) {
 		uint32_t *count = _get_size();
 		T *data = (T *)(count + 1);
 


### PR DESCRIPTION
Fixes a typo in #1211.

![image](https://github.com/godotengine/godot-cpp/assets/270928/5c743346-5a3f-4535-ad0e-66f48b602864)
