### PR TITLE
CI: Workaround upstream issue with .NET editor build not exiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           ./godot-artifacts/godot.linuxbsd.editor.x86_64.mono --headless --version
           cd test
           # Need to run the editor so .godot is generated... but it crashes! Ignore that :-)
-          (cd project && (../../godot-artifacts/godot.linuxbsd.editor.x86_64.mono --editor --headless --quit >/dev/null 2>&1 || true))
+          (cd project && (timeout 10 ../../godot-artifacts/godot.linuxbsd.editor.x86_64.mono --editor --headless --quit >/dev/null 2>&1 || true))
           GODOT=../godot-artifacts/godot.linuxbsd.editor.x86_64.mono ./run-tests.sh
 
       - name: Upload artifact


### PR DESCRIPTION
We force closing the process after 10 s, which should be ample time to generate the .godot folder.

Should work around https://github.com/godotengine/godot/issues/84735.