### PR TITLE
Let `gdextension_dir` function as standalone argument

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -284,8 +284,8 @@ def generate(env):
 
 
 def _godot_cpp(env):
-    api_file = normalize_path(env.get("custom_api_file", env.File("gdextension/extension_api.json").abspath), env)
     extension_dir = normalize_path(env.get("gdextension_dir", env.Dir("gdextension").abspath), env)
+    api_file = normalize_path(env.get("custom_api_file", env.File(extension_dir + "/extension_api.json").abspath), env)
     bindings = env.GodotCPPBindings(
         env.Dir("."),
         [


### PR DESCRIPTION
Right now, if you have a custom build of Godot to build against, you have to redundantly provide arguments for both a `gdextension_dir` and `custom_api_file`. This changes it so that, if only `gdextension_dir` is provided, it will implicitly setup a path for `custom_api_file` using the default name