### PR TITLE
Fix misunderstandings in GDREGISTER_CLASS (T)

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -112,7 +112,6 @@ private:
 	template <typename T, bool is_abstract>
 	static void _register_class(bool p_virtual = false, bool p_exposed = true, bool p_runtime = false);
 
-
 	template <typename T, bool is_abstract>
 	static GDExtensionObjectPtr _create_instance_func(void *data) {
 		if constexpr (!std::is_abstract_v<T> || !is_abstract) {
@@ -122,7 +121,6 @@ private:
 			return nullptr;
 		}
 	}
-
 
 	template <typename T, bool is_abstract>
 	static GDExtensionClassInstancePtr _recreate_instance_func(void *data, GDExtensionObjectPtr obj) {

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -112,9 +112,9 @@ private:
 	template <class T, bool is_abstract>
 	static void _register_class(bool p_virtual = false, bool p_exposed = true, bool p_runtime = false);
 
-	template <class T>
+	template <class T, bool is_abstract>
 	static GDExtensionObjectPtr _create_instance_func(void *data) {
-		if constexpr (!std::is_abstract_v<T>) {
+		if constexpr (!std::is_abstract_v<T> || !is_abstract) {
 			T *new_object = memnew(T);
 			return new_object->_owner;
 		} else {
@@ -122,9 +122,9 @@ private:
 		}
 	}
 
-	template <class T>
+	template <class T, bool is_abstract>
 	static GDExtensionClassInstancePtr _recreate_instance_func(void *data, GDExtensionObjectPtr obj) {
-		if constexpr (!std::is_abstract_v<T>) {
+		if constexpr (!std::is_abstract_v<T> || !is_abstract) {
 #ifdef HOT_RELOAD_ENABLED
 			T *new_instance = (T *)memalloc(sizeof(T));
 			Wrapped::RecreateInstance recreate_data = { new_instance, obj, Wrapped::recreate_instance };
@@ -235,9 +235,9 @@ void ClassDB::_register_class(bool p_virtual, bool p_exposed, bool p_runtime) {
 		T::to_string_bind, // GDExtensionClassToString to_string_func;
 		nullptr, // GDExtensionClassReference reference_func;
 		nullptr, // GDExtensionClassUnreference unreference_func;
-		&_create_instance_func<T>, // GDExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
+		&_create_instance_func<T, is_abstract>, // GDExtensionClassCreateInstance create_instance_func; /* this one is mandatory */
 		T::free, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
-		&_recreate_instance_func<T>, // GDExtensionClassRecreateInstance recreate_instance_func;
+		&_recreate_instance_func<T, is_abstract>, // GDExtensionClassRecreateInstance recreate_instance_func;
 		&ClassDB::get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
 		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 		nullptr, // GDExtensionClassCallVirtualWithData call_virtual_func;


### PR DESCRIPTION
to Fix #1425 
When I want to register a non abstract class, I will use `GDREGISTER_CLASS()` or other macros, But I registered the abstract class through `GDREGISTER_CLASS()` (possibly because forgot to implement the pure virtual methods), and there were no compilation errors, which would give me some misunderstandings.

It is because `if constexpr (!std::is_abstract_v<T>)` determined that this class is an abstract class and did not compile `memnew(T)`. 

May necessary to confirm that when using GDREGISTER_CLASS(), the `memnew(T)` must compile. Therefore, when I mistakenly register an abstract class by `GDREGISTER_CLASS()`, the compiler will give error message.