### PR TITLE
[4.2] Backport miscellaneous changes that can't be cherry-picked

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -274,7 +274,6 @@ public:                                                                         
 		if (p_instance) {                                                                                                                                                              \
 			m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                    \
 			cls->plist_owned.clear();                                                                                                                                                  \
-			/* TODO `GDExtensionClassFreePropertyList` is ill-defined, we need a non-const pointer to free this. */                                                                    \
 			::godot::internal::free_c_property_list(const_cast<GDExtensionPropertyInfo *>(p_list));                                                                                    \
 		}                                                                                                                                                                              \
 	}                                                                                                                                                                                  \

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -412,6 +412,7 @@ public:
 		method = p_method;
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
+		set_const(true);
 	}
 };
 
@@ -578,6 +579,7 @@ public:
 		generate_argument_types(sizeof...(P));
 		set_argument_count(sizeof...(P));
 		set_return(true);
+		set_const(true);
 	}
 };
 


### PR DESCRIPTION
PRs https://github.com/godotengine/godot-cpp/pull/1374 and https://github.com/godotengine/godot-cpp/pull/1450 can't be cherry-picked (because they are for things only in Godot 4.3), but there's two little changes that could be included in `4.2` and `4.1`.

Since we still cherry-pick so much to the `4.2` and `4.1` branches, I'd like them to remain as synchronized as possible, in order to avoid creating conflicts that make future cherry-picks harder.

So, this PR just brings these two little miscellaneous changes to `4.2`, which should cherry-pick fine to `4.1` too.

(I kind of regret not splitting these out into their own PRs so they could be cherry-picked like normal, but they are so tiny, I think this is probably fine)
