### PR TITLE
Change bit field enums to use `uint64_t` as underlying type

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1329,7 +1329,11 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
 
     if "enums" in class_api:
         for enum_api in class_api["enums"]:
-            result.append(f'\tenum {enum_api["name"]} {{')
+            if enum_api["is_bitfield"]:
+                result.append(f'\tenum {enum_api["name"]} : uint64_t {{')
+            else:
+                result.append(f'\tenum {enum_api["name"]} {{')
+
             for value in enum_api["values"]:
                 result.append(f'\t\t{value["name"]} = {value["value"]},')
             result.append("\t};")
@@ -1686,6 +1690,8 @@ def generate_global_constants(api, output_dir):
     header.append(f"#ifndef {header_guard}")
     header.append(f"#define {header_guard}")
     header.append("")
+    header.append("#include <cstdint>")
+    header.append("")
     header.append("namespace godot {")
     header.append("")
 
@@ -1698,7 +1704,11 @@ def generate_global_constants(api, output_dir):
         if enum_def["name"].startswith("Variant."):
             continue
 
-        header.append(f'\tenum {enum_def["name"]} {{')
+        if enum_def["is_bitfield"]:
+            header.append(f'\tenum {enum_def["name"]} : uint64_t {{')
+        else:
+            header.append(f'\tenum {enum_def["name"]} {{')
+
         for value in enum_def["values"]:
             header.append(f'\t\t{value["name"]} = {value["value"]},')
         header.append("\t};")


### PR DESCRIPTION
Fixes godotengine/godot#85444.

As discussed in the issue above, this would change the underlying integer type for enums declared with `VARIANT_BITFIELD_CAST` to be `uint64_t` instead of the default `int`.

This helps resolve an issue where MSVC will currently truncate any enum values larger than 2^31 for enums that don't have an explicit underlying type, which is affecting `RenderingServer::ArrayFormat`, as seen in the issue above.

Note that this technically opens up for other potential future problems, where someone on the Godot side of things could define a regular `int`-backed enum, bind it with `VARIANT_BITFIELD_CAST` and then include it in something like a `GDREGISTER_NATIVE_STRUCT`, which would lead to an ABI difference and potentially memory corruption.