### PR TITLE
Prevent `-Wtype-limits` warning on GCC 11 due to unsigned comparison

### DIFF
--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -271,7 +271,12 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 	} else if (internal::godot_version.minor != GODOT_VERSION_MINOR) {
 		compatible = internal::godot_version.minor > GODOT_VERSION_MINOR;
 	} else {
+#if GODOT_VERSION_PATCH > 0
 		compatible = internal::godot_version.patch >= GODOT_VERSION_PATCH;
+#else
+		// Prevent -Wtype-limits warning due to unsigned comparison.
+		compatible = true;
+#endif
 	}
 	if (!compatible) {
 		// We need to use snprintf() here because vformat() uses Variant, and we haven't loaded


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1322

I don't know if this is the best fix, it does what I wish GCC would do, which is just turn `unsigned_value >= 0` into `true` :-)

FYI, I'm not personally getting this error locally, even though I am using GCC 11.4 on Ubuntu 22.04, which is the same as the issue reporter. So, someone that's actually getting this error should confirm that this fixes it.