### PR TITLE
Add `ClassDB::has_instance_binding_callbacks()` and check before getting callbacks in `internal::get_object_instance_binding()`

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -134,6 +134,7 @@ public:
 
 	static GDExtensionClassCallVirtual get_virtual_func(void *p_userdata, GDExtensionConstStringNamePtr p_name);
 	static const GDExtensionInstanceBindingCallbacks *get_instance_binding_callbacks(const StringName &p_class);
+	static bool has_instance_binding_callbacks(const StringName &p_class);
 
 	static void initialize(GDExtensionInitializationLevel p_level);
 	static void deinitialize(GDExtensionInitializationLevel p_level);

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -314,6 +314,10 @@ const GDExtensionInstanceBindingCallbacks *ClassDB::get_instance_binding_callbac
 	return callbacks_it->second;
 }
 
+bool ClassDB::has_instance_binding_callbacks(const StringName &p_class) {
+	return instance_binding_callbacks.find(p_class) != instance_binding_callbacks.end();
+}
+
 void ClassDB::bind_virtual_method(const StringName &p_class, const StringName &p_method, GDExtensionClassCallVirtual p_call) {
 	std::unordered_map<StringName, ClassInfo>::iterator type_it = classes.find(p_class);
 	ERR_FAIL_COND_MSG(type_it == classes.end(), String("Class '{0}' doesn't exist.").format(Array::make(p_class)));

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -50,7 +50,7 @@ Object *get_object_instance_binding(GodotObject *p_engine_object) {
 	// Otherwise, try to look up the correct binding callbacks.
 	const GDExtensionInstanceBindingCallbacks *binding_callbacks = nullptr;
 	StringName class_name;
-	if (gdextension_interface_object_get_class_name(p_engine_object, library, reinterpret_cast<GDExtensionStringNamePtr>(class_name._native_ptr()))) {
+	if (gdextension_interface_object_get_class_name(p_engine_object, library, reinterpret_cast<GDExtensionStringNamePtr>(class_name._native_ptr())) && ClassDB::has_instance_binding_callbacks(class_name)) {
 		binding_callbacks = ClassDB::get_instance_binding_callbacks(class_name);
 	}
 	if (binding_callbacks == nullptr) {


### PR DESCRIPTION
In my case, I need to get all singletons from `Engine::get_singleton()->get_singleton()`, but if it has not instance callbacks, it will print a error ~~and return a invalid object~~.
I add `ClassDB::has_instance_binding_callbacks()` to check if it is available or not.

I think this is beneficial to do some reflection operations like in C#, so I open this pr.