### PR TITLE
Fix return value and `r_valid` value in `Variant::iter_init` and `Variant::iter_next`

### DIFF
--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -638,14 +638,16 @@ bool Variant::in(const Variant &index, bool *r_valid) const {
 
 bool Variant::iter_init(Variant &r_iter, bool &r_valid) const {
 	GDExtensionBool valid;
-	internal::gdextension_interface_variant_iter_init(_native_ptr(), r_iter._native_ptr(), &valid);
-	return PtrToArg<bool>::convert(&valid);
+	GDExtensionBool result = internal::gdextension_interface_variant_iter_init(_native_ptr(), r_iter._native_ptr(), &valid);
+	r_valid = PtrToArg<bool>::convert(&valid);
+	return PtrToArg<bool>::convert(&result);
 }
 
 bool Variant::iter_next(Variant &r_iter, bool &r_valid) const {
 	GDExtensionBool valid;
-	internal::gdextension_interface_variant_iter_next(_native_ptr(), r_iter._native_ptr(), &valid);
-	return PtrToArg<bool>::convert(&valid);
+	GDExtensionBool result = internal::gdextension_interface_variant_iter_next(_native_ptr(), r_iter._native_ptr(), &valid);
+	r_valid = PtrToArg<bool>::convert(&valid);
+	return PtrToArg<bool>::convert(&result);
 }
 
 Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {


### PR DESCRIPTION
Variant iteration methods were returning wrong values from GDExtension API call, never reporting that iterations were valid.
This PR makes `r_valid` be set, as well as return the result from the call instead of returning `valid`.