### PR TITLE
Use `GDREGISTER` defines in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-	ClassDB::register_class<Example>();
+	GDREGISTER_CLASS(Example);
 }
 ```
 

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -21,15 +21,15 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	ClassDB::register_class<ExampleRef>();
-	ClassDB::register_class<ExampleMin>();
-	ClassDB::register_class<Example>();
-	ClassDB::register_class<ExampleVirtual>(true);
-	ClassDB::register_abstract_class<ExampleAbstractBase>();
-	ClassDB::register_class<ExampleConcrete>();
-	ClassDB::register_class<ExampleBase>();
-	ClassDB::register_class<ExampleChild>();
-	ClassDB::register_runtime_class<ExampleRuntime>();
+	GDREGISTER_CLASS(ExampleRef);
+	GDREGISTER_CLASS(ExampleMin);
+	GDREGISTER_CLASS(Example);
+	GDREGISTER_VIRTUAL_CLASS(ExampleVirtual);
+	GDREGISTER_ABSTRACT_CLASS(ExampleAbstractBase);
+	GDREGISTER_CLASS(ExampleConcrete);
+	GDREGISTER_CLASS(ExampleBase);
+	GDREGISTER_CLASS(ExampleChild);
+	GDREGISTER_RUNTIME_CLASS(ExampleRuntime);
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
Converts the direct use of class registration functions to their equivalent `GDREGISTER` defines.