### PR TITLE
Add automatic generation of getters and setters to GDCLASS and a helper macro for using them

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -149,6 +149,15 @@ struct EngineClassRegistration {
 	}
 };
 
+template <typename>
+struct MemberPointerTraits;
+
+template <typename Result, typename Object>
+struct MemberPointerTraits<Result (Object::*)> {
+	using result_type = Result;
+	using object_type = Object;
+};
+
 } // namespace internal
 
 } // namespace godot
@@ -368,6 +377,12 @@ public:                                                                         
 		_gde_binding_free_callback,                                                                                                                                                    \
 		_gde_binding_reference_callback,                                                                                                                                               \
 	};                                                                                                                                                                                 \
+                                                                                                                                                                                       \
+	template <auto T>                                                                                                                                                                  \
+	typename internal::MemberPointerTraits<decltype(T)>::result_type _get_data_member() { return (this->*T); }                                                                                 \
+                                                                                                                                                                                       \
+	template <auto T>                                                                                                                                                                  \
+	void _set_data_member(typename internal::MemberPointerTraits<decltype(T)>::result_type t) { (this->*T) = t; }                                                                              \
                                                                                                                                                                                        \
 private:
 

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -51,6 +51,14 @@
 #define ADD_GROUP(m_name, m_prefix) godot::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
 #define ADD_SUBGROUP(m_name, m_prefix) godot::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) godot::ClassDB::add_property(get_class_static(), m_property, m_setter, m_getter)
+#define AUTO_ADD_PROPERTY(p_property, p_method)                                                                \
+	{                                                                                                          \
+		auto get = &godot::detail::member_traits<decltype(p_method)>::object_type::_get_data_member<p_method>; \
+		auto set = &godot::detail::member_traits<decltype(p_method)>::object_type::_set_data_member<p_method>; \
+		ClassDB::bind_method(D_METHOD(&#p_method[1]), get);                                               \
+		ClassDB::bind_method(D_METHOD(&#p_method[1]), set);                                               \
+		ClassDB::add_property(get_class_static(), p_property, &#p_method[1], &#p_method[1]);         \
+	}
 #define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) godot::ClassDB::add_property(get_class_static(), m_property, m_setter, m_getter, m_index)
 
 namespace godot {

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -51,13 +51,13 @@
 #define ADD_GROUP(m_name, m_prefix) godot::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
 #define ADD_SUBGROUP(m_name, m_prefix) godot::ClassDB::add_property_subgroup(get_class_static(), m_name, m_prefix)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) godot::ClassDB::add_property(get_class_static(), m_property, m_setter, m_getter)
-#define AUTO_ADD_PROPERTY(p_property, p_method)                                                                \
-	{                                                                                                          \
-		auto get = &godot::detail::member_traits<decltype(p_method)>::object_type::_get_data_member<p_method>; \
-		auto set = &godot::detail::member_traits<decltype(p_method)>::object_type::_set_data_member<p_method>; \
-		ClassDB::bind_method(D_METHOD(&#p_method[1]), get);                                               \
-		ClassDB::bind_method(D_METHOD(&#p_method[1]), set);                                               \
-		ClassDB::add_property(get_class_static(), p_property, &#p_method[1], &#p_method[1]);         \
+#define AUTO_ADD_PROPERTY(p_property, p_method)                                                                                                              \
+	{                                                                                                                                                        \
+		auto get = &godot::internal::MemberPointerTraits<decltype(p_method)>::object_type::_get_data_member<p_method>;                                       \
+		auto set = &godot::internal::MemberPointerTraits<decltype(p_method)>::object_type::_set_data_member<p_method>;                                       \
+		ClassDB::bind_method(D_METHOD(StringName("get") + StringName(&#p_method[1])), get);                                                                  \
+		ClassDB::bind_method(D_METHOD(StringName("set") + StringName(&#p_method[1])), set);                                                                  \
+		ClassDB::add_property(get_class_static(), p_property, StringName("set") + StringName(&#p_method[1]), StringName("get") + StringName(&#p_method[1])); \
 	}
 #define ADD_PROPERTYI(m_property, m_setter, m_getter, m_index) godot::ClassDB::add_property(get_class_static(), m_property, m_setter, m_getter, m_index)
 


### PR DESCRIPTION
First time PR here. 

This lets you add properties without defining setters and getters. Example usage:

```cpp
class Example : public Node {
  GDCLASS(Example, Node)
protected:
  static void _bind_methods();
public:
  int x;
};

void Example::_bind_methods() {
  AUTO_ADD_PROPERTY(PropertyInfo(Variant::INT, "x"), &Example::x);
}
```

It achieves it by adding templated getters and setters in GDCLASS. Is this something you would consider adding support for? Thanks