### PR TITLE
Allow detecting when building as a GDExtension

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -295,6 +295,9 @@ def generate(env):
     if env["precision"] == "double":
         env.Append(CPPDEFINES=["REAL_T_IS_DOUBLE"])
 
+    # Allow detecting when building as a GDExtension.
+    env.Append(CPPDEFINES=["GDEXTENSION"])
+
     # Suffix
     suffix = ".{}.{}".format(env["platform"], env["target"])
     if env.dev_build:


### PR DESCRIPTION
Intended use case: I am working on a project that can be built as either an engine module or a GDExtension. I need to be able to detect whether I am building for GDExtension or not in my code, like this:

```cpp
#ifdef GDEXTENSION
#include <godot_cpp/core/class_db.hpp>
#include <godot_cpp/variant/string.hpp>
#elif defined(GODOT_MODULE)
#include "core/object/class_db.h"
#include "core/string/ustring.h"
#else
#error "Must build as Godot GDExtension or Godot module."
#endif
```

See also https://github.com/godotengine/godot/pull/86269 - having at least one of these PRs is highly useful, but having both is even better, because it lets you explicitly error on invalid configurations.

Without this PR, I have to put this in my own SConstruct file. This works fine... but this would be generally useful for lots of projects, and is super tiny, so I think we should make it a part of godot-cpp.