### PR TITLE
Fix warnings emitted with -Wall

### DIFF
--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -353,7 +353,7 @@ void ClassDB::add_virtual_method(const StringName &p_class, const MethodInfo &p_
 	if (mi.argument_count > 0) {
 		mi.arguments = (GDExtensionPropertyInfo *)memalloc(sizeof(GDExtensionPropertyInfo) * mi.argument_count);
 		mi.arguments_metadata = (GDExtensionClassMethodArgumentMetadata *)memalloc(sizeof(GDExtensionClassMethodArgumentMetadata) * mi.argument_count);
-		for (int i = 0; i < mi.argument_count; i++) {
+		for (uint32_t i = 0; i < mi.argument_count; i++) {
 			mi.arguments[i] = p_method.arguments[i]._to_gdextension();
 			mi.arguments_metadata[i] = p_method.arguments_metadata[i];
 		}
@@ -429,7 +429,7 @@ void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
 		{
 			std::lock_guard<std::mutex> lock(engine_singletons_mutex);
 			singleton_objects.reserve(engine_singletons.size());
-			for (const std::pair<StringName, Object *> &pair : engine_singletons) {
+			for (const std::pair<const StringName, Object *> &pair : engine_singletons) {
 				singleton_objects.push_back(pair.second);
 			}
 		}

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -75,7 +75,7 @@ MethodInfo::operator Dictionary() const {
 	dict["name"] = name;
 	dict["args"] = internal::convert_property_list(arguments);
 	Array da;
-	for (int i = 0; i < default_arguments.size(); i++) {
+	for (size_t i = 0; i < default_arguments.size(); i++) {
 		da.push_back(default_arguments[i]);
 	}
 	dict["default_args"] = da;


### PR DESCRIPTION
Hello, I am tracking 4.2 branch of godot-cpp for my project and compiling my whole project with -Wall. I recently updated godot-cpp to pull all changes from 4.2 branch and there are some new warnings during build that this PR fixes.

The warnings that are fixed by this are:
```
src/core/object.cpp:78:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<godot::Variant>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
   78 |         for (int i = 0; i < default_arguments.size(); i++) {
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~

src/core/class_db.cpp:356:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
  356 |                 for (int i = 0; i < mi.argument_count; i++) {
      |                                 ~~^~~~~~~~~~~~~~~~~~~

src/core/class_db.cpp:432:69: warning: loop variable ‘pair’ of type ‘const std::pair<godot::StringName, godot::Object*>&’ binds to a temporary constructed from type ‘std::pair<const godot::StringName, godot::Object*>’ [-Wrange-loop-construct]
  432 |                         for (const std::pair<StringName, Object *> &pair : engine_singletons) {
      |                                                                     ^~~~

src/core/class_db.cpp:432:69: note: use non-reference type ‘const std::pair<godot::StringName, godot::Object*>’ to make the copy explicit or ‘const std::pair<const godot::StringName, godot::Object*>&’ to prevent copying

```

The first two are just changing the int type to match the one on right hand side and the third one is just what gcc suggested.