### PR TITLE
Add custom target for the file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ add_custom_command(OUTPUT ${GENERATED_FILES_LIST}
 		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/binding_generator.py
 		COMMENT "Generating bindings"
 )
+add_custom_target(godotcpp_generated_files DEPENDS ${GENERATED_FILES_LIST})
 
 # Get Sources
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS src/*.c**)


### PR DESCRIPTION
The reason I want to propose this is so that users who just want a compilation database (I use Windows Subsystem for Linux/WSL so its useful for me) can then set the following in their own cmake project in the CMakeLists.txt:

`option(CMAKE_EXPORT_COMPILE_COMMANDS ON)`

And then run:

```
cd build
cmake ..
cmake --build . -t godotcpp_generated_files
```

The above just builds the generated files, and nothing else. No compilation of anything, so its very lightweight.