### PR TITLE
[SCons] Fixed crashes in several scripts

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,6 @@ import platform
 import sys
 import subprocess
 from binding_generator import scons_generate_bindings, scons_emit_files
-from SCons.Errors import UserError
 
 
 EnsureSConsVersion(4, 0)

--- a/tools/android.py
+++ b/tools/android.py
@@ -29,7 +29,7 @@ def generate(env):
 
     if env["arch"] not in ("arm64", "x86_64", "arm32", "x86_32"):
         print("Only arm64, x86_64, arm32, and x86_32 are supported on Android. Exiting.")
-        Exit()
+        env.Exit(1)
 
     if sys.platform == "win32" or sys.platform == "msys":
         my_spawn.configure(env)

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -3,6 +3,7 @@ import os, sys, platform
 from SCons.Variables import EnumVariable, PathVariable, BoolVariable
 from SCons.Tool import Tool
 from SCons.Builder import Builder
+from SCons.Errors import UserError
 
 from binding_generator import scons_generate_bindings, scons_emit_files
 
@@ -226,7 +227,7 @@ def generate(env):
                 env["arch"] = "x86_32"
             else:
                 print("Unsupported CPU architecture: " + host_machine)
-                Exit()
+                env.Exit(1)
 
     print("Building for architecture " + env["arch"] + " on platform " + env["platform"])
 
@@ -284,8 +285,8 @@ def _godot_cpp(env):
     )
     # Forces bindings regeneration.
     if env["generate_bindings"]:
-        AlwaysBuild(bindings)
-        NoCache(bindings)
+        env.AlwaysBuild(bindings)
+        env.NoCache(bindings)
 
     # Sources to compile
     sources = []

--- a/tools/javascript.py
+++ b/tools/javascript.py
@@ -8,7 +8,7 @@ def exists(env):
 def generate(env):
     if env["arch"] not in ("wasm32"):
         print("Only wasm32 supported on web. Exiting.")
-        Exit()
+        env.Exit(1)
 
     if "EM_CONFIG" in os.environ:
         env["ENV"] = os.environ

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -20,7 +20,7 @@ def exists(env):
 def generate(env):
     if env["arch"] not in ("universal", "arm64", "x86_64"):
         print("Only universal, arm64, and x86_64 are supported on macOS. Exiting.")
-        Exit()
+        env.Exit(1)
 
     if sys.platform == "darwin":
         # Use clang on macOS by default


### PR DESCRIPTION
After moving most of the code from `SConstruct` to `godotcpp.py` (63755b2a32085fda8ab5d615264867e0c98b005a) some methods are no longer detected by the interpreter and require a call through the environment (that's how I understood it).
Also, the import of `UserError` was not moved.

Now these commands will not lead to crashes:
```
scons gdextension_dir=gdextension.file
scons custom_api_file=gdextension
scons compiledb_file=wrong/path_to.json
```

And the `generate_bindings` argument works again
```
scons generate_bindings=yes
```

Fixes #1236

The `Exit()` method should also be called from `env` and not return 0 on errors.