### PR TITLE
Fix file list issues when trying to build with meson via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ endif()
 execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; binding_generator.print_file_list(\"${GODOT_GDEXTENSION_API_FILE}\", \"${CMAKE_CURRENT_BINARY_DIR}\", headers=True, sources=True)"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	OUTPUT_VARIABLE GENERATED_FILES_LIST
+	OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 add_custom_command(OUTPUT ${GENERATED_FILES_LIST}

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -136,9 +136,7 @@ def get_file_list(api_filepath, output_dir, headers=False, sources=False):
 
 
 def print_file_list(api_filepath, output_dir, headers=False, sources=False):
-    end = ";"
-    for f in get_file_list(api_filepath, output_dir, headers, sources):
-        print(f, end=end)
+    print(*get_file_list(api_filepath, output_dir, headers, sources), sep=";", end=None)
 
 
 def scons_emit_files(target, source, env):


### PR DESCRIPTION
While attempting to build this project with meson (via its cmake module) I ran into an issue with the generated file listing having a trailing `;` and trailing whitespace, which meson doesn't handle very well. This PR fixes these issues.