### PR TITLE
Rework GDCLASS macro to allow abstract classes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -48,6 +48,7 @@ typedef void GodotObject;
 // Base for all engine classes, to contain the pointer to the engine instance.
 class Wrapped {
 	friend class GDExtensionBinding;
+	friend class ClassDB;
 	friend void postinitialize_handler(Wrapped *);
 
 protected:
@@ -131,17 +132,6 @@ struct EngineClassRegistration {
 
 } // namespace godot
 
-#ifdef HOT_RELOAD_ENABLED
-#define _GDCLASS_RECREATE(m_class, m_inherits)                                                   \
-	m_class *new_instance = (m_class *)memalloc(sizeof(m_class));                                \
-	Wrapped::RecreateInstance recreate_data = { new_instance, obj, Wrapped::recreate_instance }; \
-	Wrapped::recreate_instance = &recreate_data;                                                 \
-	memnew_placement(new_instance, m_class);                                                     \
-	return new_instance;
-#else
-#define _GDCLASS_RECREATE(m_class, m_inherits) return nullptr;
-#endif
-
 // Use this on top of your own classes.
 // Note: the trail of `***` is to keep sane diffs in PRs, because clang-format otherwise moves every `\` which makes
 // every line of the macro different
@@ -224,15 +214,6 @@ public:                                                                         
                                                                                                                                                                                        \
 	static ::godot::StringName &get_parent_class_static() {                                                                                                                            \
 		return m_inherits::get_class_static();                                                                                                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionObjectPtr create(void *data) {                                                                                                                                   \
-		m_class *new_object = memnew(m_class);                                                                                                                                         \
-		return new_object->_owner;                                                                                                                                                     \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionClassInstancePtr recreate(void *data, GDExtensionObjectPtr obj) {                                                                                                \
-		_GDCLASS_RECREATE(m_class, m_inherits);                                                                                                                                        \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {                                                                \
@@ -435,14 +416,6 @@ public:                                                                         
                                                                                                                                                                                        \
 	static ::godot::StringName &get_parent_class_static() {                                                                                                                            \
 		return m_inherits::get_class_static();                                                                                                                                         \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionObjectPtr create(void *data) {                                                                                                                                   \
-		return nullptr;                                                                                                                                                                \
-	}                                                                                                                                                                                  \
-                                                                                                                                                                                       \
-	static GDExtensionClassInstancePtr recreate(void *data, GDExtensionObjectPtr obj) {                                                                                                \
-		return nullptr;                                                                                                                                                                \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static void free(void *data, GDExtensionClassInstancePtr ptr) {                                                                                                                    \

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -198,11 +198,22 @@ protected:
 	static void _bind_methods() {}
 };
 
-class ExampleAbstract : public Object {
-	GDCLASS(ExampleAbstract, Object);
+class ExampleAbstractBase : public Object {
+	GDCLASS(ExampleAbstractBase, Object);
 
 protected:
 	static void _bind_methods() {}
+
+	virtual int test_function() = 0;
+};
+
+class ExampleConcrete : public ExampleAbstractBase {
+	GDCLASS(ExampleConcrete, ExampleAbstractBase);
+
+protected:
+	static void _bind_methods() {}
+
+	virtual int test_function() override { return 25; }
 };
 
 #endif // EXAMPLE_CLASS_H

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -25,7 +25,8 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ExampleMin>();
 	ClassDB::register_class<Example>();
 	ClassDB::register_class<ExampleVirtual>(true);
-	ClassDB::register_abstract_class<ExampleAbstract>();
+	ClassDB::register_abstract_class<ExampleAbstractBase>();
+	ClassDB::register_class<ExampleConcrete>();
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
Fixes #1287 

This PR moves the `create` and `recreate` methods out of the `GDCLASS` macro and adjusts the references in the `ClassDB` to use the new `ClassCreator` template class that provides the same functionality as the previous methods in the macro.  

Users can now freely create Godot classes with pure virtual functions, i.e. this is now possible:
```cpp
class MyTestClass : public VBoxContainer
{
    GDCLASS(MyTestClass, VBoxContainer);
    static void _bind_methods() {}
public:
    virtual void test_function() = 0;
};
```
