### PR TITLE
Fix wrong build options for MSVC

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -38,10 +38,16 @@ def generate(env):
             env["CC"] = "clang-cl"
             env["CXX"] = "clang-cl"
 
-        if env["use_static_cpp"]:
-            env.Append(CCFLAGS=["/MT"])
+        if env["optimize"] == "debug" or env["optimize"] == "none":
+            if env["use_static_cpp"]:
+                env.Append(CCFLAGS=["/MTd"])
+            else:
+                env.Append(CCFLAGS=["/MDd"])
         else:
-            env.Append(CCFLAGS=["/MD"])
+            if env["use_static_cpp"]:
+                env.Append(CCFLAGS=["/MT"])
+            else:
+                env.Append(CCFLAGS=["/MD"])
 
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True


### PR DESCRIPTION
Building for MSVC does not work because there is a mismatch in the used CRT.

Building ``godot-cpp`` like this:

```scons platform=windows -j15 custom_api_file="..\Godot_v4.2-rc2_win64\extension_api.json" target=template_release use_static_cpp=no optimize=speed debug_symbols=yes```

and

```scons platform=windows -j15 custom_api_file="..\Godot_v4.2-rc2_win64\extension_api.json" target=template_debug use_static_cpp=no optimize=debug debug_symbols=yes```

On master this produces lib files that you can't actually use because they are linked to the wrong CRT.