### PR TITLE
Add an automated test using a Variant iterator

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -184,6 +184,10 @@ func _ready():
 	assert_equal(example.test_bitfield(0), 0)
 	assert_equal(example.test_bitfield(Example.FLAG_ONE | Example.FLAG_TWO), 3)
 
+	# Test variant iterator.
+	assert_equal(example.test_variant_iterator([10, 20, 30]), [15, 25, 35])
+	assert_equal(example.test_variant_iterator(null), "iter_init: not valid")
+
 	# RPCs.
 	assert_equal(example.return_last_rpc_arg(), 0)
 	example.test_rpc(42)

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -171,6 +171,8 @@ void Example::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("test_bitfield", "flags"), &Example::test_bitfield);
 
+	ClassDB::bind_method(D_METHOD("test_variant_iterator", "input"), &Example::test_variant_iterator);
+
 	ClassDB::bind_method(D_METHOD("test_rpc", "value"), &Example::test_rpc);
 	ClassDB::bind_method(D_METHOD("test_send_rpc", "value"), &Example::test_send_rpc);
 	ClassDB::bind_method(D_METHOD("return_last_rpc_arg"), &Example::return_last_rpc_arg);
@@ -482,6 +484,41 @@ Variant Example::test_variant_call(Variant p_variant) {
 
 BitField<Example::Flags> Example::test_bitfield(BitField<Flags> flags) {
 	return flags;
+}
+
+Variant Example::test_variant_iterator(const Variant &p_input) {
+	Array output;
+
+	Variant iter;
+
+	bool is_init_valid = true;
+	if (!p_input.iter_init(iter, is_init_valid)) {
+		if (!is_init_valid) {
+			return "iter_init: not valid";
+		}
+		return output;
+	}
+
+	bool is_iter_next_valid = true;
+	bool is_iter_get_valid = true;
+	do {
+		if (!is_iter_next_valid) {
+			return "iter_next: not valid";
+		}
+
+		Variant value = p_input.iter_get(iter, is_iter_get_valid);
+		if (!is_iter_get_valid) {
+			return "iter_get: not valid";
+		}
+		output.push_back(((int)value) + 5);
+
+	} while (p_input.iter_next(iter, is_iter_next_valid));
+
+	if (!is_iter_next_valid) {
+		return "iter_next: not valid";
+	}
+
+	return output;
 }
 
 void Example::test_rpc(int p_value) {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -152,6 +152,8 @@ public:
 
 	BitField<Flags> test_bitfield(BitField<Flags> flags);
 
+	Variant test_variant_iterator(const Variant &p_input);
+
 	// RPC
 	void test_rpc(int p_value);
 	void test_send_rpc(int p_value);


### PR DESCRIPTION
This is a follow up to PR https://github.com/godotengine/godot-cpp/pull/1253 which adds a limited test to see if Variant iterators are working.

Unfortunately, we won't be able to merge it until after Godot PR https://github.com/godotengine/godot/pull/83681 is merged first. Depending on if/when that gets cherry-picked into Godot 4.1, we may need to keep this test for only Godot 4.2+