### PR TITLE
Fix comparison of `Callable`s from `callable_mp()` of the same method

### DIFF
--- a/src/variant/callable_method_pointer.cpp
+++ b/src/variant/callable_method_pointer.cpp
@@ -30,16 +30,64 @@
 
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 
+#include <godot_cpp/templates/hashfuncs.hpp>
+
 namespace godot {
 
-static void custom_callable_mp_call(void *userdata, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error) {
-	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)userdata;
+static void custom_callable_mp_call(void *p_userdata, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error) {
+	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)p_userdata;
 	callable_method_pointer->call((const Variant **)p_args, p_argument_count, *(Variant *)r_return, *r_error);
 }
 
-static void custom_callable_mp_free(void *userdata) {
-	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)userdata;
+static GDExtensionBool custom_callable_mp_is_valid(void *p_userdata) {
+	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)p_userdata;
+	ObjectID object = callable_method_pointer->get_object();
+	return object == ObjectID() || ObjectDB::get_instance(object);
+}
+
+static void custom_callable_mp_free(void *p_userdata) {
+	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)p_userdata;
 	memdelete(callable_method_pointer);
+}
+
+static uint32_t custom_callable_mp_hash(void *p_userdata) {
+	CallableCustomMethodPointerBase *callable_method_pointer = (CallableCustomMethodPointerBase *)p_userdata;
+	return callable_method_pointer->get_hash();
+}
+
+static GDExtensionBool custom_callable_mp_equal_func(void *p_a, void *p_b) {
+	CallableCustomMethodPointerBase *a = (CallableCustomMethodPointerBase *)p_a;
+	CallableCustomMethodPointerBase *b = (CallableCustomMethodPointerBase *)p_b;
+
+	if (a->get_comp_size() != b->get_comp_size()) {
+		return false;
+	}
+
+	return memcmp(a->get_comp_ptr(), b->get_comp_ptr(), a->get_comp_size() * 4) == 0;
+}
+
+static GDExtensionBool custom_callable_mp_less_than_func(void *p_a, void *p_b) {
+	CallableCustomMethodPointerBase *a = (CallableCustomMethodPointerBase *)p_a;
+	CallableCustomMethodPointerBase *b = (CallableCustomMethodPointerBase *)p_b;
+
+	if (a->get_comp_size() != b->get_comp_size()) {
+		return a->get_comp_size() < b->get_comp_size();
+	}
+
+	return memcmp(a->get_comp_ptr(), b->get_comp_ptr(), a->get_comp_size() * 4) < 0;
+}
+
+void CallableCustomMethodPointerBase::_setup(uint32_t *p_base_ptr, uint32_t p_ptr_size) {
+	comp_ptr = p_base_ptr;
+	comp_size = p_ptr_size / 4;
+
+	for (uint32_t i = 0; i < comp_size; i++) {
+		if (i == 0) {
+			h = hash_murmur3_one_32(comp_ptr[i]);
+		} else {
+			h = hash_murmur3_one_32(comp_ptr[i], h);
+		}
+	}
 }
 
 namespace internal {
@@ -50,7 +98,11 @@ Callable create_callable_from_ccmp(CallableCustomMethodPointerBase *p_callable_m
 	info.token = internal::token;
 	info.object_id = p_callable_method_pointer->get_object();
 	info.call_func = &custom_callable_mp_call;
+	info.is_valid_func = &custom_callable_mp_is_valid;
 	info.free_func = &custom_callable_mp_free;
+	info.hash_func = &custom_callable_mp_hash;
+	info.equal_func = &custom_callable_mp_equal_func;
+	info.less_than_func = &custom_callable_mp_less_than_func;
 
 	Callable callable;
 	::godot::internal::gdextension_interface_callable_custom_create(callable._native_ptr(), &info);

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -101,8 +101,19 @@ func _ready():
 
 	# mp_callable() with void method.
 	var mp_callable: Callable = example.test_callable_mp()
+	assert_equal(mp_callable.is_valid(), true)
 	mp_callable.call(example, "void", 36)
 	assert_equal(custom_signal_emitted, ["unbound_method1: Example - void", 36])
+
+	# Check that it works with is_connected().
+	assert_equal(example.renamed.is_connected(mp_callable), false)
+	example.renamed.connect(mp_callable)
+	assert_equal(example.renamed.is_connected(mp_callable), true)
+	# Make sure a new object is still treated as equivalent.
+	assert_equal(example.renamed.is_connected(example.test_callable_mp()), true)
+	assert_equal(mp_callable.hash(), example.test_callable_mp().hash())
+	example.renamed.disconnect(mp_callable)
+	assert_equal(example.renamed.is_connected(mp_callable), false)
 
 	# mp_callable() with return value.
 	var mp_callable_ret: Callable = example.test_callable_mp_ret()
@@ -116,6 +127,16 @@ func _ready():
 	var mp_callable_static: Callable = example.test_callable_mp_static()
 	mp_callable_static.call(example, "static", 83)
 	assert_equal(custom_signal_emitted, ["unbound_static_method1: Example - static", 83])
+
+	# Check that it works with is_connected().
+	assert_equal(example.renamed.is_connected(mp_callable_static), false)
+	example.renamed.connect(mp_callable_static)
+	assert_equal(example.renamed.is_connected(mp_callable_static), true)
+	# Make sure a new object is still treated as equivalent.
+	assert_equal(example.renamed.is_connected(example.test_callable_mp_static()), true)
+	assert_equal(mp_callable_static.hash(), example.test_callable_mp_static().hash())
+	example.renamed.disconnect(mp_callable_static)
+	assert_equal(example.renamed.is_connected(mp_callable_static), false)
 
 	# mp_callable_static() with return value.
 	var mp_callable_static_ret: Callable = example.test_callable_mp_static_ret()


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1293

This duplicates a lot of code from `custom_method_pointer.h/cpp` in Godot. I finally understand why it does what it does in such a weird way. :-) The tl;dr version is that the size of C++ method pointers in undefined (as opposed to function pointers, which do have a defined size), so putting them in a struct and then looping over the data for comparison and hashes is the easiest, portable way to do that.

Marking this as a draft for now, because it depends on PR https://github.com/godotengine/godot-cpp/pull/1280 which isn't merged yet