### PR TITLE
Add PackedRealArray as an alias for PackedFloat(32/64)Array

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -356,6 +356,12 @@ String vformat(const String &p_text, const VarArgs... p_args) {
 
 #include <godot_cpp/variant/builtin_vararg_methods.hpp>
 
+#ifdef REAL_T_IS_DOUBLE
+using PackedRealArray = PackedFloat64Array;
+#else
+using PackedRealArray = PackedFloat32Array;
+#endif // REAL_T_IS_DOUBLE
+
 } // namespace godot
 
 #endif // GODOT_VARIANT_HPP


### PR DESCRIPTION
This PR adds PackedRealArray as an alias for PackedFloat(32/64)Array to allow you to specify that you want an array of the float size defined for `real_t`. In the core engine, it is possible to use `Vector<real_t>`, but this is not possible in GDExtension because PackedFloat(32/64)Array are explicit types and not just `Vector<T>`.

I used `using` instead of `#define` to ensure that the namespace is preserved, so that if you don't have `using namespace godot;` then you need `godot::PackedRealArray` just like you would need `godot::PackedFloat32Array`. I also tried using `typedef` and it works fine too including with the namespace, but `using` is the newer preferred syntax.