### PR TITLE
Simplify register apis in ClassDB and use macros to register classes instead of functions in example.

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -103,16 +103,12 @@ private:
 	static void initialize_class(const ClassInfo &cl);
 	static void bind_method_godot(const StringName &p_class_name, MethodBind *p_method);
 
-	template <class T, bool is_abstract>
-	static void _register_class(bool p_virtual = false, bool p_exposed = true);
+	template <class T, bool is_virtual = false, bool is_abstract = false, bool is_exposed = true>
+	static void _register_class();
 
 public:
-	template <class T>
-	static void register_class(bool p_virtual = false);
-	template <class T>
-	static void register_abstract_class();
-	template <class T>
-	static void register_internal_class();
+	template <class T, bool is_virtual = false, bool is_abstract = false, bool is_exposed = true>
+	static void register_class();
 	template <class T>
 	static void register_engine_class();
 
@@ -158,8 +154,8 @@ public:
 		godot::ClassDB::bind_virtual_method(m_class::get_class_static(), #m_method, _call##m_method);                                         \
 	}
 
-template <class T, bool is_abstract>
-void ClassDB::_register_class(bool p_virtual, bool p_exposed) {
+template <class T, bool is_virtual, bool is_abstract, bool is_exposed>
+void ClassDB::_register_class() {
 	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
 
 	// Register this class within our plugin
@@ -177,9 +173,9 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed) {
 
 	// Register this class with Godot
 	GDExtensionClassCreationInfo2 class_info = {
-		p_virtual, // GDExtensionBool is_virtual;
+		is_virtual, // GDExtensionBool is_virtual;
 		is_abstract, // GDExtensionBool is_abstract;
-		p_exposed, // GDExtensionBool is_exposed;
+		is_exposed, // GDExtensionBool is_exposed;
 		T::set_bind, // GDExtensionClassSet set_func;
 		T::get_bind, // GDExtensionClassGet get_func;
 		T::has_get_property_list() ? T::get_property_list_bind : nullptr, // GDExtensionClassGetPropertyList get_property_list_func;
@@ -206,19 +202,9 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed) {
 	initialize_class(classes[cl.name]);
 }
 
-template <class T>
-void ClassDB::register_class(bool p_virtual) {
-	ClassDB::_register_class<T, false>(p_virtual);
-}
-
-template <class T>
-void ClassDB::register_abstract_class() {
-	ClassDB::_register_class<T, true>();
-}
-
-template <class T>
-void ClassDB::register_internal_class() {
-	ClassDB::_register_class<T, false>(false, false);
+template <class T, bool is_virtual, bool is_abstract, bool is_exposed>
+void ClassDB::register_class() {
+	ClassDB::_register_class<T, is_virtual, is_exposed, is_exposed>();
 }
 
 template <class T>
@@ -282,9 +268,9 @@ MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, StringName p_name, M p
 }
 
 #define GDREGISTER_CLASS(m_class) ClassDB::register_class<m_class>();
-#define GDREGISTER_VIRTUAL_CLASS(m_class) ClassDB::register_class<m_class>(true);
-#define GDREGISTER_ABSTRACT_CLASS(m_class) ClassDB::register_abstract_class<m_class>();
-#define GDREGISTER_INTERNAL_CLASS(m_class) ClassDB::register_internal_class<m_class>();
+#define GDREGISTER_VIRTUAL_CLASS(m_class) ClassDB::register_class<m_class, true>();
+#define GDREGISTER_ABSTRACT_CLASS(m_class) ClassDB::register_class<m_class, false, true>();
+#define GDREGISTER_INTERNAL_CLASS(m_class) ClassDB::register_class<m_class, false, false, false>();
 
 } // namespace godot
 

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -177,4 +177,11 @@ protected:
 	static void _bind_methods() {}
 };
 
+class ExampleInternal : public Object {
+	GDCLASS(ExampleInternal, Object);
+
+protected:
+	static void _bind_methods() {}
+};
+
 #endif // EXAMPLE_CLASS_H

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -21,11 +21,12 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	ClassDB::register_class<ExampleRef>();
-	ClassDB::register_class<ExampleMin>();
-	ClassDB::register_class<Example>();
-	ClassDB::register_class<ExampleVirtual>(true);
-	ClassDB::register_abstract_class<ExampleAbstract>();
+	GDREGISTER_CLASS(ExampleRef);
+	GDREGISTER_CLASS(ExampleMin);
+	GDREGISTER_CLASS(Example);
+	GDREGISTER_VIRTUAL_CLASS(ExampleVirtual);
+	GDREGISTER_ABSTRACT_CLASS(ExampleAbstract);
+	GDREGISTER_INTERNAL_CLASS(ExampleInternal);
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
Refer to this [comment](https://github.com/godotengine/godot/pull/70329#issuecomment-1704348532).

And I found that in godot source, register of all classes are using `GDREGISTER_XXX_CLASS(T)` instead of using `ClassDB::register_xxx_class<T>()`, so I think we should change the example to encourage users to register classes by macros.

But this pr will change apis of `ClassDB` significantly and violate programming principles, I think this pr need more discussion.