### PR TITLE
Add missing enum & ctor for PackedVector4Array implementation

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -100,6 +100,7 @@ public:
 		PACKED_VECTOR2_ARRAY,
 		PACKED_VECTOR3_ARRAY,
 		PACKED_COLOR_ARRAY,
+		PACKED_VECTOR4_ARRAY,
 
 		VARIANT_MAX
 	};
@@ -212,6 +213,7 @@ public:
 	Variant(const PackedVector2Array &v);
 	Variant(const PackedVector3Array &v);
 	Variant(const PackedColorArray &v);
+	Variant(const PackedVector4Array &v);
 	~Variant();
 
 	operator bool() const;
@@ -260,6 +262,7 @@ public:
 	operator PackedVector2Array() const;
 	operator PackedVector3Array() const;
 	operator PackedColorArray() const;
+	operator PackedVector4Array() const;
 
 	Variant &operator=(const Variant &other);
 	Variant &operator=(Variant &&other);

--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -248,6 +248,10 @@ Variant::Variant(const PackedColorArray &v) {
 	from_type_constructor[PACKED_COLOR_ARRAY](_native_ptr(), v._native_ptr());
 }
 
+Variant::Variant(const PackedVector4Array &v) {
+	from_type_constructor[PACKED_VECTOR4_ARRAY](_native_ptr(), v._native_ptr());
+}
+
 Variant::~Variant() {
 	internal::gdextension_interface_variant_destroy(_native_ptr());
 }
@@ -504,6 +508,10 @@ Variant::operator PackedVector3Array() const {
 
 Variant::operator PackedColorArray() const {
 	return PackedColorArray(this);
+}
+
+Variant::operator PackedVector4Array() const {
+	return PackedVector4Array(this);
 }
 
 Variant &Variant::operator=(const Variant &other) {


### PR DESCRIPTION
@dsnopek I think this may have been overlooked in https://github.com/godotengine/godot-cpp/pull/1456