### PR TITLE
clang: Add CallableCustomMethodPointerBase virtual destructor

### DIFF
--- a/include/godot_cpp/variant/callable_method_pointer.hpp
+++ b/include/godot_cpp/variant/callable_method_pointer.hpp
@@ -40,6 +40,7 @@ class CallableCustomMethodPointerBase {
 public:
 	virtual Object *get_object() const = 0;
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, GDExtensionCallError &r_call_error) const = 0;
+	virtual ~CallableCustomMethodPointerBase() {}
 };
 
 namespace internal {


### PR DESCRIPTION
Fixes #1272
+ clang++ (debian v16/v17) warning: destructor called on 'godot::CallableCustomMethodPointerBase' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]