### PR TITLE
Add typecasting to ObjectDB::get_instance()

### DIFF
--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -119,6 +119,11 @@ public:
 		}
 		return internal::get_object_instance_binding(obj);
 	}
+
+	template <typename T>
+	static T *get_instance(uint64_t p_object_id) {
+		return Object::cast_to<T>(ObjectDB::get_instance(p_object_id));
+	}
 };
 
 template <class T>


### PR DESCRIPTION
I almost always get and instance from ObjectDB then immediately cast it to whatever type I want. Object::cast_to already does error checking so its easy to combine the two as a simple QOL