### PR TITLE
Fix object return value of builtin types' methods.

### DIFF
--- a/include/godot_cpp/core/builtin_ptrcall.hpp
+++ b/include/godot_cpp/core/builtin_ptrcall.hpp
@@ -32,12 +32,24 @@
 #define GODOT_BUILTIN_PTRCALL_HPP
 
 #include <gdextension_interface.h>
+#include <godot_cpp/core/object.hpp>
 
 #include <array>
 
 namespace godot {
 
 namespace internal {
+
+template <class O, class... Args>
+O *_call_builtin_method_ptr_ret_obj(const GDExtensionPtrBuiltInMethod method, GDExtensionTypePtr base, const Args &...args) {
+	GodotObject *ret = nullptr;
+	std::array<GDExtensionConstTypePtr, sizeof...(Args)> call_args = { { (GDExtensionConstTypePtr)args... } };
+	method(base, call_args.data(), &ret, sizeof...(Args));
+	if (ret == nullptr) {
+		return nullptr;
+	}
+	return reinterpret_cast<O *>(internal::get_object_instance_binding(ret));
+}
 
 template <class... Args>
 void _call_builtin_constructor(const GDExtensionPtrConstructor constructor, GDExtensionTypePtr base, Args... args) {


### PR DESCRIPTION
Currently `Signal::get_object()` and `Callable::get_object()` will return an invalid `Object *` without converting by `internal::get_object_instance_binding()`.

This pr fix this problem by adding necessary Conversion for builtin types in binding generator.