### PR TITLE
Fix `_notification()` with parent and child classes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -239,11 +239,16 @@ public:                                                                         
                                                                                                                                                                                        \
 	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {                                                                \
 		if (p_instance && m_class::_get_notification()) {                                                                                                                              \
+			if (!p_reversed) {                                                                                                                                                         \
+				m_inherits::notification_bind(p_instance, p_what, p_reversed);                                                                                                         \
+			}                                                                                                                                                                          \
 			if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                                                                     \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
-				return cls->_notification(p_what);                                                                                                                                     \
+				cls->_notification(p_what);                                                                                                                                            \
 			}                                                                                                                                                                          \
-			m_inherits::notification_bind(p_instance, p_what, p_reversed);                                                                                                             \
+			if (p_reversed) {                                                                                                                                                          \
+				m_inherits::notification_bind(p_instance, p_what, p_reversed);                                                                                                         \
+			}                                                                                                                                                                          \
 		}                                                                                                                                                                              \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -245,6 +245,14 @@ func _ready():
 	assert_equal(example.test_virtual_implemented_in_script("Virtual", 939), "Implemented")
 	assert_equal(custom_signal_emitted, ["Virtual", 939])
 
+	# Test that notifications happen on both parent and child classes.
+	var example_child = $ExampleChild
+	assert_equal(example_child.get_value1(), 11)
+	assert_equal(example_child.get_value2(), 33)
+	example_child.notification(NOTIFICATION_ENTER_TREE, true)
+	assert_equal(example_child.get_value1(), 11)
+	assert_equal(example_child.get_value2(), 22)
+
 	exit_with_status()
 
 func _on_Example_custom_signal(signal_name, value):

--- a/test/project/main.tscn
+++ b/test/project/main.tscn
@@ -24,4 +24,6 @@ offset_right = 79.0
 offset_bottom = 29.0
 text = "Click me!"
 
+[node name="ExampleChild" type="ExampleChild" parent="."]
+
 [connection signal="custom_signal" from="Example" to="." method="_on_Example_custom_signal"]

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -630,6 +630,24 @@ void Example::_input(const Ref<InputEvent> &event) {
 	}
 }
 
+void ExampleBase::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_value1"), &ExampleBase::get_value1);
+	ClassDB::bind_method(D_METHOD("get_value2"), &ExampleBase::get_value2);
+}
+
+void ExampleBase::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		value1 = 11;
+		value2 = 22;
+	}
+}
+
+void ExampleChild::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE) {
+		value2 = 33;
+	}
+}
+
 String Example::test_virtual_implemented_in_script(const String &p_name, int p_value) {
 	String ret;
 	if (GDVIRTUAL_CALL(_do_something_virtual, p_name, p_value, ret)) {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -220,6 +220,31 @@ protected:
 	virtual int test_function() override { return 25; }
 };
 
+class ExampleBase : public Node {
+	GDCLASS(ExampleBase, Node);
+
+protected:
+	int value1 = 0;
+	int value2 = 0;
+
+	static void _bind_methods();
+
+	void _notification(int p_what);
+
+public:
+	int get_value1() { return value1; }
+	int get_value2() { return value2; }
+};
+
+class ExampleChild : public ExampleBase {
+	GDCLASS(ExampleChild, ExampleBase);
+
+protected:
+	static void _bind_methods() {}
+
+	void _notification(int p_what);
+};
+
 class ExampleRuntime : public Node {
 	GDCLASS(ExampleRuntime, Node);
 

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -27,6 +27,8 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<ExampleVirtual>(true);
 	ClassDB::register_abstract_class<ExampleAbstractBase>();
 	ClassDB::register_class<ExampleConcrete>();
+	ClassDB::register_class<ExampleBase>();
+	ClassDB::register_class<ExampleChild>();
 	ClassDB::register_runtime_class<ExampleRuntime>();
 }
 


### PR DESCRIPTION
Currently, if you have a parent and child class both defined in GDExtension, and the child class has it's own `_notification()` method, the parent `_notification()` won't be called. But, also, godot-cpp is not respecting the `p_reversed` flag, and will always run reversed, calling the child before the parent.

This PR fixes that!

It also adds an automated test to ensure that it is working correctly, and so we won't break this again.