### PR TITLE
Add `.editorconfig`, consolidate `.gitattributes`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.py,SConstruct}]
+indent_style = space
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,2 @@
-*.c eol=lf
-*.cpp eol=lf
-*.gd eol=lf
-*.tscn eol=lf
-*.cfg eol=lf
-*.godot eol=lf
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf


### PR DESCRIPTION
Implements an `.editorconfig`, acting as a simplified version of the one found in the main repo. `.gitattributes` was simplified even further, granting uniform EOL normalization as this repo doesn't have the same edge-cases as the main repo.