### PR TITLE
[Scons] Set the minimum Android API level to 21

### DIFF
--- a/tools/android.py
+++ b/tools/android.py
@@ -8,7 +8,7 @@ def options(opts):
     opts.Add(
         "android_api_level",
         "Target Android API level",
-        "18" if "32" in ARGUMENTS.get("arch", "arm64") else "21",
+        "21",
     )
     opts.Add(
         "ANDROID_HOME",
@@ -47,11 +47,9 @@ def generate(env):
         my_spawn.configure(env)
 
     # Validate API level
-    api_level = int(env["android_api_level"])
-    if "64" in env["arch"] and api_level < 21:
-        print("WARN: 64-bit Android architectures require an API level of at least 21; setting android_api_level=21")
+    if int(env["android_api_level"]) < 21:
+        print("WARNING: minimum supported Android target api is 21. Forcing target api 21.")
         env["android_api_level"] = "21"
-        api_level = 21
 
     # Setup toolchain
     toolchain = get_android_ndk_root(env) + "/toolchains/llvm/prebuilt/"


### PR DESCRIPTION
Godot has been using the minimum version 21 for a long time
https://github.com/godotengine/godot/pull/67610

Fixes #938