### PR TITLE
Change cmake required to v3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@
 # Todo
 # Test build for Windows, Mac and mingw.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(godot-cpp LANGUAGES CXX)
 
 option(GENERATE_TEMPLATE_GET_NODE "Generate a template version of the Node class's get_node." ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.13)
 project(godot-cpp-test)
-cmake_minimum_required(VERSION 3.6)
 
 set(GODOT_GDEXTENSION_DIR ../gdextension/ CACHE STRING "Path to GDExtension interface header directory")
 set(CPP_BINDINGS_PATH ../ CACHE STRING "Path to C++ bindings")


### PR DESCRIPTION
This is because target_link_options was added in v3.13 So this wouldn't build with cmake v3.12

https://cmake.org/cmake/help/latest/release/3.13.html#commands

Likewise in CMAKE_CXX_STANDARD only supports value of 17 starting with cmake v3.9
So the test wouldn't build properly with cmake v3.6