### PR TITLE
Fix generating default values for `StringName`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2569,6 +2569,8 @@ def correct_default_value(value, type_name):
         return f"{type_name}()"
     if value.startswith("Array["):
         return f"{{}}"
+    if value.startswith("&"):
+        return value[1::]
     return value
 
 


### PR DESCRIPTION
Cases other than `&""` were not processed correctly

See https://github.com/godotengine/godot/pull/91382#issuecomment-2165890277