### PR TITLE
CI: Fix MinGW install error by pinning to earlier version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
       - name: Setup MinGW for Windows/MinGW build
         if: ${{ matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes' }}
         uses: egor-tensin/setup-mingw@v2
+        with:
+          version: 12.2.0
 
       - name: Generate godot-cpp sources only
         run: |


### PR DESCRIPTION
Works around https://github.com/egor-tensin/setup-mingw/issues/14.