### PR TITLE
Set instance and instance binding in `Wrapped` constructor.

### DIFF
--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -82,6 +82,9 @@ public:
 	static void free_static(void *p_ptr, bool p_pad_align = false);
 };
 
+template <typename T, std::enable_if_t<!std::is_base_of<::godot::Wrapped, T>::value, bool> = true>
+_ALWAYS_INLINE_ void _pre_initialize() {}
+
 _ALWAYS_INLINE_ void postinitialize_handler(void *) {}
 
 template <typename T>
@@ -94,10 +97,10 @@ _ALWAYS_INLINE_ T *_post_initialize(T *p_obj) {
 #define memrealloc(m_mem, m_size) ::godot::Memory::realloc_static(m_mem, m_size)
 #define memfree(m_mem) ::godot::Memory::free_static(m_mem)
 
-#define memnew(m_class) ::godot::_post_initialize(new ("", "") m_class)
+#define memnew(m_class) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", "") m_class))
 
-#define memnew_allocator(m_class, m_allocator) ::godot::_post_initialize(new ("", m_allocator::alloc) m_class)
-#define memnew_placement(m_placement, m_class) ::godot::_post_initialize(new ("", m_placement, sizeof(m_class), "") m_class)
+#define memnew_allocator(m_class, m_allocator) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", m_allocator::alloc) m_class))
+#define memnew_placement(m_placement, m_class) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", m_placement, sizeof(m_class), "") m_class))
 
 // Generic comparator used in Map, List, etc.
 template <typename T>

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -9,6 +9,9 @@ class TestClass:
 func _ready():
 	var example: Example = $Example
 
+	# Timing of set instance binding.
+	assert_equal(example.is_object_binding_set_by_parent_constructor(), true)
+
 	# Signal.
 	example.emit_custom_signal("Button", 42)
 	assert_equal(custom_signal_emitted, ["Button", 42])

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -193,6 +193,8 @@ void Example::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("return_extended_ref"), &Example::return_extended_ref);
 	ClassDB::bind_method(D_METHOD("extended_ref_checks", "ref"), &Example::extended_ref_checks);
 
+	ClassDB::bind_method(D_METHOD("is_object_binding_set_by_parent_constructor"), &Example::is_object_binding_set_by_parent_constructor);
+
 	ClassDB::bind_method(D_METHOD("test_array"), &Example::test_array);
 	ClassDB::bind_method(D_METHOD("test_tarray_arg", "array"), &Example::test_tarray_arg);
 	ClassDB::bind_method(D_METHOD("test_tarray"), &Example::test_tarray);
@@ -290,7 +292,17 @@ void Example::_bind_methods() {
 	BIND_ENUM_CONSTANT(OUTSIDE_OF_CLASS);
 }
 
-Example::Example() {
+bool Example::has_object_instance_binding() const {
+	return internal::gdextension_interface_object_get_instance_binding(_owner, internal::token, nullptr);
+}
+
+Example::Example() :
+		object_instance_binding_set_by_parent_constructor(has_object_instance_binding()) {
+	// Test conversion, to ensure users can use all parent calss functions at this time.
+	// It would crash if instance binding still not be initialized.
+	Variant v = Variant(this);
+	Object *o = (Object *)v;
+
 	//UtilityFunctions::print("Constructor.");
 }
 
@@ -368,6 +380,10 @@ void Example::varargs_func_void(const Variant **args, GDExtensionInt arg_count, 
 
 void Example::emit_custom_signal(const String &name, int value) {
 	emit_signal("custom_signal", name, value);
+}
+
+bool Example::is_object_binding_set_by_parent_constructor() const {
+	return object_instance_binding_set_by_parent_constructor;
 }
 
 Array Example::test_array() const {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -82,6 +82,9 @@ private:
 	Vector2 dprop[3];
 	int last_rpc_arg = 0;
 
+	const bool object_instance_binding_set_by_parent_constructor;
+	bool has_object_instance_binding() const;
+
 public:
 	// Constants.
 	enum Constants {
@@ -119,6 +122,8 @@ public:
 	void varargs_func_void(const Variant **args, GDExtensionInt arg_count, GDExtensionCallError &error);
 	void emit_custom_signal(const String &name, int value);
 	int def_args(int p_a = 100, int p_b = 200);
+
+	bool is_object_binding_set_by_parent_constructor() const;
 
 	Array test_array() const;
 	int test_tarray_arg(const TypedArray<int64_t> &p_array);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1039

Refer to this [comment](https://github.com/godotengine/godot/issues/91023#issuecomment-2074129143). This is my solution to advance the timing of setting instance and instance binding.

There may be some potential problems that I haven't found, please review it carefully.

This is my test class:
```c++
class MyLineEdit : public LineEdit {
	GDCLASS(MyLineEdit, LineEdit)
protected:
	static void _bind_methods() {}

public:
	void _on_text_submitted(const String &p_test) {
		UtilityFunctions::print("Submitted: ", p_test);
	}

	MyLineEdit() {
		connect("text_submitted", callable_mp(this, &MyLineEdit::_on_text_submitted));
	}
};
```

Before this pr, it will push an error:
```
ERROR: Condition "_instance_bindings != nullptr && _instance_bindings[0].binding != nullptr" is true.
   at: set_instance_binding (core/object/object.cpp:1824)
```

