### PR TITLE
Fix import logic for importing customs list.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -20,11 +20,13 @@ except:
 env.PrependENVPath("PATH", os.getenv("PATH"))
 
 # Custom options and profile flags.
-customs = ["custom.py"]
+
 try:
-    customs += Import("customs")
+    Import("customs")
 except:
-    pass
+    customs = []
+customs += ["custom.py"]
+
 profile = ARGUMENTS.get("profile", "")
 if profile:
     if os.path.isfile(profile):


### PR DESCRIPTION
fix import logic for adding files to customs. Current logic always throws exception when trying to append to customs list because Import function has no return.

```
    #Import function from Scons codebase - does not return anything - merely updates global variables
    def Import(self, *vars):
        try:
            frame = call_stack[-1]
            globals = frame.globals
            exports = frame.exports
            for var in vars:
                var = self.Split(var)
                for v in var:
                    if v == '*':
                        globals.update(global_exports)
                        globals.update(exports)
                    else:
                        if v in exports:
                            globals[v] = exports[v]
                        else:
                            globals[v] = global_exports[v]
        except KeyError as x:
            raise SCons.Errors.UserError("Import of non-existent variable '%s'"%x)     
```