### PR TITLE
Remove `env.get` logic from defaults

### DIFF
--- a/tools/targets.py
+++ b/tools/targets.py
@@ -99,7 +99,9 @@ def generate(env):
 
     # Set optimize and debug_symbols flags.
     # "custom" means do nothing and let users set their own optimization flags.
-    if env.get("is_msvc", False):
+    if not env.get("is_msvc"):
+        env["is_msvc"] = False
+    if env["is_msvc"]:
         if env["debug_symbols"]:
             env.Append(CCFLAGS=["/Zi", "/FS"])
             env.Append(LINKFLAGS=["/DEBUG:FULL"])


### PR DESCRIPTION
After some local tests, it turns out these never worked in practice. They *seemed* to work, as the vast majority had simple fallbacks that were able to function identically. However, `use_hot_reload` tried to use logic from another container entirely; because that value always defaulted to `template_debug`, the conditional always passed & `use_hot_reload` was **always** enabled if no commandline value was specified

The majority of changes in this PR are removing the `env.get` logic outright, as every other case can substitute the previous fallback value as the default & the end result is functionally identical. `use_hot_reload` now has a default value of `None`, meaning it doesn't add any environment option; as such, an explicit assignment is handled before the very first use-case. This was achieved by porting over the *expected* logic of the previous default value

The only other change was adjusting the `compiledb` environment check from the `env.get` function to the dictionary equivalent. This is because I believe we should be using `env.get` only in scenarios where a value might be null. Otherwise, the fallback value used is redundant, as an explicit bool is guaranteed

EDIT: Fixes #1297