### PR TITLE
Add test for `Callable.bind()`

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -83,6 +83,9 @@ func _ready():
 	var array: Array[int] = [1, 2, 3]
 	assert_equal(example.test_tarray_arg(array), 6)
 
+	example.callable_bind()
+	assert_equal(custom_signal_emitted, ["bound", 11])
+
 	# String += operator
 	assert_equal(example.test_string_ops(), "ABCĎE")
 

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -176,6 +176,7 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("return_last_rpc_arg"), &Example::return_last_rpc_arg);
 
 	ClassDB::bind_method(D_METHOD("def_args", "a", "b"), &Example::def_args, DEFVAL(100), DEFVAL(200));
+	ClassDB::bind_method(D_METHOD("callable_bind"), &Example::callable_bind);
 
 	ClassDB::bind_static_method("Example", D_METHOD("test_static", "a", "b"), &Example::test_static);
 	ClassDB::bind_static_method("Example", D_METHOD("test_static2"), &Example::test_static2);
@@ -494,6 +495,11 @@ void Example::test_send_rpc(int p_value) {
 
 int Example::return_last_rpc_arg() {
 	return last_rpc_arg;
+}
+
+void Example::callable_bind() {
+	Callable c = Callable(this, "emit_custom_signal").bind("bound", 11);
+	c.call();
 }
 
 // Properties.

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -157,6 +157,8 @@ public:
 	void test_send_rpc(int p_value);
 	int return_last_rpc_arg();
 
+	void callable_bind();
+
 	// Property.
 	void set_custom_position(const Vector2 &pos);
 	Vector2 get_custom_position() const;


### PR DESCRIPTION
I originally [posted this test](https://github.com/godotengine/godot-cpp/pull/1091#issuecomment-1585216006) in a comment on PR https://github.com/godotengine/godot-cpp/pull/1091, which has since been merged.

This tests part of the functionality added in that PR (so that we hopefully won't break it in the future :-)).