### PR TITLE
Declare explicit specializations for `CharStringT`

### DIFF
--- a/include/godot_cpp/variant/char_string.hpp
+++ b/include/godot_cpp/variant/char_string.hpp
@@ -120,6 +120,18 @@ protected:
 	void copy_from(const T *p_cstr);
 };
 
+template <>
+const char *CharStringT<char>::get_data() const;
+
+template <>
+const char16_t *CharStringT<char16_t>::get_data() const;
+
+template <>
+const char32_t *CharStringT<char32_t>::get_data() const;
+
+template <>
+const wchar_t *CharStringT<wchar_t>::get_data() const;
+
 typedef CharStringT<char> CharString;
 typedef CharStringT<char16_t> Char16String;
 typedef CharStringT<char32_t> Char32String;


### PR DESCRIPTION
Related to #1150.

I'm in the process of upgrading godot-cpp from 1009da4d7e to 3b3f357de9, and when compiling with clang-cl (and maybe regular Clang as well?) I seem to end up with the following compilation error:

```
src/variant/char_string.cpp(95,32): error: explicit specialization of 'get_data' after instantiation
const char *CharStringT<char>::get_data() const {
                               ^
include/godot_cpp/core/type_info.hpp(354,1): note: implicit instantiation first required here
MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
^
include/godot_cpp/core/type_info.hpp(342,128): note: expanded from macro 'MAKE_TYPED_ARRAY_INFO'
                        return make_property_info(Variant::Type::ARRAY, "", PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type).utf8().get_data()); \
                                                                                                                                                    ^
```

From what I can tell it seems like it gets cranky over the fact that the specializations made for `CharStringT::get_data()` weren't declared first. Searching around a bit [seems to support](https://stackoverflow.com/questions/7774188/explicit-specialization-after-instantiation) that this should be required, although the example shown there is a bit different.

Weirdly enough it compiles just fine with latest MSVC. I haven't tried GCC, but I assume CI would have caught that already.

Anyway, this PR fixes this by simply declaring the specializations.