### PR TITLE
SCons: Disable C++ exception handling by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,21 +72,22 @@ endif()
 # Input from user for GDExtension interface header and the API JSON file
 set(GODOT_GDEXTENSION_DIR "gdextension" CACHE STRING "")
 set(GODOT_CUSTOM_API_FILE "" CACHE STRING "")
-set(FLOAT_PRECISION "single" CACHE STRING "")
-if ("${FLOAT_PRECISION}" STREQUAL "double")
-	add_definitions(-DREAL_T_IS_DOUBLE)
-endif()
 
 set(GODOT_GDEXTENSION_API_FILE "${GODOT_GDEXTENSION_DIR}/extension_api.json")
 if (NOT "${GODOT_CUSTOM_API_FILE}" STREQUAL "")  # User-defined override.
 	set(GODOT_GDEXTENSION_API_FILE "${GODOT_CUSTOM_API_FILE}")
 endif()
 
+set(FLOAT_PRECISION "single" CACHE STRING "")
+if ("${FLOAT_PRECISION}" STREQUAL "double")
+	add_definitions(-DREAL_T_IS_DOUBLE)
+endif()
+
 set(GODOT_COMPILE_FLAGS )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# using Visual Studio C++
-	set(GODOT_COMPILE_FLAGS "/EHsc /utf-8") # /GF /MP
+	set(GODOT_COMPILE_FLAGS "/utf-8") # /GF /MP
 
 	if(CMAKE_BUILD_TYPE MATCHES Debug)
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /MDd") # /Od /RTC1 /Zi
@@ -105,6 +106,21 @@ else()  # GCC/Clang
 	else()
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -O3")
 	endif(CMAKE_BUILD_TYPE MATCHES Debug)
+endif()
+
+# Disable exception handling. Godot doesn't use exceptions anywhere, and this
+# saves around 20% of binary size and very significant build time (GH-80513).
+option(GODOT_DISABLE_EXCEPTIONS ON "Force disabling exception handling code")
+if (GODOT_DISABLE_EXCEPTIONS)
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -D_HAS_EXCEPTIONS=0")
+	else()
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-exceptions")
+	endif()
+else()
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /EHsc")
+	endif()
 endif()
 
 # Generate source from the bindings file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(GODOT_LINKER_FLAGS )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	# using Visual Studio C++
-	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /EHsc /WX") # /GF /MP
+	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /WX") # /GF /MP
 	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /DTYPED_METHOD_BIND")
 
 	if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -90,6 +90,21 @@ else()
 	else()
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -O3")
 	endif(CMAKE_BUILD_TYPE MATCHES Debug)
+endif()
+
+# Disable exception handling. Godot doesn't use exceptions anywhere, and this
+# saves around 20% of binary size and very significant build time (GH-80513).
+option(GODOT_DISABLE_EXCEPTIONS ON "Force disabling exception handling code")
+if (GODOT_DISABLE_EXCEPTIONS)
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -D_HAS_EXCEPTIONS=0")
+	else()
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-exceptions")
+	endif()
+else()
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /EHsc")
+	endif()
 endif()
 
 # Get Sources

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -183,6 +183,12 @@ def options(opts, env):
         )
     )
 
+    opts.Add(
+        BoolVariable(
+            "disable_exceptions", "Force disabling exception handling code", default=env.get("disable_exceptions", True)
+        )
+    )
+
     # Add platform options
     for pl in platforms:
         tool = Tool(pl, toolpath=["tools"])
@@ -241,6 +247,16 @@ def generate(env):
 
     if env["use_hot_reload"]:
         env.Append(CPPDEFINES=["HOT_RELOAD_ENABLED"])
+
+    # Disable exception handling. Godot doesn't use exceptions anywhere, and this
+    # saves around 20% of binary size and very significant build time.
+    if env["disable_exceptions"]:
+        if env.get("is_msvc", False):
+            env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 0)])
+        else:
+            env.Append(CXXFLAGS=["-fno-exceptions"])
+    elif env.get("is_msvc", False):
+        env.Append(CXXFLAGS=["/EHsc"])
 
     tool = Tool(env["platform"], toolpath=["tools"])
 

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -31,7 +31,7 @@ def generate(env):
         env.Tool("mslink")
 
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
-        env.Append(CCFLAGS=["/EHsc", "/utf-8"])
+        env.Append(CCFLAGS=["/utf-8"])
         env.Append(LINKFLAGS=["/WX"])
 
         if env["use_clang_cl"]:


### PR DESCRIPTION
Counterpart to https://github.com/godotengine/godot/pull/80612.

Didn't test it, neither SCons nor CMake changes.