### PR TITLE
Add missing int→Variant conversions

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -154,9 +154,17 @@ public:
 	Variant(int64_t v);
 	Variant(int32_t v) :
 			Variant(static_cast<int64_t>(v)) {}
-	Variant(uint32_t v) :
+	Variant(int16_t v) :
+			Variant(static_cast<int64_t>(v)) {}
+	Variant(int8_t v) :
 			Variant(static_cast<int64_t>(v)) {}
 	Variant(uint64_t v) :
+			Variant(static_cast<int64_t>(v)) {}
+	Variant(uint32_t v) :
+			Variant(static_cast<int64_t>(v)) {}
+	Variant(uint16_t v) :
+			Variant(static_cast<int64_t>(v)) {}
+	Variant(uint8_t v) :
 			Variant(static_cast<int64_t>(v)) {}
 	Variant(double v);
 	Variant(float v) :
@@ -209,8 +217,12 @@ public:
 	operator bool() const;
 	operator int64_t() const;
 	operator int32_t() const;
+	operator int16_t() const;
+	operator int8_t() const;
 	operator uint64_t() const;
 	operator uint32_t() const;
+	operator uint16_t() const;
+	operator uint8_t() const;
 	operator double() const;
 	operator float() const;
 	operator String() const;

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -268,12 +268,28 @@ Variant::operator int32_t() const {
 	return static_cast<int32_t>(operator int64_t());
 }
 
+Variant::operator int16_t() const {
+	return static_cast<int16_t>(operator int64_t());
+}
+
+Variant::operator int8_t() const {
+	return static_cast<int8_t>(operator int64_t());
+}
+
 Variant::operator uint64_t() const {
 	return static_cast<uint64_t>(operator int64_t());
 }
 
 Variant::operator uint32_t() const {
 	return static_cast<uint32_t>(operator int64_t());
+}
+
+Variant::operator uint16_t() const {
+	return static_cast<uint16_t>(operator int64_t());
+}
+
+Variant::operator uint8_t() const {
+	return static_cast<uint8_t>(operator int64_t());
 }
 
 Variant::operator double() const {


### PR DESCRIPTION
Implements `int8_t`, `uint8_t`, `int16_t`, and `uint16_t` operations/constructors for Variant. This matches the implementation of the main repo (albeit using the `stdint.h` names), and allows binding methods that use these types as parameters/returns