### PR TITLE
[DRAFT] Add CMake support for XML documentation

### DIFF
--- a/doc_source_generator.py
+++ b/doc_source_generator.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import os
+import glob
+import zlib
+
+
+def generate_doc_source(dst, source):
+    g = open(dst, "w", encoding="utf-8")
+    buf = ""
+    docbegin = ""
+    docend = ""
+    for src in source:
+        src_path = str(src)
+        if not src_path.endswith(".xml"):
+            continue
+        with open(src_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        buf += content
+
+    buf = (docbegin + buf + docend).encode("utf-8")
+    decomp_size = len(buf)
+
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+
+    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    g.write("\n")
+    g.write("#include <godot_cpp/godot.hpp>\n")
+    g.write("\n")
+
+    g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
+    g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
+    g.write("static const unsigned char _doc_data_compressed[] = {\n")
+    for i in range(len(buf)):
+        g.write("\t" + str(buf[i]) + ",\n")
+    g.write("};\n")
+    g.write("\n")
+
+    g.write(
+        "static godot::internal::DocDataRegistration _doc_data_registration(_doc_data_hash, _doc_data_uncompressed_size, _doc_data_compressed_size, _doc_data_compressed);\n"
+    )
+    g.write("\n")
+
+    g.close()
+
+
+def scons_generate_doc_source(target, source, env):
+    generate_doc_source(str(target[0]), source)
+
+
+def generate_doc_source_from_directory(target, directory):
+    generate_doc_source(target, glob.glob(os.path.join(directory, "*.xml")))

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -10,6 +10,7 @@ from SCons.Script import ARGUMENTS
 
 
 from binding_generator import scons_generate_bindings, scons_emit_files
+from doc_source_generator import scons_generate_doc_source
 
 
 def add_sources(sources, dir, extension):
@@ -336,51 +337,6 @@ def options(opts, env):
             tool.options(opts)
 
 
-def make_doc_source(target, source, env):
-    import zlib
-
-    dst = str(target[0])
-    g = open(dst, "w", encoding="utf-8")
-    buf = ""
-    docbegin = ""
-    docend = ""
-    for src in source:
-        src_path = str(src)
-        if not src_path.endswith(".xml"):
-            continue
-        with open(src_path, "r", encoding="utf-8") as f:
-            content = f.read()
-        buf += content
-
-    buf = (docbegin + buf + docend).encode("utf-8")
-    decomp_size = len(buf)
-
-    # Use maximum zlib compression level to further reduce file size
-    # (at the cost of initial build times).
-    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
-
-    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    g.write("\n")
-    g.write("#include <godot_cpp/godot.hpp>\n")
-    g.write("\n")
-
-    g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
-    g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
-    g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
-    g.write("static const unsigned char _doc_data_compressed[] = {\n")
-    for i in range(len(buf)):
-        g.write("\t" + str(buf[i]) + ",\n")
-    g.write("};\n")
-    g.write("\n")
-
-    g.write(
-        "static godot::internal::DocDataRegistration _doc_data_registration(_doc_data_hash, _doc_data_uncompressed_size, _doc_data_compressed_size, _doc_data_compressed);\n"
-    )
-    g.write("\n")
-
-    g.close()
-
-
 def generate(env):
     # Default num_jobs to local cpu count if not user specified.
     # SCons has a peculiarity where user-specified options won't be overridden
@@ -513,7 +469,7 @@ def generate(env):
     env.Append(
         BUILDERS={
             "GodotCPPBindings": Builder(action=Action(scons_generate_bindings, "$GENCOMSTR"), emitter=scons_emit_files),
-            "GodotCPPDocData": Builder(action=make_doc_source),
+            "GodotCPPDocData": Builder(action=scons_generate_doc_source),
         }
     )
     env.AddMethod(_godot_cpp, "GodotCPP")


### PR DESCRIPTION
I forgot to add CMake support in PR https://github.com/godotengine/godot-cpp/pull/1374

So far this PR is just refactoring the scons code so that CMake can generate the code via the `doc_source_generator.py` script. However, I haven't yet figured out how to add that to CMake yet. If anyone who knows CMake can help out, that'd be great! Otherwise, I will work something eventually. :-)