### PR TITLE
Correctly handle `Object *` arguments that were encoded as `nullptr`

### DIFF
--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -170,11 +170,11 @@ template <class T>
 struct PtrToArg<T *> {
 	static_assert(std::is_base_of<Object, T>::value, "Cannot encode non-Object value as an Object");
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return reinterpret_cast<T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr))));
+		return likely(p_ptr) ? reinterpret_cast<T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)))) : nullptr;
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		*reinterpret_cast<const void **>(p_ptr) = p_var ? p_var->_owner : nullptr;
+		*reinterpret_cast<const void **>(p_ptr) = likely(p_var) ? p_var->_owner : nullptr;
 	}
 };
 
@@ -182,11 +182,11 @@ template <class T>
 struct PtrToArg<const T *> {
 	static_assert(std::is_base_of<Object, T>::value, "Cannot encode non-Object value as an Object");
 	_FORCE_INLINE_ static const T *convert(const void *p_ptr) {
-		return reinterpret_cast<const T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr))));
+		return likely(p_ptr) ? reinterpret_cast<const T *>(godot::internal::get_object_instance_binding(*reinterpret_cast<GDExtensionObjectPtr *>(const_cast<void *>(p_ptr)))) : nullptr;
 	}
 	typedef const Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
-		*reinterpret_cast<const void **>(p_ptr) = p_var ? p_var->_owner : nullptr;
+		*reinterpret_cast<const void **>(p_ptr) = likely(p_var) ? p_var->_owner : nullptr;
 	}
 };
 

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -184,6 +184,10 @@ func _ready():
 	control.queue_free()
 	sprite.queue_free()
 
+	# Test that passing null for objects works as expected too.
+	var example_null : Example = null
+	assert_equal(example.test_object_cast_to_node(example_null), false)
+
 	# Test conversions to and from Variant.
 	assert_equal(example.test_variant_vector2i_conversion(Vector2i(1, 1)), Vector2i(1, 1))
 	assert_equal(example.test_variant_vector2i_conversion(Vector2(1.0, 1.0)), Vector2i(1, 1))


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86478
Fixes https://github.com/godotengine/godot-cpp/issues/1056

This is an alternative to PR https://github.com/godotengine/godot/pull/87613, fixing the issue in godot-cpp rather than in Godot itself. I explained my reasons for wanting to fix it in godot-cpp in [this comment](https://github.com/godotengine/godot/pull/87613#issuecomment-1937341788).

This uses a ternary expression to match the code in the `encode()` method just below the `convert()` method this PR changes:

```c++
	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {
		*reinterpret_cast<const void **>(p_ptr) = p_var ? p_var->_owner : nullptr;
	}
```

I think having the symmetry between the encode/decode methods is nice, even though it leads to a very long line of code. :-)

This PR also adds an automated test which will crash on `master`, but succeed with this PR.