### PR TITLE
Attempt to fix recent CI failures on `master` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           ./godot-artifacts/godot.linuxbsd.editor.x86_64.mono --headless --version
           cd test
           # Need to run the editor so .godot is generated... but it crashes! Ignore that :-)
-          (cd project && (timeout 10 ../../godot-artifacts/godot.linuxbsd.editor.x86_64.mono --editor --headless --quit >/dev/null 2>&1 || true))
+          (cd project && (timeout 30 ../../godot-artifacts/godot.linuxbsd.editor.x86_64.mono --import --headless >/dev/null 2>&1 || true))
           GODOT=../godot-artifacts/godot.linuxbsd.editor.x86_64.mono ./run-tests.sh
 
       - name: Upload artifact


### PR DESCRIPTION
Starting a few weeks ago, we've been getting sporadic CI failures on the `master` branch. Running the failed jobs again usually succeeds (although, I've had a couple that failed 2-3 times before finally succeeding).

The errors look like this:

<details>
<summary>Error output from the logs</summary>

```
Run chmod +x ./godot-artifacts/godot.linuxbsd.editor.x86_64.mono
4.3.dev.mono.gh.55b8724bd
SCRIPT ERROR: Parse Error: Could not find type "Example" in the current scope.
          at: GDScript::reload (res://main.gd:10)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:22)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:24)
SCRIPT ERROR: Parse Error: Identifier "ExampleRef" not declared in the current scope.
          at: GDScript::reload (res://main.gd:42)
SCRIPT ERROR: Parse Error: Identifier "ExampleRef" not declared in the current scope.
          at: GDScript::reload (res://main.gd:67)
SCRIPT ERROR: Parse Error: Identifier "ExampleRef" not declared in the current scope.
          at: GDScript::reload (res://main.gd:173)
SCRIPT ERROR: Parse Error: Could not find type "Example" in the current scope.
          at: GDScript::reload (res://main.gd:195)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:222)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:223)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:224)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:227)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:228)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:230)
SCRIPT ERROR: Parse Error: Identifier "Example" not declared in the current scope.
          at: GDScript::reload (res://main.gd:230)
SCRIPT ERROR: Parse Error: Identifier "ExampleRef" not declared in the current scope.
          at: GDScript::reload (res://main.gd:251)
ERROR: Failed to load script "res://main.gd" with error "Parse error".
   at: load (modules/gdscript/gdscript.cpp:2894)
SCRIPT ERROR: Parse Error: Could not find base class "Example".
          at: GDScript::reload (res://example.gd:1)
ERROR: Failed to load script "res://example.gd" with error "Parse error".
   at: load (modules/gdscript/gdscript.cpp:2894)
ERROR: Cannot get class 'Example'.
   at: _instantiate_internal (core/object/class_db.cpp:504)
WARNING: Node Example of type Example cannot be created. A placeholder will be created instead.
     at: instantiate (scene/resources/packed_scene.cpp:278)
ERROR: Cannot get class 'ExampleMin'.
   at: _instantiate_internal (core/object/class_db.cpp:504)
WARNING: Node ExampleMin of type ExampleMin cannot be created. A placeholder will be created instead.
     at: instantiate (scene/resources/packed_scene.cpp:278)
ERROR: Cannot get class 'ExampleChild'.
   at: _instantiate_internal (core/object/class_db.cpp:504)
WARNING: Node ExampleChild of type ExampleChild cannot be created. A placeholder will be created instead.
     at: instantiate (scene/resources/packed_scene.cpp:278)
Godot Engine v4.3.dev.mono.gh.55b8724bd ([20](https://github.com/godotengine/godot-cpp/actions/runs/8990060558/job/24694536766#step:14:21)24-05-07 14:49:50 UTC) - https://godotengine.org


Debugger Break, Reason: 'Parser Error: Could not find type "Example" in the current scope.'
*Frame 0 - res://main.gd:10 in function ''
Enter "help" for assistance.
debug> 
Debugger Break, Reason: 'Parser Error: Could not find base class "Example".'
*Frame 0 - res://example.gd:1 in function ''
Enter "help" for assistance.
```
</details>

This leads me to believe that the line before, where we attempt to get Godot to "import" and setup the `.godot/extension_list.cfg`, isn't working. Perhaps because it sometimes takes longer than 10 seconds (which is our current timeout) to do?

So, this PR switches to using the new `--import` flag from PR https://github.com/godotengine/godot/pull/90431, and increasing the timeout to 30 seconds, although, hopefully, Godot will finish importing quicker. (I wonder if I should make an even longer timeout, just in case? 60 seconds?)

I'm not 100% sure this'll work.