### PR TITLE
Fix invalid `void` return in `BitField`

### DIFF
--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -255,7 +255,7 @@ class BitField {
 public:
 	_FORCE_INLINE_ void set_flag(T p_flag) { value |= p_flag; }
 	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & p_flag; }
-	_FORCE_INLINE_ void clear_flag(T p_flag) { return value &= ~p_flag; }
+	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~p_flag; }
 	_FORCE_INLINE_ BitField(int64_t p_value) { value = p_value; }
 	_FORCE_INLINE_ operator int64_t() const { return value; }
 	_FORCE_INLINE_ operator Variant() const { return value; }


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot-cpp/issues/1406