### PR TITLE
Adjust clang version checking to account for other non-vanilla clangs

### DIFF
--- a/tools/targets.py
+++ b/tools/targets.py
@@ -24,7 +24,7 @@ def using_clang(env):
     return "clang" in os.path.basename(env["CC"])
 
 
-def is_vanilla_clang(env):
+def is_clang_type(env, family_string):
     if not using_clang(env):
         return False
     try:
@@ -32,7 +32,7 @@ def is_vanilla_clang(env):
     except (subprocess.CalledProcessError, OSError):
         print("Couldn't parse CXX environment variable to infer compiler version.")
         return False
-    return not version.startswith("Apple")
+    return version.startswith(family_string)
 
 
 # Main tool definition
@@ -125,10 +125,10 @@ def generate(env):
             else:
                 env.Append(CCFLAGS=["-g2"])
         else:
-            if using_clang(env) and not is_vanilla_clang(env):
+            if using_clang(env) and is_clang_type(env, "Apple"):
                 # Apple Clang, its linker doesn't like -s.
                 env.Append(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
-            else:
+            elif is_clang_type(env, "clang"):
                 env.Append(LINKFLAGS=["-s"])
 
         if env["optimize"] == "speed":


### PR DESCRIPTION
We can no longer make the assumption that all non-vanilla clang versions are Apple's clang or that all other non vanilla clangs will work with the given arguments. There are times where additional tools might use non vanilla clang and the presumed arguments here will break compilation on those platforms. So we should ask explicitly for whether it's Apple clang or if it is vanilla clang (begins with standard "clang version xx.x.x-xxxx"). 

We might want to consider adding tooling-specific optimization functions long term to fetch desired optimizations on a platform basis.

I could use someone to test this on Apple platforms (ios/macos) and additionally linux to make sure that this doesn't cause a regression. It worked well for my Windows machine and my other targeted platforms. 