### PR TITLE
Refactor compiledb implementation

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -274,9 +274,8 @@ def generate(env):
     env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]
 
     # compile_commands.json
-    if env.get("compiledb", False):
-        env.Tool("compilation_db")
-        env.Alias("compiledb", env.CompilationDatabase(normalize_path(env["compiledb_file"], env)))
+    env.Tool("compilation_db")
+    env.Alias("compiledb", env.CompilationDatabase(normalize_path(env["compiledb_file"], env)))
 
     # Builders
     env.Append(BUILDERS={"GodotCPPBindings": Builder(action=scons_generate_bindings, emitter=scons_emit_files)})
@@ -315,7 +314,13 @@ def _godot_cpp(env):
 
     if env["build_library"]:
         library = env.StaticLibrary(target=env.File("bin/%s" % library_name), source=sources)
-        env.Default(library)
+        default_args = [library]
+
+        # Add compiledb if the option is set
+        if env.get("compiledb", False):
+            default_args += ["compiledb"]
+
+        env.Default(*default_args)
 
     env.AppendUnique(LIBS=[env.File("bin/%s" % library_name)])
     return library


### PR DESCRIPTION
This comment enables the possibility to build the "compile_commands.json" file by only using `scons -Q compiledb`. No need to use the argument `compiledb=yes`.

And when using the `compiledb=yes`, it will create a "compiled_commands.json" automatically.