### PR TITLE
Fix `#include` formatting

### DIFF
--- a/include/godot_cpp/templates/local_vector.hpp
+++ b/include/godot_cpp/templates/local_vector.hpp
@@ -31,10 +31,10 @@
 #ifndef GODOT_LOCAL_VECTOR_HPP
 #define GODOT_LOCAL_VECTOR_HPP
 
-#include "godot_cpp/core/error_macros.hpp"
-#include "godot_cpp/core/memory.hpp"
-#include "godot_cpp/templates/sort_array.hpp"
-#include "godot_cpp/templates/vector.hpp"
+#include <godot_cpp/core/error_macros.hpp>
+#include <godot_cpp/core/memory.hpp>
+#include <godot_cpp/templates/sort_array.hpp>
+#include <godot_cpp/templates/vector.hpp>
 
 #include <initializer_list>
 #include <type_traits>

--- a/test/src/tests.h
+++ b/test/src/tests.h
@@ -6,23 +6,24 @@
 #ifndef TESTS_H
 #define TESTS_H
 
-#include "godot_cpp/templates/cowdata.hpp"
-#include "godot_cpp/templates/hash_map.hpp"
-#include "godot_cpp/templates/hash_set.hpp"
-#include "godot_cpp/templates/hashfuncs.hpp"
-#include "godot_cpp/templates/list.hpp"
-#include "godot_cpp/templates/pair.hpp"
-#include "godot_cpp/templates/rb_map.hpp"
-#include "godot_cpp/templates/rb_set.hpp"
-#include "godot_cpp/templates/rid_owner.hpp"
-#include "godot_cpp/templates/safe_refcount.hpp"
-#include "godot_cpp/templates/search_array.hpp"
-#include "godot_cpp/templates/self_list.hpp"
-#include "godot_cpp/templates/sort_array.hpp"
-#include "godot_cpp/templates/spin_lock.hpp"
-#include "godot_cpp/templates/thread_work_pool.hpp"
-#include "godot_cpp/templates/vector.hpp"
-#include "godot_cpp/templates/vmap.hpp"
-#include "godot_cpp/templates/vset.hpp"
+#include <godot_cpp/templates/cowdata.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
+#include <godot_cpp/templates/hashfuncs.hpp>
+#include <godot_cpp/templates/list.hpp>
+#include <godot_cpp/templates/local_vector.hpp>
+#include <godot_cpp/templates/pair.hpp>
+#include <godot_cpp/templates/rb_map.hpp>
+#include <godot_cpp/templates/rb_set.hpp>
+#include <godot_cpp/templates/rid_owner.hpp>
+#include <godot_cpp/templates/safe_refcount.hpp>
+#include <godot_cpp/templates/search_array.hpp>
+#include <godot_cpp/templates/self_list.hpp>
+#include <godot_cpp/templates/sort_array.hpp>
+#include <godot_cpp/templates/spin_lock.hpp>
+#include <godot_cpp/templates/thread_work_pool.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/templates/vmap.hpp>
+#include <godot_cpp/templates/vset.hpp>
 
 #endif // TESTS_H


### PR DESCRIPTION
Minor syntactic tweaks to ensure all `godot_cpp/*.hpp` includes use angle brackets instead of double-quotes. Also adds `local_vector` to the `tests.h` includes, as that seems to have been overlooked when it was first added.