### PR TITLE
Add support to import custom variables from parent SConstruct (redux)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -22,6 +22,10 @@ env.PrependENVPath("PATH", os.getenv("PATH"))
 
 # Custom options and profile flags.
 customs = ["custom.py"]
+try:
+    customs += Import("customs")
+except:
+    pass
 profile = ARGUMENTS.get("profile", "")
 if profile:
     if os.path.isfile(profile):


### PR DESCRIPTION
Updated version of #1196.

As explained [here](https://github.com/godotengine/godot-cpp/pull/1196#issuecomment-1682240391), the `env` passed from the parent SConstruct don't have the values from the custom files. So, in order to the custom files to be loaded in the godot-cpp project from the parent, it is essential to pass the "customs" variable.