### PR TITLE
Switch to using `ObjectID` in custom callables

### DIFF
--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -392,7 +392,7 @@ typedef GDExtensionBool (*GDExtensionCallableCustomLessThan)(void *callable_user
 typedef void (*GDExtensionCallableCustomToString)(void *callable_userdata, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out);
 
 typedef struct {
-	/* Only `call_func` and `token` are strictly required, however, `object` should be passed if its not a static method.
+	/* Only `call_func` and `token` are strictly required, however, `object_id` should be passed if its not a static method.
 	 *
 	 * `token` should point to an address that uniquely identifies the GDExtension (for example, the
 	 * `GDExtensionClassLibraryPtr` passed to the entry symbol function.
@@ -409,7 +409,7 @@ typedef struct {
 	void *callable_userdata;
 	void *token;
 
-	GDExtensionObjectPtr object;
+	GDObjectInstanceID object_id;
 
 	GDExtensionCallableCustomCall call_func;
 	GDExtensionCallableCustomIsValid is_valid_func;

--- a/src/variant/callable_method_pointer.cpp
+++ b/src/variant/callable_method_pointer.cpp
@@ -52,7 +52,7 @@ Callable create_custom_callable(CallableCustomMethodPointerBase *p_callable_meth
 	GDExtensionCallableCustomInfo info = {};
 	info.callable_userdata = p_callable_method_pointer;
 	info.token = internal::token;
-	info.object = object != nullptr ? object->_owner : nullptr;
+	info.object_id = object ? object->get_instance_id() : 0;
 	info.call_func = &call_custom_callable;
 	info.free_func = &free_custom_callable;
 


### PR DESCRIPTION
This adapts the existing `callable_mp()` and `callable_mp_static()` implementation to use `ObjectID` after Godot PR https://github.com/godotengine/godot/pull/83800