### PR TITLE
Add missing `OP_POWER` operator to `Variant`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2433,6 +2433,7 @@ def get_operator_id_name(op):
         "unary-": "negate",
         "unary+": "positive",
         "%": "module",
+        "**": "power",
         "<<": "shift_left",
         ">>": "shift_right",
         "&": "bit_and",

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -122,6 +122,7 @@ public:
 		OP_NEGATE,
 		OP_POSITIVE,
 		OP_MODULE,
+		OP_POWER,
 		// bitwise
 		OP_SHIFT_LEFT,
 		OP_SHIFT_RIGHT,


### PR DESCRIPTION
I don't think this breaks compatibility as there's no binary compatibility to maintain here, the mapping to the engine is done via the interface macros, but need verification here

* Fixes: https://github.com/godotengine/godot-cpp/issues/1348

Edit: This likely fixes `Variant::evaluate` which tries to map `Operator` to `GDExtensionVariantOperator` which doesn't line up