### PR TITLE
Automatically register only engine classes whose header has been included

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -131,8 +131,6 @@ def get_file_list(api_filepath, output_dir, headers=False, sources=False):
     if sources:
         utility_functions_source_path = source_gen_folder / "variant" / "utility_functions.cpp"
         files.append(str(utility_functions_source_path.as_posix()))
-        register_engine_classes_source_path = source_gen_folder / "register_engine_classes.cpp"
-        files.append(str(register_engine_classes_source_path.as_posix()))
 
     return files
 
@@ -1207,10 +1205,6 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
                 generate_engine_class_source(class_api, used_classes, fully_used_classes, use_template_get_node)
             )
 
-    register_engine_classes_filename = Path(output_dir) / "src" / "register_engine_classes.cpp"
-    with register_engine_classes_filename.open("w+", encoding="utf-8") as source_file:
-        source_file.write(generate_register_engine_classes_source(api))
-
     for native_struct in api["native_structures"]:
         struct_name = native_struct["name"]
         snake_struct_name = camel_to_snake(struct_name)
@@ -1285,7 +1279,7 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
             result.append(f"#include <godot_cpp/{get_include_path(included)}>")
 
     if class_name == "EditorPlugin":
-        result.append("#include <godot_cpp/templates/vector.hpp>")
+        result.append("#include <godot_cpp/classes/editor_plugin_registration.hpp>")
 
     if len(fully_used_classes) > 0:
         result.append("")
@@ -1436,30 +1430,6 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
     result.append("")
     result.append("};")
     result.append("")
-
-    if class_name == "EditorPlugin":
-        result.append("class EditorPlugins {")
-        result.append("private:")
-        result.append("\tstatic Vector<StringName> plugin_classes;")
-        result.append("")
-        result.append("public:")
-        result.append("\tstatic void add_plugin_class(const StringName &p_class_name);")
-        result.append("\tstatic void remove_plugin_class(const StringName &p_class_name);")
-        result.append("\tstatic void deinitialize(GDExtensionInitializationLevel p_level);")
-        result.append("")
-
-        result.append("\ttemplate <class T>")
-        result.append("\tstatic void add_by_type() {")
-        result.append("\t\tadd_plugin_class(T::get_class_static());")
-        result.append("\t}")
-
-        result.append("\ttemplate <class T>")
-        result.append("\tstatic void remove_by_type() {")
-        result.append("\t\tremove_plugin_class(T::get_class_static());")
-        result.append("\t}")
-
-        result.append("};")
-        result.append("")
 
     result.append("} // namespace godot")
     result.append("")
@@ -1679,38 +1649,6 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
                 result.append(method_signature)
             result.append("")
 
-    result.append("")
-    result.append("} // namespace godot ")
-
-    return "\n".join(result)
-
-
-def generate_register_engine_classes_source(api):
-    includes = []
-    registrations = []
-
-    for class_api in api["classes"]:
-        if class_api["name"] == "ClassDB":
-            continue
-
-        class_name = class_api["name"]
-        snake_class_name = camel_to_snake(class_name)
-
-        includes.append(f"#include <godot_cpp/classes/{snake_class_name}.hpp>")
-        registrations.append(f"\tClassDB::register_engine_class<{class_name}>();")
-
-    result = []
-    add_header(f"register_engine_classes.cpp", result)
-
-    result.append("#include <godot_cpp/godot.hpp>")
-    result.append("")
-    result = result + includes
-    result.append("")
-    result.append("namespace godot {")
-    result.append("")
-    result.append("void GDExtensionBinding::register_engine_classes() {")
-    result = result + registrations
-    result.append("}")
     result.append("")
     result.append("} // namespace godot ")
 

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -111,6 +111,22 @@ namespace internal {
 GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::PropertyInfo> &plist_cpp, uint32_t *r_size);
 void free_c_property_list(GDExtensionPropertyInfo *plist);
 
+typedef void (*EngineClassRegistrationCallback)();
+void add_engine_class_registration_callback(EngineClassRegistrationCallback p_callback);
+void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks);
+void register_engine_classes();
+
+template <class T>
+struct EngineClassRegistration {
+	EngineClassRegistration() {
+		add_engine_class_registration_callback(&EngineClassRegistration<T>::callback);
+	}
+
+	static void callback() {
+		register_engine_class(T::get_class_static(), &T::_gde_binding_callbacks);
+	}
+};
+
 } // namespace internal
 
 } // namespace godot
@@ -352,6 +368,7 @@ public:                                                                         
 // Don't use this for your classes, use GDCLASS() instead.
 #define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits)                                                          \
 private:                                                                                                                   \
+	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;               \
 	void operator=(const m_class &p_rval) {}                                                                               \
                                                                                                                            \
 protected:                                                                                                                 \

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -119,8 +119,10 @@ public:
 	static void register_abstract_class();
 	template <class T>
 	static void register_internal_class();
-	template <class T>
-	static void register_engine_class();
+
+	_FORCE_INLINE_ static void _register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
+		instance_binding_callbacks[p_name] = p_callbacks;
+	}
 
 	template <class N, class M, typename... VarArgs>
 	static MethodBind *bind_method(N p_method_name, M p_method, VarArgs... p_args);
@@ -231,11 +233,6 @@ void ClassDB::register_abstract_class() {
 template <class T>
 void ClassDB::register_internal_class() {
 	ClassDB::_register_class<T, false>(false, false);
-}
-
-template <class T>
-void ClassDB::register_engine_class() {
-	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
 }
 
 template <class N, class M, typename... VarArgs>

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -196,9 +196,6 @@ enum ModuleInitializationLevel {
 };
 
 class GDExtensionBinding {
-private:
-	static void register_engine_classes();
-
 public:
 	using Callback = void (*)(ModuleInitializationLevel p_level);
 

--- a/src/classes/editor_plugin_registration.cpp
+++ b/src/classes/editor_plugin_registration.cpp
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  editor_plugin_registration.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include <godot_cpp/classes/editor_plugin_registration.hpp>
+
+#include <godot_cpp/variant/variant.hpp>
+
+namespace godot {
+
+Vector<StringName> EditorPlugins::plugin_classes;
+
+void EditorPlugins::add_plugin_class(const StringName &p_class_name) {
+	ERR_FAIL_COND_MSG(plugin_classes.find(p_class_name) != -1, vformat("Editor plugin already registered: %s", p_class_name));
+	plugin_classes.push_back(p_class_name);
+	internal::gdextension_interface_editor_add_plugin(p_class_name._native_ptr());
+}
+
+void EditorPlugins::remove_plugin_class(const StringName &p_class_name) {
+	int index = plugin_classes.find(p_class_name);
+	ERR_FAIL_COND_MSG(index == -1, vformat("Editor plugin is not registered: %s", p_class_name));
+	plugin_classes.remove_at(index);
+	internal::gdextension_interface_editor_remove_plugin(p_class_name._native_ptr());
+}
+
+void EditorPlugins::deinitialize(GDExtensionInitializationLevel p_level) {
+	if (p_level == GDEXTENSION_INITIALIZATION_EDITOR) {
+		for (const StringName &class_name : plugin_classes) {
+			internal::gdextension_interface_editor_remove_plugin(class_name._native_ptr());
+		}
+		plugin_classes.clear();
+	}
+}
+
+} // namespace godot

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -28,11 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include <vector>
+
 #include <godot_cpp/classes/wrapped.hpp>
 
 #include <godot_cpp/variant/builtin_types.hpp>
 
 #include <godot_cpp/classes/object.hpp>
+
+#include <godot_cpp/core/class_db.hpp>
 
 namespace godot {
 
@@ -81,6 +85,11 @@ void postinitialize_handler(Wrapped *p_wrapped) {
 
 namespace internal {
 
+std::vector<EngineClassRegistrationCallback> &get_engine_class_registration_callbacks() {
+	static std::vector<EngineClassRegistrationCallback> engine_class_registration_callbacks;
+	return engine_class_registration_callbacks;
+}
+
 GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::PropertyInfo> &plist_cpp, uint32_t *r_size) {
 	GDExtensionPropertyInfo *plist = nullptr;
 	// Linked list size can be expensive to get so we cache it
@@ -104,6 +113,22 @@ GDExtensionPropertyInfo *create_c_property_list(const ::godot::List<::godot::Pro
 
 void free_c_property_list(GDExtensionPropertyInfo *plist) {
 	memfree(plist);
+}
+
+void add_engine_class_registration_callback(EngineClassRegistrationCallback p_callback) {
+	get_engine_class_registration_callbacks().push_back(p_callback);
+}
+
+void register_engine_class(const StringName &p_name, const GDExtensionInstanceBindingCallbacks *p_callbacks) {
+	ClassDB::_register_engine_class(p_name, p_callbacks);
+}
+
+void register_engine_classes() {
+	std::vector<EngineClassRegistrationCallback> &engine_class_registration_callbacks = get_engine_class_registration_callbacks();
+	for (EngineClassRegistrationCallback cb : engine_class_registration_callbacks) {
+		cb();
+	}
+	engine_class_registration_callbacks.clear();
 }
 
 } // namespace internal

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -30,7 +30,7 @@
 
 #include <godot_cpp/godot.hpp>
 
-#include <godot_cpp/classes/editor_plugin.hpp>
+#include <godot_cpp/classes/editor_plugin_registration.hpp>
 #include <godot_cpp/classes/wrapped.hpp>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -416,7 +416,7 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	ERR_FAIL_NULL_V_MSG(init_callback, false, "Initialization callback must be defined.");
 
 	Variant::init_bindings();
-	register_engine_classes();
+	godot::internal::register_engine_classes();
 
 	return true;
 }


### PR DESCRIPTION
This is based on an idea from @maiself at a GDExtension meeting from a couple months ago!

In PR https://github.com/godotengine/godot-cpp/pull/1050, we added a `HashMap` that stores the binding callbacks for all engine types, in order to fix a serious bug where the wrapper class used could be an arbitrary parent class (rather than the actual engine class) leading to unexpected behavior in some situations.

Unfortunately, this led to issue https://github.com/godotengine/godot-cpp/issues/1160 where builds would be ~1-5mb bigger than previously.

This was due to the linker previously being able to optimize away any class that wasn't actually used in the GDExtension. However, if we have to reference every class in order to add their binding callbacks to the `HashMap`, they are all technically "used", and so none could be optimized away.

@maiself had this really clever idea, which was recorded in the meeting notes as:

```c++
// some register header

template<Class>
class Register {
	Register(class_name) {
		hash_map.insert({class_name, type_info(Class)});
	}
};

// node.hpp

static inline Register<Node>("Node"); 
```

**This would mean that classes are only added to the `HashMap`, if the developer actually includes the header file for them!** This should allow the linker to do it's old optimization again (I hope :-))

This PR attempts to implement that, however, I encountered some interesting issues when actually trying to do it:

- `static inline` variables can't be anonymous -- apparently the variable name is used to tell that each declaration refers to the same object, so all but one can be removed by the linker (which what the `inline` is aiming to do here).
- We can't directly add the items to the `HashMap` in the registration object, because the `HashMap` is keyed by `StringName`, and we can't create `StringName`'s until after godot-cpp has been initialized. So, instead, the `EngineClassRegistration<T>` constructor is adding a callback which will do the actual registration at the appropriate time.
- We can't simply declare the `std::vector` as a static variable at the compilation unit level, because static variables can be initialized in any order, and we can't know that our `inline static EngineClassRegistration<T>` variables won't be initialized before the `std::vector`. This is why that is a static variable at the function level, so that it will be initialized on demand.

None of those are really necessarily a problem, but it's why the code in this PR is more complicated than the simple psuedo-code that I started with :-)

Any feedback on how I could simplify this would be appreciated! But, personally, assuming it actually solves the problem, I think even with all these complications this is still an acceptable way to do this.

Fixes https://github.com/godotengine/godot-cpp/issues/1160