### PR TITLE
Fix some style details in generation

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -797,14 +797,16 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
 
             vararg = method["is_vararg"]
             if vararg:
-                result.append("\ttemplate<typename... Args>")
+                result.append("\ttemplate <typename... Args>")
 
             method_signature = "\t"
             if "is_static" in method and method["is_static"]:
                 method_signature += "static "
 
             if "return_type" in method:
-                method_signature += f'{correct_type(method["return_type"])} '
+                method_signature += f'{correct_type(method["return_type"])}'
+                if not method_signature.endswith("*"):
+                    method_signature += " "
             else:
                 method_signature += "void "
 
@@ -1222,7 +1224,7 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
                 continue
 
             method_signature = make_signature(class_name, method, for_builtin=True)
-            result.append(method_signature + "{")
+            result.append(method_signature + " {")
 
             method_call = "\t"
             is_ref = False
@@ -1642,8 +1644,6 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
             vararg = "is_vararg" in method and method["is_vararg"]
 
             method_signature = "\t"
-            if vararg:
-                method_signature += "private: "
             method_signature += make_signature(
                 class_name, method, for_header=True, use_template_get_node=use_template_get_node
             )
@@ -1722,16 +1722,16 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
     if class_name == "Object":
         result.append("")
 
-        result.append("\ttemplate<typename T>")
+        result.append("\ttemplate <typename T>")
         result.append("\tstatic T *cast_to(Object *p_object);")
 
-        result.append("\ttemplate<typename T>")
+        result.append("\ttemplate <typename T>")
         result.append("\tstatic const T *cast_to(const Object *p_object);")
 
         result.append("\tvirtual ~Object() = default;")
 
     elif use_template_get_node and class_name == "Node":
-        result.append("\ttemplate<typename T>")
+        result.append("\ttemplate <typename T>")
         result.append(
             "\tT *get_node(const NodePath &p_path) const { return Object::cast_to<T>(get_node_internal(p_path)); }"
         )
@@ -1773,7 +1773,7 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
 
             vararg = "is_vararg" in method and method["is_vararg"]
             if vararg:
-                method_signature = "\ttemplate<typename... Args> static "
+                method_signature = "\ttemplate <typename... Args> static "
             else:
                 method_signature = "\tstatic "
 
@@ -1787,7 +1787,9 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
                     False,
                 )
             if return_type is not None:
-                method_signature += return_type + " "
+                method_signature += return_type
+                if not method_signature.endswith("*"):
+                    method_signature += " "
             else:
                 method_signature += "void "
 
@@ -2415,7 +2417,7 @@ def make_varargs_template(
     if with_public_declare:
         function_signature = "public: "
 
-    function_signature += "template<typename... Args> "
+    function_signature += "template <typename... Args> "
 
     if static:
         function_signature += "static "
@@ -2469,7 +2471,7 @@ def make_varargs_template(
     args_array += "Variant(p_args)... };"
     result.append(args_array)
     result.append(f"\tstd::array<const Variant *, {len(method_arguments)} + sizeof...(Args)> call_args;")
-    result.append("\tfor(size_t i = 0; i < variant_args.size(); i++) {")
+    result.append("\tfor (size_t i = 0; i < variant_args.size(); i++) {")
     result.append("\t\tcall_args[i] = &variant_args[i];")
     result.append("\t}")
 
@@ -2735,7 +2737,7 @@ def correct_type(type_name, meta=None, use_alias=True):
         return f"Ref<{type_name}>"
     if type_name == "Object" or is_engine_class(type_name):
         return f"{type_name} *"
-    if type_name.endswith("*"):
+    if type_name.endswith("*") and not type_name.endswith("**") and not type_name.endswith(" *"):
         return f"{type_name[:-1]} *"
     return type_name
 


### PR DESCRIPTION
Some minor output fixes that I came across while fixing some other bugs, this would generate things like:
```cpp
static Object  *instance_from_id(int64_t instance_id);
Object * get_object() const;
virtual Error _get_packet(const uint8_t * *r_buffer, int32_t *r_buffer_size);
```

These are all now fixed