### PR TITLE
Allow submitting documentation to the Godot editor

### DIFF
--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -2835,6 +2835,31 @@ typedef void (*GDExtensionInterfaceEditorAddPlugin)(GDExtensionConstStringNamePt
  */
 typedef void (*GDExtensionInterfaceEditorRemovePlugin)(GDExtensionConstStringNamePtr p_class_name);
 
+/**
+ * @name editor_help_load_xml_from_utf8_chars
+ * @since 4.3
+ *
+ * Loads new XML-formatted documentation data in the editor.
+ *
+ * The provided pointer can be immediately freed once the function returns.
+ *
+ * @param p_data A pointer to a UTF-8 encoded C string (null terminated).
+ */
+typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *p_data);
+
+/**
+ * @name editor_help_load_xml_from_utf8_chars_and_len
+ * @since 4.3
+ *
+ * Loads new XML-formatted documentation data in the editor.
+ *
+ * The provided pointer can be immediately freed once the function returns.
+ *
+ * @param p_data A pointer to a UTF-8 encoded C string.
+ * @param p_size The number of bytes (not code units).
+ */
+typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -412,6 +412,7 @@ public:
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
+		set_const(true);
 	}
 };
 
@@ -578,6 +579,7 @@ public:
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
 		set_return(true);
+		set_const(true);
 	}
 };
 

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -190,6 +190,13 @@ extern "C" GDExtensionInterfaceClassdbUnregisterExtensionClass gdextension_inter
 extern "C" GDExtensionInterfaceGetLibraryPath gdextension_interface_get_library_path;
 extern "C" GDExtensionInterfaceEditorAddPlugin gdextension_interface_editor_add_plugin;
 extern "C" GDExtensionInterfaceEditorRemovePlugin gdextension_interface_editor_remove_plugin;
+extern "C" GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars gdextension_interface_editor_help_load_xml_from_utf8_chars;
+extern "C" GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen gdextension_interface_editor_help_load_xml_from_utf8_chars_and_len;
+
+class DocDataRegistration {
+public:
+	DocDataRegistration(const char *p_hash, int p_uncompressed_size, int p_compressed_size, const unsigned char *p_data);
+};
 
 } // namespace internal
 

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -16,6 +16,10 @@ env = SConscript("../SConstruct")
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
 
+if env["target"] in ["editor", "template_debug"]:
+    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
+    sources.append(doc_data)
+
 if env["platform"] == "macos":
     library = env.SharedLibrary(
         "project/bin/libgdexample.{}.{}.framework/libgdexample.{}.{}".format(

--- a/test/doc_classes/Example.xml
+++ b/test/doc_classes/Example.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Example" inherits="Control" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		A test control defined in GDExtension.
+	</brief_description>
+	<description>
+		A control used for the automated GDExtension tests.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="simple_func">
+			<return type="void" />
+			<description>
+				Tests a simple function call.
+			</description>
+		</method>
+	</methods>
+	<members>
+	</members>
+	<signals>
+	</signals>
+	<constants>
+	</constants>
+</class>

--- a/test/project/project.godot
+++ b/test/project/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="GDExtension Test Project"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [native_extensions]


### PR DESCRIPTION
Godot PR https://github.com/godotengine/godot/pull/83747 added support for submitting documentation to the Godot editor from a GDExtension.

This PR aims to give godot-cpp users a way to use that, ideally, in much the same way as documentation is provided by modules.

Here's how it works:

- Using PR https://github.com/godotengine/godot/pull/91518, developers can run `godot --doctool ../ --gdextension-docs` in their demo project (assuming the project is in a directory below their top-level extension code) which will generate a `doc_classes/` directory
- Edit the XML files in the `doc_classes/` directory
- Add something like this to their `SConstruct`:
  ```
  if env["target"] in ["editor", "template_debug"]:
    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
    sources.append(doc_data)
  ```
- Recompile
- And that's it!

When the GDExtension is loaded into the editor, it will automatically submit the documentation XML.

I'm not totally sure how to add this in CMake, but I think we can do it in a similar way to how we run `binding_generator.py` from CMake. I'd really appreciate any help with that!

## Original description

~~I'm not entirely sure how we should expose this to developers. What I have here presently, is mostly about being able to test that the functionality from the Godot PR works. This could certainly use some design help for how to expose the build-system part (both for SCons and cmake) as well as how the developer should trigger the registration.~~

~~We'll also probably need some tooling somewhere, to assist in generating the XML files for extension classes. It looks like `godot --doctool` doesn't include extension classes, so we'll either need to modify it so that it does, or come up with some other process.~~