### PR TITLE
Add `Vector2i/3i/4i` methods: `distance_to` and `distance_squared_to`

### DIFF
--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -117,6 +117,9 @@ struct _NO_DISCARD_ Vector2i {
 	int64_t length_squared() const;
 	double length() const;
 
+	int64_t distance_squared_to(const Vector2i &p_to) const;
+	double distance_to(const Vector2i &p_to) const;
+
 	real_t aspect() const { return width / (real_t)height; }
 	Vector2i sign() const { return Vector2i(SIGN(x), SIGN(y)); }
 	Vector2i abs() const { return Vector2i(Math::abs(x), Math::abs(y)); }

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -82,6 +82,9 @@ struct _NO_DISCARD_ Vector3i {
 	_FORCE_INLINE_ int64_t length_squared() const;
 	_FORCE_INLINE_ double length() const;
 
+	_FORCE_INLINE_ int64_t distance_squared_to(const Vector3i &p_to) const;
+	_FORCE_INLINE_ double distance_to(const Vector3i &p_to) const;
+
 	_FORCE_INLINE_ void zero();
 
 	_FORCE_INLINE_ Vector3i abs() const;
@@ -134,6 +137,14 @@ int64_t Vector3i::length_squared() const {
 
 double Vector3i::length() const {
 	return Math::sqrt((double)length_squared());
+}
+
+int64_t Vector3i::distance_squared_to(const Vector3i &p_to) const {
+	return (p_to - *this).length_squared();
+}
+
+double Vector3i::distance_to(const Vector3i &p_to) const {
+	return (p_to - *this).length();
 }
 
 Vector3i Vector3i::abs() const {

--- a/include/godot_cpp/variant/vector4i.hpp
+++ b/include/godot_cpp/variant/vector4i.hpp
@@ -84,6 +84,9 @@ struct _NO_DISCARD_ Vector4i {
 	_FORCE_INLINE_ int64_t length_squared() const;
 	_FORCE_INLINE_ double length() const;
 
+	_FORCE_INLINE_ int64_t distance_squared_to(const Vector4i &p_to) const;
+	_FORCE_INLINE_ double distance_to(const Vector4i &p_to) const;
+
 	_FORCE_INLINE_ void zero();
 
 	_FORCE_INLINE_ Vector4i abs() const;
@@ -138,6 +141,14 @@ int64_t Vector4i::length_squared() const {
 
 double Vector4i::length() const {
 	return Math::sqrt((double)length_squared());
+}
+
+int64_t Vector4i::distance_squared_to(const Vector4i &p_to) const {
+	return (p_to - *this).length_squared();
+}
+
+double Vector4i::distance_to(const Vector4i &p_to) const {
+	return (p_to - *this).length();
 }
 
 Vector4i Vector4i::abs() const {

--- a/src/variant/vector2i.cpp
+++ b/src/variant/vector2i.cpp
@@ -49,6 +49,14 @@ double Vector2i::length() const {
 	return Math::sqrt((double)length_squared());
 }
 
+int64_t Vector2i::distance_squared_to(const Vector2i &p_to) const {
+	return (p_to - *this).length_squared();
+}
+
+double Vector2i::distance_to(const Vector2i &p_to) const {
+	return (p_to - *this).length();
+}
+
 Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);
 }


### PR DESCRIPTION
This pull request adds `distance_to` and `distance_squared_to` methods for `Vector2i`, `Vector3i` and `Vector4i`, so that [godot-cpp](https://github.com/godotengine/godot-cpp) may remain in parity with GDScript.

- Depends on https://github.com/godotengine/godot/pull/83163.
