### PR TITLE
Bump GHA dependencies to Node 20

### DIFF
--- a/.github/actions/godot-cache/action.yml
+++ b/.github/actions/godot-cache/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Upload cache on completion and check it out now
     - name: Load .scons_cache directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           GODOT=../godot-artifacts/godot.linuxbsd.editor.x86_64.mono ./run-tests.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}


### PR DESCRIPTION
Bump GHA actions/cache@v4 and actions/upload-artifact@v4. Prompted by the following warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.