### PR TITLE
Fix NOTIFICATION_POSTINITIALIZE sent twice to native parent classes

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -89,6 +89,7 @@ protected:
 	::godot::List<::godot::PropertyInfo> plist_owned;
 
 	void _postinitialize();
+	virtual void _notificationv(int32_t p_what, bool p_reversed = false) {}
 
 	Wrapped(const StringName p_godot_class);
 	Wrapped(GodotObject *p_godot_object);
@@ -373,6 +374,11 @@ public:                                                                         
 		_gde_binding_free_callback,                                                                                                                                                    \
 		_gde_binding_reference_callback,                                                                                                                                               \
 	};                                                                                                                                                                                 \
+                                                                                                                                                                                       \
+protected:                                                                                                                                                                             \
+	virtual void _notificationv(int32_t p_what, bool p_reversed = false) override {                                                                                                    \
+		m_class::notification_bind(this, p_what, p_reversed);                                                                                                                          \
+	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 private:
 

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -51,10 +51,7 @@ void Wrapped::_postinitialize() {
 	}
 	godot::internal::gdextension_interface_object_set_instance_binding(_owner, godot::internal::token, this, _get_bindings_callbacks());
 	if (extension_class) {
-		Object *obj = dynamic_cast<Object *>(this);
-		if (obj) {
-			obj->notification(Object::NOTIFICATION_POSTINITIALIZE);
-		}
+		_notificationv(Object::NOTIFICATION_POSTINITIALIZE);
 	}
 }
 


### PR DESCRIPTION
As brought up on PR https://github.com/godotengine/godot/pull/91018, we're currently sending `NOTIFICATION_POSTINITIALIZE` to the native parent class twice.

This issue was introduced by PR https://github.com/godotengine/godot-cpp/issues/1269, which was attempting to get the `NOTIFICATION_POSTINITIALIZE` to arrive to the extension class by sending it in `Wrapped::_postinitialize()`, but the way it's doing it will send the notification through the native parent class again.

This PR makes it so that `Wrapped::_postinitialize()` will only send `NOTIFICATION_POSTINITIALIZE` through the class hierarchy that exists purely on the GDExtension side. Because `NOTIFICATION_POSTINITIALIZE` is run on the parent class first, this effectively just picks up where the previous notification that went through the native parent class heirarchy stopped.

PR https://github.com/godotengine/godot/pull/91018 and https://github.com/godotengine/godot/pull/91019 attempt to more comprehensively fix `NOTIFICATION_POSTINITIALIZE`, but those require changing the GDExtension interface (which is Godot 4.4 material at this point), and we need a fix to this issue that can be used with Godot 4.1, 4.2 and 4.3.