### PR TITLE
Fix tests after upstream change to `Node::to_string()`

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -14,7 +14,7 @@ func _ready():
 	assert_equal(custom_signal_emitted, ["Button", 42])
 
 	# To string.
-	assert_equal(example.to_string(),'Example:[ GDExtension::Example <--> Instance ID:%s ]' % example.get_instance_id())
+	assert_equal(example.to_string(),'[ GDExtension::Example <--> Instance ID:%s ]' % example.get_instance_id())
 	# It appears there's a bug with instance ids :-(
 	#assert_equal($Example/ExampleMin.to_string(), 'ExampleMin:[Wrapped:%s]' % $Example/ExampleMin.get_instance_id())
 


### PR DESCRIPTION
Our tests are failing after Godot PR https://github.com/godotengine/godot/pull/92827 was merged

This PR fixes the tests!