### PR TITLE
Make CMake only include debug symbols when appropriate 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 	add_definitions(-DNOMINMAX)
 else()  # GCC/Clang
-	set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -g")
-
 	if(CMAKE_BUILD_TYPE MATCHES Debug)
-		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-omit-frame-pointer -O0")
+		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -fno-omit-frame-pointer -O0 -g")
 	else()
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -O3")
 	endif(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
Recently, I noticed that GDExtension shared libraries using godot-cpp that were built with CMake had significantly larger file sizes than the equivalent shared libraries built with SCons.


### Pre-analysis

For the SCons project, I followed [the GDExtension C++ example](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_cpp_example.html). To enable debug symbols, I added `debug_symbols=True` to the `scons` command. When debug symbols were disabled, I also set release optimizations through `target=template_release` since I used `CMAKE_BUILD_TYPE=Release` with CMake to avoid setting debug symbols through the default Debug build type.

For the CMake project, I used the same project but with [this custom `CMakeLists.txt` file](https://github.com/godotengine/godot-cpp/files/13174115/CMakeLists.txt). To enable debug symbols, I configured the build with `CMAKE_BUILD_TYPE=Debug`. As noted above, when not building with debug symbols, I configured the build with `CMAKE_BUILD_TYPE=Release` as not setting anything would have fallen back to the default of `CMAKE_BUILD_TYPE=Debug`.

| Build tool | Build type | Debug symbols | `.so` size |
| ---------- | ---------- | ------------- | ---------- |
| SCons      | Release    | No            | 5.9 MB     |
| CMake      | Release    | No            | 27.6 MB    |
| SCons      | Debug      | Yes           | 30.7 MB    |
| CMake      | Debug      | Yes           | 27.6 MB    |

Notice how enabling debug symbols did not change the file size of the CMake-built shared library. It seems that, despite setting `CMAKE_BUILD_TYPE=Release`, debug symbols are still being added.


### Analysis

Looking at the `CMakeLists.txt` file in this repository, I noticed that, at least for non-MSVC compilers, the `-g` flag was always being set regardless if the build was configured to be a debug build or not. This forces the project to build with debug symbols and ignores the `CMAKE_BUILD_TYPE`.

https://github.com/godotengine/godot-cpp/blob/c1196a1ab0a1ca166d0e5e2f08f9fe4156118c5e/CMakeLists.txt#L101-L109

To my knowledge, there isn't an easy way for others using godot-cpp's `CMakeLists.txt` to workaround this if they wish to build their project without debug symbols, unless they strip them from the shared library after the fact.


### Changes

In order to allow projects to choose whether or not to build with debug symbols, I removed the line setting the `-g` flag. This is because CMake already sets the `-g` flag automatically based on the `CMAKE_BUILD_TYPE`.

However, I also noticed several other flags, such as `-O0` and `-O3`, were being set. These flags are similarly automatically set by CMake depending on the value of `CMAKE_BUILD_TYPE`. My assumption here is that the godot-cpp CMake file is trying to be as explicit as possible. So, to maintain consistency, I added the `-g` flag alongside the other flags that are set when a `Debug` CMake build is run.


### Results

| Build tool | Build type | Debug symbols | `.so` size |
| ---------- | ---------- | ------------- | ---------- |
| SCons      | Release    | No            | 5.7 MB     |
| CMake      | Release    | No            | 5.7 MB     |
| SCons      | Debug      | Yes           | 30.7 MB    |
| CMake      | Debug      | Yes           | 27.6 MB    |

Now, it is possible to build the shared library without debug symbols using CMake. That is about an 80% reduction in release shared library size for projects building with CMake, which also happens to be consistent with SCons.