### PR TITLE
Add protections against registering classes that didn't use `GDCLASS()`

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -202,6 +202,8 @@ protected:                                                                      
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 public:                                                                                                                                                                                \
+	typedef m_class self_type;                                                                                                                                                         \
+                                                                                                                                                                                       \
 	static void initialize_class() {                                                                                                                                                   \
 		static bool initialized = false;                                                                                                                                               \
 		if (initialized) {                                                                                                                                                             \
@@ -395,6 +397,10 @@ protected:                                                                      
 		return nullptr;                                                                                                    \
 	}                                                                                                                      \
                                                                                                                            \
+	static inline bool has_get_property_list() {                                                                           \
+		return false;                                                                                                      \
+	}                                                                                                                      \
+                                                                                                                           \
 	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                  \
 		return nullptr;                                                                                                    \
 	}                                                                                                                      \
@@ -416,6 +422,8 @@ protected:                                                                      
 	}                                                                                                                      \
                                                                                                                            \
 public:                                                                                                                    \
+	typedef m_class self_type;                                                                                             \
+                                                                                                                           \
 	static void initialize_class() {}                                                                                      \
                                                                                                                            \
 	static ::godot::StringName &get_class_static() {                                                                       \
@@ -425,6 +433,17 @@ public:                                                                         
                                                                                                                            \
 	static ::godot::StringName &get_parent_class_static() {                                                                \
 		return m_inherits::get_class_static();                                                                             \
+	}                                                                                                                      \
+                                                                                                                           \
+	static GDExtensionObjectPtr create(void *data) {                                                                       \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static GDExtensionClassInstancePtr recreate(void *data, GDExtensionObjectPtr obj) {                                    \
+		return nullptr;                                                                                                    \
+	}                                                                                                                      \
+                                                                                                                           \
+	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                        \
 	}                                                                                                                      \
                                                                                                                            \
 	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                           \

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -170,6 +170,7 @@ public:
 
 template <class T, bool is_abstract>
 void ClassDB::_register_class(bool p_virtual, bool p_exposed) {
+	static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
 	instance_binding_callbacks[T::get_class_static()] = &T::_gde_binding_callbacks;
 
 	// Register this class within our plugin


### PR DESCRIPTION
This adds the same protections against registering classes that didn't use `GDCLASS()`, as were added to the engine in PR https://github.com/godotengine/godot/pull/81020

This same problem affects godot-cpp, but to a much lesser degree. I was able to reproduce the issue by making a class heirarchy like:

```c++
class Example : public Object {
    GDCLASS(Example, Object);

protected:
    static void _bind_methods() { };
};

class ExampleChild : public Example {
};
```

With out this PR, registering `ExampleChild` was allowed to go ahead, which meant really registering `Example` again under a different name. However, with this PR, it gives the compiler error `Class not declared properly, please use GDCLASS.`, just like in the engine.