### PR TITLE
Add SCons variant_dir support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -4,6 +4,9 @@ import os
 import platform
 import sys
 import subprocess
+
+# binding_generator is located in the source tree along with this SConstruct file
+sys.path.append(Dir(".").srcnode().abspath)
 from binding_generator import scons_generate_bindings, scons_emit_files
 
 
@@ -32,7 +35,7 @@ if profile:
     elif os.path.isfile(profile + ".py"):
         customs.append(profile + ".py")
 opts = Variables(customs, ARGUMENTS)
-cpp_tool = Tool("godotcpp", toolpath=["tools"])
+cpp_tool = Tool("godotcpp", toolpath=[Dir("tools").srcnode().abspath])
 cpp_tool.options(opts, env)
 opts.Update(env)
 

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -12,12 +12,6 @@ from SCons.Script import ARGUMENTS
 from binding_generator import scons_generate_bindings, scons_emit_files
 
 
-def add_sources(sources, dir, extension):
-    for f in os.listdir(dir):
-        if f.endswith("." + extension):
-            sources.append(dir + "/" + f)
-
-
 def get_cmdline_bool(option, default):
     """We use `ARGUMENTS.get()` to check if options were manually overridden on the command line,
     and SCons' _text2bool helper to convert them to booleans, otherwise they're handled as strings.
@@ -30,6 +24,10 @@ def get_cmdline_bool(option, default):
 
 
 def normalize_path(val, env):
+    """Normalize a path that was provided by the user on the command line
+    and is thus either an absolute path or relative to the top level directory (#)
+    where the command was run
+    """
     return val if os.path.isabs(val) else os.path.join(env.Dir("#").abspath, val)
 
 
@@ -50,9 +48,10 @@ def validate_parent_dir(key, val, env):
 
 def get_platform_tools_paths(env):
     path = env.get("custom_tools", None)
+    tools_path = env.Dir("tools").srcnode().abspath
     if path is None:
-        return ["tools"]
-    return [normalize_path(path, env), "tools"]
+        return [tools_path]
+    return [normalize_path(path, env), tools_path]
 
 
 def get_custom_platforms(env):
@@ -511,8 +510,22 @@ def generate(env):
 
 
 def _godot_cpp(env):
-    extension_dir = normalize_path(env.get("gdextension_dir", env.Dir("gdextension").abspath), env)
-    api_file = normalize_path(env.get("custom_api_file", env.File(extension_dir + "/extension_api.json").abspath), env)
+    extension_dir = env.get("gdextension_dir", None)
+    # A user provided extension_dir is relative to where they are running from (#)
+    # But our gdextension directory is here in the source tree
+    if extension_dir is not None:
+        extension_dir = normalize_path(extension_dir, env)
+    else:
+        extension_dir = env.Dir("gdextension").srcnode().abspath
+
+    api_file = env.get("custom_api_file", None)
+    # A user provided api_file is relative to where they are running from (#)
+    # But a default api_file is relative to extension_dir
+    if api_file is not None:
+        api_file = normalize_path(api_file, env)
+    else:
+        api_file = os.path.join(extension_dir, "extension_api.json")
+
     bindings = env.GodotCPPBindings(
         env.Dir("."),
         [
@@ -527,15 +540,12 @@ def _godot_cpp(env):
         env.NoCache(bindings)
 
     # Sources to compile
-    sources = []
-    add_sources(sources, "src", "cpp")
-    add_sources(sources, "src/classes", "cpp")
-    add_sources(sources, "src/core", "cpp")
-    add_sources(sources, "src/variant", "cpp")
+    sources = env.Glob("src/*.cpp")
+    sources += env.Glob("src/*/*.cpp")
     sources.extend([f for f in bindings if str(f).endswith(".cpp")])
 
     # Includes
-    env.AppendUnique(CPPPATH=[env.Dir(d) for d in [extension_dir, "include", "gen/include"]])
+    env.AppendUnique(CPPPATH=[env.Dir(extension_dir), env.Dir("include").srcnode(), env.Dir("gen/include")])
 
     library = None
     library_name = "libgodot-cpp" + env["suffix"] + env["LIBSUFFIX"]


### PR DESCRIPTION
Adds support for using SCons's variant_dir feature to specify the build path for where to build a variant of the the library.

Correct paths in SConstruct and godotcpp tool for the following, even when the current directory is not the root of the repository:
 - the binding_generator python module
 - godotcpp tools
 - source code and includes
 - generated source code