### PR TITLE
[Web] Force emcc to use "wasm" longjmp mode

### DIFF
--- a/tools/web.py
+++ b/tools/web.py
@@ -36,12 +36,16 @@ def generate(env):
 
     # Thread support (via SharedArrayBuffer).
     if env["threads"]:
-        env.Append(CCFLAGS=["-s", "USE_PTHREADS=1"])
-        env.Append(LINKFLAGS=["-s", "USE_PTHREADS=1"])
+        env.Append(CCFLAGS=["-sUSE_PTHREADS=1"])
+        env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
 
     # Build as side module (shared library).
-    env.Append(CPPFLAGS=["-s", "SIDE_MODULE=1"])
-    env.Append(LINKFLAGS=["-s", "SIDE_MODULE=1"])
+    env.Append(CPPFLAGS=["-sSIDE_MODULE=1"])
+    env.Append(LINKFLAGS=["-sSIDE_MODULE=1"])
+
+    # Force wasm longjmp mode.
+    env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
+    env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
 
     env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
 


### PR DESCRIPTION
`SUPPORT_LONGJMP` have changed since emscripten 3.1.32 to default to `"wasm"` mode when exceptions are enabled, and `"emscripten"` mode when disabled.

While we generally don't use exception in core, linked libraries may need them, and emscripten doesn't plan to support WASM EH + Emscripten SjLj in the long term.

See godotengine/godot#93143