### PR TITLE
`GDCLASS` synced by ending with "private:"

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -365,105 +365,109 @@ public:                                                                         
 		_gde_binding_create_callback,                                                                                                                                                  \
 		_gde_binding_free_callback,                                                                                                                                                    \
 		_gde_binding_reference_callback,                                                                                                                                               \
-	};
+	};                                                                                                                                                                                 \
+                                                                                                                                                                                       \
+private:
 
 // Don't use this for your classes, use GDCLASS() instead.
-#define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits)                                                          \
-private:                                                                                                                   \
-	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;               \
-	void operator=(const m_class &p_rval) {}                                                                               \
-                                                                                                                           \
-protected:                                                                                                                 \
-	virtual const GDExtensionInstanceBindingCallbacks *_get_bindings_callbacks() const override {                          \
-		return &_gde_binding_callbacks;                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                      \
-	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                   \
-                                                                                                                           \
-	static void (*_get_bind_methods())() {                                                                                 \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static void (Wrapped::*_get_notification())(int) {                                                                     \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {                     \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                          \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static inline bool has_get_property_list() {                                                                           \
-		return false;                                                                                                      \
-	}                                                                                                                      \
-                                                                                                                           \
-	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                  \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const {                          \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) const {               \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static void (Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const {                           \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static String (Wrapped::*_get_to_string())() const {                                                                   \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-public:                                                                                                                    \
-	typedef m_class self_type;                                                                                             \
-                                                                                                                           \
-	static void initialize_class() {}                                                                                      \
-                                                                                                                           \
-	static ::godot::StringName &get_class_static() {                                                                       \
-		static ::godot::StringName string_name = ::godot::StringName(#m_alias_for);                                        \
-		return string_name;                                                                                                \
-	}                                                                                                                      \
-                                                                                                                           \
-	static ::godot::StringName &get_parent_class_static() {                                                                \
-		return m_inherits::get_class_static();                                                                             \
-	}                                                                                                                      \
-                                                                                                                           \
-	static GDExtensionObjectPtr create(void *data) {                                                                       \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static GDExtensionClassInstancePtr recreate(void *data, GDExtensionObjectPtr obj) {                                    \
-		return nullptr;                                                                                                    \
-	}                                                                                                                      \
-                                                                                                                           \
-	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                        \
-	}                                                                                                                      \
-                                                                                                                           \
-	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                           \
-		/* Do not call memnew here, we don't want the post-initializer to be called */                                     \
-		return new ("") m_class((GodotObject *)p_instance);                                                                \
-	}                                                                                                                      \
-	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                             \
-		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                         \
-		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                                \
-		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                       \
-	}                                                                                                                      \
-	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) { \
-		return true;                                                                                                       \
-	}                                                                                                                      \
-	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                        \
-		_gde_binding_create_callback,                                                                                      \
-		_gde_binding_free_callback,                                                                                        \
-		_gde_binding_reference_callback,                                                                                   \
-	};                                                                                                                     \
-	m_class() : m_class(#m_alias_for) {}
+#define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits) /******************************************************************************************************************/ \
+private:                                                                                                                                                                               \
+	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;                                                                           \
+	void operator=(const m_class &p_rval) {}                                                                                                                                           \
+                                                                                                                                                                                       \
+protected:                                                                                                                                                                             \
+	virtual const GDExtensionInstanceBindingCallbacks *_get_bindings_callbacks() const override {                                                                                      \
+		return &_gde_binding_callbacks;                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	m_class(const char *p_godot_class) : m_inherits(p_godot_class) {}                                                                                                                  \
+	m_class(GodotObject *p_godot_object) : m_inherits(p_godot_object) {}                                                                                                               \
+                                                                                                                                                                                       \
+	static void (*_get_bind_methods())() {                                                                                                                                             \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void (Wrapped::*_get_notification())(int) {                                                                                                                                 \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static bool (Wrapped::*_get_set())(const ::godot::StringName &p_name, const Variant &p_property) {                                                                                 \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static bool (Wrapped::*_get_get())(const ::godot::StringName &p_name, Variant &r_ret) const {                                                                                      \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static inline bool has_get_property_list() {                                                                                                                                       \
+		return false;                                                                                                                                                                  \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void (Wrapped::*_get_get_property_list())(List<PropertyInfo> * p_list) const {                                                                                              \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static bool (Wrapped::*_get_property_can_revert())(const ::godot::StringName &p_name) const {                                                                                      \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static bool (Wrapped::*_get_property_get_revert())(const ::godot::StringName &p_name, Variant &) const {                                                                           \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void (Wrapped::*_get_validate_property())(::godot::PropertyInfo & p_property) const {                                                                                       \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static String (Wrapped::*_get_to_string())() const {                                                                                                                               \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+public:                                                                                                                                                                                \
+	typedef m_class self_type;                                                                                                                                                         \
+                                                                                                                                                                                       \
+	static void initialize_class() {}                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static ::godot::StringName &get_class_static() {                                                                                                                                   \
+		static ::godot::StringName string_name = ::godot::StringName(#m_alias_for);                                                                                                    \
+		return string_name;                                                                                                                                                            \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static ::godot::StringName &get_parent_class_static() {                                                                                                                            \
+		return m_inherits::get_class_static();                                                                                                                                         \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static GDExtensionObjectPtr create(void *data) {                                                                                                                                   \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static GDExtensionClassInstancePtr recreate(void *data, GDExtensionObjectPtr obj) {                                                                                                \
+		return nullptr;                                                                                                                                                                \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                                                    \
+	}                                                                                                                                                                                  \
+                                                                                                                                                                                       \
+	static void *_gde_binding_create_callback(void *p_token, void *p_instance) {                                                                                                       \
+		/* Do not call memnew here, we don't want the post-initializer to be called */                                                                                                 \
+		return new ("") m_class((GodotObject *)p_instance);                                                                                                                            \
+	}                                                                                                                                                                                  \
+	static void _gde_binding_free_callback(void *p_token, void *p_instance, void *p_binding) {                                                                                         \
+		/* Explicitly call the deconstructor to ensure proper lifecycle for non-trivial members */                                                                                     \
+		reinterpret_cast<m_class *>(p_binding)->~m_class();                                                                                                                            \
+		Memory::free_static(reinterpret_cast<m_class *>(p_binding));                                                                                                                   \
+	}                                                                                                                                                                                  \
+	static GDExtensionBool _gde_binding_reference_callback(void *p_token, void *p_instance, GDExtensionBool p_reference) {                                                             \
+		return true;                                                                                                                                                                   \
+	}                                                                                                                                                                                  \
+	static constexpr GDExtensionInstanceBindingCallbacks _gde_binding_callbacks = {                                                                                                    \
+		_gde_binding_create_callback,                                                                                                                                                  \
+		_gde_binding_free_callback,                                                                                                                                                    \
+		_gde_binding_reference_callback,                                                                                                                                               \
+	};                                                                                                                                                                                 \
+	m_class() : m_class(#m_alias_for) {}                                                                                                                                               \
+                                                                                                                                                                                       \
+private:
 
 // Don't use this for your classes, use GDCLASS() instead.
 #define GDEXTENSION_CLASS(m_class, m_inherits) GDEXTENSION_CLASS_ALIAS(m_class, m_class, m_inherits)


### PR DESCRIPTION
The current implementation of `GDCLASS` exits the define with the scope set to "public". This doesn't match the behavior utilized in the godot repository, so people working in the source repository or making a module might be confused by a differing style. The most obvious scenario is someone expecting to have their functions/values after `GDCLASS` to be implicitly private, as has normally been the case, but with gdextension they will be public. This has the potential to go unnoticed for a long stretch of time, as there's no warning for if something *should* be private; so a user could realistically continue coding as if the values were private, but as soon as that repo is passed on to someone else that guarantee is gone

The only area this change risks regression in is classes that assume an implicitly public scope after `GDCLASS`. To me, this is entirely worth it, as it's to the end of consistent behavior for all parties moving forward. In addition, unlike the prior public example, there *will* be warnings/errors for attempting to access a private function/value, so an affected user could immediately recognize and address the regression in a matter of seconds

The same appendment was given to `GDEXTENSION_CLASS`, mirroring the trailing style of similar defines in the godot repository. This won't actually change anything currently generated, as an explicit "public:" is always defined right after (inferring that the generator was setup expecting a private environment), but it'll be convenient moving forward to have that parity. In addition, the same line buffer found in `GDCLASS` was added, so if any future changes to this define take place, they won't risk shaking up the diff logs

* *Bugsquad edit, fixes: https://github.com/godotengine/godot-cpp/issues/1305*