### PR TITLE
ignoring venv in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,7 @@ godot.creator.*
 
 # compile commands (https://clang.llvm.org/docs/JSONCompilationDatabase.html)
 compile_commands.json
+
+# Python development
+.venv
+venv


### PR DESCRIPTION
Since python is a dependency for building this code, it seems like a `requirements.txt` file should be part of the repo.

`venv` folders should also be in the `.gitignore`, akin to https://github.com/godotengine/godot/commit/a6fda19e8520b523f41655e3dd1b94cfe9bd1f3c