### PR TITLE
Fix incorrect utility call signature

### DIFF
--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -77,7 +77,7 @@ R _call_utility_ret(GDExtensionPtrUtilityFunction func, const Args &...args) {
 }
 
 template <typename... Args>
-Object *_call_utility_ret_obj(const GDExtensionPtrUtilityFunction func, void *instance, const Args &...args) {
+Object *_call_utility_ret_obj(const GDExtensionPtrUtilityFunction func, const Args &...args) {
 	GodotObject *ret = nullptr;
 	std::array<GDExtensionConstTypePtr, sizeof...(Args)> mb_args = { { (GDExtensionConstTypePtr)args... } };
 	func(&ret, mb_args.data(), mb_args.size());


### PR DESCRIPTION
The alternative method would be to change the bindings from:
https://github.com/godotengine/godot-cpp/blob/a62f633cebee4b36356dc903d00670733cd28fb1/binding_generator.py#L2054

To:
```python
function_call += "internal::_call_utility_ret_obj(_gde_function, nullptr"
```

But I don't see any reason to pass this argument here, and this is strictly internal, so I think this is the simplest and cleanest solution, I have tested both methods and they both work correctly

See:
* https://github.com/godotengine/godot-cpp/pull/1421