### PR TITLE
Fix formatting of `compatibility_minimum` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [example.gdextension](test/project/example.gdextension) used in the test pro
 [configuration]
 
 entry_symbol = "example_library_init"
-compatibility_minimum = 4.1
+compatibility_minimum = "4.1"
 
 [libraries]
 

--- a/test/project/example.gdextension
+++ b/test/project/example.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "example_library_init"
-compatibility_minimum = 4.1
+compatibility_minimum = "4.1"
 
 [libraries]
 


### PR DESCRIPTION
Without quotes the values is parsed as a float, breaking in various cases.

* See: https://github.com/godotengine/godot-docs/issues/7864