### PR TITLE
Fix PropertyInfo to use hint/usage default constants

### DIFF
--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -47,9 +47,9 @@ struct PropertyInfo {
 	Variant::Type type = Variant::NIL;
 	StringName name;
 	StringName class_name;
-	uint32_t hint = 0;
+	uint32_t hint = PROPERTY_HINT_NONE;
 	String hint_string;
-	uint32_t usage = 7;
+	uint32_t usage = PROPERTY_USAGE_DEFAULT;
 
 	PropertyInfo() = default;
 


### PR DESCRIPTION
This seems to stem from the old property usage flags before they were adjusted in 2022.  It's probably just best to init the value using the `PROPERTY_USAGE_DEFAULT` to avoid this in the future.