### PR TITLE
Add hot reload support to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 # GODOT_GDEXTENSION_DIR:		Path to the directory containing GDExtension interface header and API JSON file
 # GODOT_CPP_SYSTEM_HEADERS		Mark the header files as SYSTEM. This may be useful to supress warnings in projects including this one.
 # GODOT_CPP_WARNING_AS_ERROR	Treat any warnings as errors
+# GODOT_ENABLE_HOT_RELOAD       Build with hot reload support. Defaults to YES for Debug-builds and NO for Release-builds.
 # GODOT_CUSTOM_API_FILE:		Path to a custom GDExtension API JSON file (takes precedence over `gdextension_dir`)
 # FLOAT_PRECISION:				Floating-point precision level ("single", "double")
 #
@@ -43,7 +44,6 @@ project(godot-cpp LANGUAGES CXX)
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)
 option(GODOT_CPP_SYSTEM_HEADERS "Expose headers as SYSTEM." ON)
 option(GODOT_CPP_WARNING_AS_ERROR "Treat warnings as errors" OFF)
-option(GODOT_ENABLE_HOT_RELOAD "Build with hot reload support" OFF)
 
 # Add path to modules
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
@@ -56,6 +56,13 @@ set( compiler_is_msvc "$<CXX_COMPILER_ID:MSVC>" )
 # Default build type is Debug in the SConstruct
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 	set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Hot reload is enabled by default in Debug-builds
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    option(GODOT_ENABLE_HOT_RELOAD "Build with hot reload support" ON)
+else()
+    option(GODOT_ENABLE_HOT_RELOAD "Build with hot reload support" OFF)
 endif()
 
 if(NOT DEFINED BITS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ project(godot-cpp LANGUAGES CXX)
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)
 option(GODOT_CPP_SYSTEM_HEADERS "Expose headers as SYSTEM." ON)
 option(GODOT_CPP_WARNING_AS_ERROR "Treat warnings as errors" OFF)
+option(GODOT_ENABLE_HOT_RELOAD "Build with hot reload support" OFF)
 
 # Add path to modules
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/" )
@@ -114,6 +115,10 @@ else()
 	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 		set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} /EHsc")
 	endif()
+endif()
+
+if (GODOT_ENABLE_HOT_RELOAD)
+    set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -D HOT_RELOAD_ENABLED")
 endif()
 
 # Generate source from the bindings file


### PR DESCRIPTION
Add support for hot reloading when building `godot-cpp` using CMake.

CMake projects can enable the reloading by setting `GODOT_ENABLE_HOT_RELOAD` to `ON` before including the `godot-cpp` subdirectory.

Example:

```cmake
set(GODOT_ENABLE_HOT_RELOAD ON)
add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/godot-cpp/" build-godot-cpp)
```

I believe I've done all of this correctly — I'm super new to both Godot and Scons, but from how I understand the Scons-support for hot reloading in https://github.com/godotengine/godot-cpp/pull/1200, I believe this to be correct.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-cpp/issues/1542*