### PR TITLE
Generate arguments for virtual functions that take `float` as taking `float` (rather than `double`)

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2583,6 +2583,8 @@ def correct_type(type_name, meta=None, use_alias=True):
     if meta != None:
         if "int" in meta:
             return f"{meta}_t"
+        elif meta == "float":
+            return meta
         elif meta in type_conversion:
             return type_conversion[type_name]
         else:


### PR DESCRIPTION
While looking into issue https://github.com/godotengine/godot-cpp/issues/1350, I noticed that we were generating virtual methods that were declared to take `float` in Godot as taking `double` in godot-cpp.

For example, `AudioStreamPlayback::_mix(AudioFrame *, float, int)` would turn up in godot-cpp as `AudioStreamPlayback::_mix(AudioFrame *, double, int)`. This is despite the `extension_api.json` giving `float` as the "meta".

So, this PR makes it so that those functions actually take `float`. This fits with our general goal of providing the same API on both the Godot and godot-cpp side.

I don't know if there's any problems with doing this. However, it seems like it should be fine, because our `PtrToArg<T>::convert()` should be able to change the `double *` passed in the ptrcall into a `float` for the function call.

But I'm going to mark it as draft for now, while I investigate the implications of this change.

**Note:** This _doesn't_ actually fix the problem I was looking into originally. It's entirely possible that this is totally unrelated to that issue. :-)