### PR TITLE
Cherry-picks for the godot-cpp 4.1 branch - 9th batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,22 +134,22 @@ jobs:
 
       - name: Generate godot-cpp sources only
         run: |
-          scons platform=${{ matrix.platform }} build_library=no ${{ matrix.flags }}
+          scons platform=${{ matrix.platform }} verbose=yes build_library=no ${{ matrix.flags }}
           scons -c
 
       - name: Build godot-cpp (debug)
         run: |
-          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }}
+          scons platform=${{ matrix.platform }} verbose=yes target=template_debug ${{ matrix.flags }}
 
       - name: Build test without rebuilding godot-cpp (debug)
         run: |
           cd test
-          scons platform=${{ matrix.platform }} target=template_debug ${{ matrix.flags }} build_library=no
+          scons platform=${{ matrix.platform }} verbose=yes target=template_debug ${{ matrix.flags }} build_library=no
 
       - name: Build test and godot-cpp (release)
         run: |
           cd test
-          scons platform=${{ matrix.platform }} target=template_release ${{ matrix.flags }}
+          scons platform=${{ matrix.platform }} verbose=yes target=template_release ${{ matrix.flags }}
 
       - name: Download latest Godot artifacts
         uses: dsnopek/action-download-artifact@1322f74e2dac9feed2ee76a32d9ae1ca3b4cf4e9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Web dependencies
         if: ${{ matrix.platform == 'web' }}
-        uses: mymindstorm/setup-emsdk@v13
+        uses: mymindstorm/setup-emsdk@v14
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-	ClassDB::register_class<Example>();
+	GDREGISTER_CLASS(Example);
 }
 ```
 

--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -47,9 +47,9 @@ struct PropertyInfo {
 	Variant::Type type = Variant::NIL;
 	StringName name;
 	StringName class_name;
-	uint32_t hint = 0;
+	uint32_t hint = PROPERTY_HINT_NONE;
 	String hint_string;
-	uint32_t usage = 7;
+	uint32_t usage = PROPERTY_USAGE_DEFAULT;
 
 	PropertyInfo() = default;
 

--- a/src/variant/projection.cpp
+++ b/src/variant/projection.cpp
@@ -136,7 +136,7 @@ Projection Projection::create_for_hmd(int p_eye, real_t p_aspect, real_t p_intra
 
 Projection Projection::create_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 	Projection proj;
-	proj.set_orthogonal(p_left, p_right, p_bottom, p_top, p_zfar, p_zfar);
+	proj.set_orthogonal(p_left, p_right, p_bottom, p_top, p_znear, p_zfar);
 	return proj;
 }
 

--- a/test/src/register_types.cpp
+++ b/test/src/register_types.cpp
@@ -21,13 +21,13 @@ void initialize_example_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	ClassDB::register_class<ExampleRef>();
-	ClassDB::register_class<ExampleMin>();
-	ClassDB::register_class<Example>();
-	ClassDB::register_class<ExampleVirtual>(true);
-	ClassDB::register_abstract_class<ExampleAbstract>();
-	ClassDB::register_class<ExampleBase>();
-	ClassDB::register_class<ExampleChild>();
+	GDREGISTER_CLASS(ExampleRef);
+	GDREGISTER_CLASS(ExampleMin);
+	GDREGISTER_CLASS(Example);
+	GDREGISTER_VIRTUAL_CLASS(ExampleVirtual);
+	GDREGISTER_ABSTRACT_CLASS(ExampleAbstract);
+	GDREGISTER_CLASS(ExampleBase);
+	GDREGISTER_CLASS(ExampleChild);
 }
 
 void uninitialize_example_module(ModuleInitializationLevel p_level) {

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -3,6 +3,7 @@ import os, sys, platform
 from SCons.Variables import EnumVariable, PathVariable, BoolVariable
 from SCons.Variables.BoolVariable import _text2bool
 from SCons.Tool import Tool
+from SCons.Action import Action
 from SCons.Builder import Builder
 from SCons.Errors import UserError
 from SCons.Script import ARGUMENTS
@@ -64,6 +65,67 @@ def get_custom_platforms(env):
             continue
         platforms.append(x.removesuffix(".py"))
     return platforms
+
+
+def no_verbose(env):
+    colors = {}
+
+    # Colors are disabled in non-TTY environments such as pipes. This means
+    # that if output is redirected to a file, it will not contain color codes
+    if sys.stdout.isatty():
+        colors["blue"] = "\033[0;94m"
+        colors["bold_blue"] = "\033[1;94m"
+        colors["reset"] = "\033[0m"
+    else:
+        colors["blue"] = ""
+        colors["bold_blue"] = ""
+        colors["reset"] = ""
+
+    # There is a space before "..." to ensure that source file names can be
+    # Ctrl + clicked in the VS Code terminal.
+    compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    java_compile_source_message = "{}Compiling {}$SOURCE{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    compile_shared_source_message = "{}Compiling shared {}$SOURCE{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    link_program_message = "{}Linking Program {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    link_library_message = "{}Linking Static Library {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    ranlib_library_message = "{}Ranlib Library {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    link_shared_library_message = "{}Linking Shared Library {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    java_library_message = "{}Creating Java Archive {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    compiled_resource_message = "{}Creating Compiled Resource {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+    generated_file_message = "{}Generating {}$TARGET{} ...{}".format(
+        colors["blue"], colors["bold_blue"], colors["blue"], colors["reset"]
+    )
+
+    env.Append(CXXCOMSTR=[compile_source_message])
+    env.Append(CCCOMSTR=[compile_source_message])
+    env.Append(SHCCCOMSTR=[compile_shared_source_message])
+    env.Append(SHCXXCOMSTR=[compile_shared_source_message])
+    env.Append(ARCOMSTR=[link_library_message])
+    env.Append(RANLIBCOMSTR=[ranlib_library_message])
+    env.Append(SHLINKCOMSTR=[link_shared_library_message])
+    env.Append(LINKCOMSTR=[link_program_message])
+    env.Append(JARCOMSTR=[java_library_message])
+    env.Append(JAVACCOMSTR=[java_compile_source_message])
+    env.Append(RCCOMSTR=[compiled_resource_message])
+    env.Append(GENCOMSTR=[generated_file_message])
 
 
 platforms = ["linux", "macos", "windows", "android", "ios", "web"]
@@ -239,6 +301,7 @@ def options(opts, env):
     )
     opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", True))
     opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
+    opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
 
     # Add platform options (custom tools can override platforms)
     for pl in sorted(set(platforms + custom_platforms)):
@@ -362,8 +425,16 @@ def generate(env):
     env.Tool("compilation_db")
     env.Alias("compiledb", env.CompilationDatabase(normalize_path(env["compiledb_file"], env)))
 
+    # Formatting
+    if not env["verbose"]:
+        no_verbose(env)
+
     # Builders
-    env.Append(BUILDERS={"GodotCPPBindings": Builder(action=scons_generate_bindings, emitter=scons_emit_files)})
+    env.Append(
+        BUILDERS={
+            "GodotCPPBindings": Builder(action=Action(scons_generate_bindings, "$GENCOMSTR"), emitter=scons_emit_files)
+        }
+    )
     env.AddMethod(_godot_cpp, "GodotCPP")
 
 


### PR DESCRIPTION
The 9th batch of PR's marked with `cherrypick:4.1`