### PR TITLE
Add a method to auto rename the PDB to avoid blocking debug symbols

### DIFF
--- a/test/SConstruct
+++ b/test/SConstruct
@@ -35,8 +35,13 @@ elif env["platform"] == "ios":
             source=sources,
         )
 else:
+    library_path = "project/bin/libgdexample{}{}".format(env["suffix"], env["SHLIBSUFFIX"])
+
+    if env.get("is_msvc", False) and env["debug_symbols"] and env["use_hot_reload"]:
+        env.MSVCTryRenamePDB(library_path)
+
     library = env.SharedLibrary(
-        "project/bin/libgdexample{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
+        library_path,
         source=sources,
     )
 

--- a/test/project/example.gdextension
+++ b/test/project/example.gdextension
@@ -1,7 +1,8 @@
 [configuration]
 
 entry_symbol = "example_library_init"
-compatibility_minimum = "4.1"
+compatibility_minimum = "4.2"
+reloadable = true
 
 [libraries]
 

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -1,4 +1,5 @@
 import os, sys, platform
+import methods
 
 from SCons.Variables import EnumVariable, PathVariable, BoolVariable
 from SCons.Tool import Tool
@@ -315,6 +316,9 @@ def generate(env):
     # Builders
     env.Append(BUILDERS={"GodotCPPBindings": Builder(action=scons_generate_bindings, emitter=scons_emit_files)})
     env.AddMethod(_godot_cpp, "GodotCPP")
+
+    # Global methods
+    env.AddMethod(methods.msvc_try_rename_pdb, "MSVCTryRenamePDB")
 
 
 def _godot_cpp(env):

--- a/tools/methods.py
+++ b/tools/methods.py
@@ -1,0 +1,61 @@
+import os
+
+# Useful methods for custom scripts
+
+
+# A utility function for getting the name of an unblocked file
+def _get_unblocked_file_name(original_file_path, new_file_ext, max_files=256, keep_newest_one=True):
+    lib_dir = os.path.normpath(os.path.dirname(original_file_path))
+    lib_name = os.path.splitext(os.path.basename(original_file_path))[0]
+
+    # Collect all matching files
+    found_files = [
+        f
+        for f in os.listdir(lib_dir)
+        if os.path.isfile(os.path.join(lib_dir, f)) and f.startswith(lib_name) and f.endswith("." + new_file_ext)
+    ]
+    found_files = sorted(found_files, key=lambda x: os.path.getmtime(os.path.join(lib_dir, x)))
+
+    # Clean up the old files if possible, except for the newest one
+    if found_files:
+        if keep_newest_one:
+            found_files.pop()
+        for f in found_files:
+            try:
+                os.remove(os.path.join(lib_dir, f))
+            except:
+                pass
+
+    # Search for a unblocked file name
+    file_name = ""
+    for s in range(max_files):
+        file_name = "{}_{}.{}".format(os.path.join(lib_dir, lib_name), s, new_file_ext)
+        if not os.path.exists(file_name):
+            break
+        try:
+            with open(file_name, "a") as f:
+                pass
+        except IOError:
+            continue
+        break
+
+    return file_name
+
+
+# This is necessary to support debugging and Hot-Reload at the same time when building using MSVC
+def msvc_try_rename_pdb(env, full_lib_path):
+    if not env.get("is_msvc", False):
+        print("Renaming the PDB file will be ignored because of a compiler mismatch.")
+        return
+    if not env["debug_symbols"]:
+        print("Renaming the PDB file will be ignored because debug symbols generation is disabled.")
+        return
+    if not env["use_hot_reload"]:
+        print("Renaming the PDB file will be ignored because Hot-Reload is disabled.")
+        return
+
+    pdb_name = _get_unblocked_file_name(full_lib_path, "pdb")
+    print("New path to the PDB: " + pdb_name)
+
+    # Explicit assignment of the PDB path
+    env.Append(LINKFLAGS=["/PDB:" + pdb_name])


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/82536 but only for `godot-cpp` and `scons`.
Other language binds should make similar fixes to the build system to support Hot-Reload and debugging on Windows.

The main problem with `PDB` is that the name of this file is written to the `DLL` during the build and you can't just rename it. You can move the `PDB` and `DLL` to another folder or place them in different folders and specify pdb folder in Visual Studio and everything will work. But you can't change the name of the PDB, so that it can't be used automatically for debugging. Maybe I'm wrong and there is a more elegant solution.

To solve this problem, I added a new file `methods.py`, as in Godot, in which the `msvc_try_rename_pdb` function is located. This function checks whether renaming can be applied and outputs a new path to the console.

The search for an unblocked name takes place in `_get_unblocked_file_name`. In this function, I first find all the `PDB`s except the newest one, in order to save it if the project has not been modified, since `scons` will not restore it when deleted. Then I try to delete these files and search for the first unblocked name based on the template `{"full/library_name"}_{index}.pdb`.
And at the end of `msvc_try_rename_pdb` I explicitly specify the `/PDB:` for the linker.

This function is registered via `env.AddMethod` in `godotcpp.py` and can be called in a user script, for example in a test script.

I also updated `.gdextension` file to `4.2` and `reloadable = true`, because there is nowhere else to find how to activate hot-reloading.

Demo:

https://github.com/godotengine/godot-cpp/assets/7782218/19518f0c-8a67-4b01-be4c-3b8806e958e1
