### PR TITLE
Clean up existing data in move assignment operator

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1060,6 +1060,8 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
             f"\tinternal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &other);"
         )
     else:
+        if builtin_api["has_destructor"]:
+            result.append("\t_method_bindings.destructor(&opaque);")
         result.append("\tstd::swap(opaque, other.opaque);")
     result.append("\treturn *this;")
     result.append("}")

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -531,6 +531,7 @@ Variant &Variant::operator=(const Variant &other) {
 }
 
 Variant &Variant::operator=(Variant &&other) {
+	clear();
 	std::swap(opaque, other.opaque);
 	return *this;
 }


### PR DESCRIPTION
I need some advice on this one from someone with stronger modern C++ knowledge than me.

While trying to find the source of the memory leak in issue https://github.com/godotengine/godot-cpp/issues/1240, I noticed that the move assignment operator on variant types is not cleaning up any pre-existing data, for example, in `Array`, there was:

```
Array &Array::operator=(Array &&other) {
	std::swap(opaque, other.opaque);
	return *this;
}
```

If `opaque` already contained a valid array, this seems like it would swap it for the data in `other.opaque`, without ever cleaning up the pre-existing data in `opaque`.

Does this make sense? Or, am I just misunderstanding these new fangled rvalue references and move operations?

Marking as a draft because I don't know if this makes sense

_(PS: This is NOT the source of the memory leak in https://github.com/godotengine/godot-cpp/issues/1240 as my PR doesn't fix it.)_