### PR TITLE
Use /MTd and /MDd flags on Windows dev builds

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -38,9 +38,15 @@ def generate(env):
             env["CXX"] = "clang-cl"
 
         if env["use_static_cpp"]:
-            env.Append(CCFLAGS=["/MT"])
+            if env["dev_build"]:
+                env.Append(CCFLAGS=["/MTd"])
+            else:
+                env.Append(CCFLAGS=["/MT"])
         else:
-            env.Append(CCFLAGS=["/MD"])
+            if env["dev_build"]:
+                env.Append(CCFLAGS=["/MDd"])
+            else:
+                env.Append(CCFLAGS=["/MD"])
 
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True


### PR DESCRIPTION
Select the debug runtime library for dev builds (i.e. when passing `dev_build=yes` to scons).

I had to do this change to build my extension successfully in debug mode because I link with other libraries which are built with this flag which is the default choice for debug builds. Otherwise, I get linker errors of the kind `"error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MT_StaticRelease' doesn't match value 'MTd_StaticDebug' in <file>.obj"`