### PR TITLE
Send NOTIFICATION_POSTINITIALIZE to extension classes

### DIFF
--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -50,6 +50,12 @@ void Wrapped::_postinitialize() {
 		godot::internal::gdextension_interface_object_set_instance(_owner, reinterpret_cast<GDExtensionConstStringNamePtr>(extension_class), this);
 	}
 	godot::internal::gdextension_interface_object_set_instance_binding(_owner, godot::internal::token, this, _get_bindings_callbacks());
+	if (extension_class) {
+		Object *obj = dynamic_cast<Object *>(this);
+		if (obj) {
+			obj->notification(Object::NOTIFICATION_POSTINITIALIZE);
+		}
+	}
 }
 
 Wrapped::Wrapped(const StringName p_godot_class) {

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -236,6 +236,11 @@ func _ready():
 	get_viewport().push_input(event)
 	assert_equal(custom_signal_emitted, ["_input: H", 72])
 
+	# Check NOTIFICATION_POST_INITIALIZED, both when created from GDScript and godot-cpp.
+	var new_example_ref = ExampleRef.new()
+	assert_equal(new_example_ref.was_post_initialized(), true)
+	assert_equal(example.test_post_initialize(), true)
+
 	exit_with_status()
 
 func _on_Example_custom_signal(signal_name, value):

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -63,9 +63,17 @@ int ExampleRef::get_id() const {
 	return id;
 }
 
+void ExampleRef::_notification(int p_what) {
+	if (p_what == NOTIFICATION_POSTINITIALIZE) {
+		post_initialized = true;
+	}
+}
+
 void ExampleRef::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_id", "id"), &ExampleRef::set_id);
 	ClassDB::bind_method(D_METHOD("get_id"), &ExampleRef::get_id);
+
+	ClassDB::bind_method(D_METHOD("was_post_initialized"), &ExampleRef::was_post_initialized);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "id"), "set_id", "get_id");
 }
@@ -220,6 +228,7 @@ void Example::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("def_args", "a", "b"), &Example::def_args, DEFVAL(100), DEFVAL(200));
 	ClassDB::bind_method(D_METHOD("callable_bind"), &Example::callable_bind);
+	ClassDB::bind_method(D_METHOD("test_post_initialize"), &Example::test_post_initialize);
 
 	ClassDB::bind_static_method("Example", D_METHOD("test_static", "a", "b"), &Example::test_static);
 	ClassDB::bind_static_method("Example", D_METHOD("test_static2"), &Example::test_static2);
@@ -595,6 +604,12 @@ Vector2 Example::get_custom_position() const {
 
 Vector4 Example::get_v4() const {
 	return Vector4(1.2, 3.4, 5.6, 7.8);
+}
+
+bool Example::test_post_initialize() const {
+	Ref<ExampleRef> new_example_ref;
+	new_example_ref.instantiate();
+	return new_example_ref->was_post_initialized();
 }
 
 // Virtual function override.

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -35,9 +35,12 @@ private:
 	static int last_id;
 
 	int id;
+	bool post_initialized = false;
 
 protected:
 	static void _bind_methods();
+
+	void _notification(int p_what);
 
 public:
 	ExampleRef();
@@ -45,6 +48,8 @@ public:
 
 	void set_id(int p_id);
 	int get_id() const;
+
+	bool was_post_initialized() const { return post_initialized; }
 };
 
 class ExampleMin : public Control {
@@ -166,6 +171,8 @@ public:
 	void set_custom_position(const Vector2 &pos);
 	Vector2 get_custom_position() const;
 	Vector4 get_v4() const;
+
+	bool test_post_initialize() const;
 
 	// Static method.
 	static int test_static(int p_a, int p_b);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1269

This turned out to be a little messier to implement than I had imagined, because in godot-cpp it's `Wrapped::_postinitialize()` (rather than in Godot where it's `Object::_postinitialize()`) so it's got to cast the `Wrapped *` to `Object *` to send the notification. It's probably safe to assume that all `Wrapped *` are in fact descended from `Object *`, but I did a `dynamic_cast<Object *>()` just to be sure.

This PR includes tests that fail without the fix, and then succeed with it.