### PR TITLE
SCons: Add `silence_msvc` option for Windows

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -5,10 +5,76 @@ from SCons.Tool import msvc, mingw
 from SCons.Variables import *
 
 
+def silence_msvc(env):
+    import os
+    import re
+    import tempfile
+
+    # Ensure we have a location to write captured output to, in case of false positives.
+    capture_path = os.path.join(os.path.dirname(__file__), "..", "msvc_capture.log")
+    with open(capture_path, "wt", encoding="utf-8"):
+        pass
+
+    old_spawn = env["SPAWN"]
+    re_redirect_stream = re.compile(r"^[12]?>")
+    re_cl_capture = re.compile(r"^.+\.(c|cc|cpp|cxx|c[+]{2})$", re.IGNORECASE)
+    re_link_capture = re.compile(r'\s{3}\S.+\s(?:"[^"]+.lib"|\S+.lib)\s.+\s(?:"[^"]+.exp"|\S+.exp)')
+
+    def spawn_capture(sh, escape, cmd, args, env):
+        # We only care about cl/link, process everything else as normal.
+        if args[0] not in ["cl", "link"]:
+            return old_spawn(sh, escape, cmd, args, env)
+
+        # Process as normal if the user is manually rerouting output.
+        for arg in args:
+            if re_redirect_stream.match(arg):
+                return old_spawn(sh, escape, cmd, args, env)
+
+        tmp_stdout, tmp_stdout_name = tempfile.mkstemp()
+        os.close(tmp_stdout)
+        args.append(f">{tmp_stdout_name}")
+        ret = old_spawn(sh, escape, cmd, args, env)
+
+        try:
+            with open(tmp_stdout_name, "r", encoding=sys.stdout.encoding, errors="replace") as tmp_stdout:
+                lines = tmp_stdout.read().splitlines()
+            os.remove(tmp_stdout_name)
+        except OSError:
+            pass
+
+        # Early process no lines (OSError)
+        if not lines:
+            return ret
+
+        is_cl = args[0] == "cl"
+        content = ""
+        caught = False
+        for line in lines:
+            # These conditions are far from all-encompassing, but are specialized
+            # for what can be reasonably expected to show up in the repository.
+            if not caught and (is_cl and re_cl_capture.match(line)) or (not is_cl and re_link_capture.match(line)):
+                caught = True
+                try:
+                    with open(capture_path, "a", encoding=sys.stdout.encoding) as log:
+                        log.write(line + "\n")
+                except OSError:
+                    print(f'WARNING: Failed to log captured line: "{line}".')
+                continue
+            content += line + "\n"
+        # Content remaining assumed to be an error/warning.
+        if content:
+            sys.stderr.write(content)
+
+        return ret
+
+    env["SPAWN"] = spawn_capture
+
+
 def options(opts):
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True))
+    opts.Add(BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting errors to stderr.", True))
 
 
 def exists(env):
@@ -41,6 +107,9 @@ def generate(env):
             env.Append(CCFLAGS=["/MT"])
         else:
             env.Append(CCFLAGS=["/MD"])
+
+        if env["silence_msvc"] and not env.GetOption("clean"):
+            silence_msvc(env)
 
     elif sys.platform == "win32" or sys.platform == "msys":
         env["use_mingw"] = True


### PR DESCRIPTION
Brings over the `silence_msvc` option from the main repo, which suppresses all redundant output from MSVC's `cl`/`link` tools. Additionally, any error output that *does* occur is instead rerouted to `stderr` as expected, instead of printing it in `stdout` for some reason.

Before:
```
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\popup.cpp ...
animation_node_blend3.cpp
visual_shader_node_varying.cpp
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\visual_shader_node_uv_func.cpp ...
shape_cast2d.cpp
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\gpu_particles_collision_sdf3d.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\gltf_camera.cpp ...
v_split_container.cpp
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\script_create_dialog.cpp ...
progress_bar.cpp
char_fx_transform.cpp
gltf_state.cpp
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\v_box_container.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\popup_menu.cpp ...
shape2d.cpp
popup.cpp
```

After:
```
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\grid_container.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\visual_shader_node_curve_xyz_texture.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\open_xr_composition_layer_quad.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\skin_reference.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\graph_frame.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\render_scene_buffers_configuration.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\visual_shader_node_float_op.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\navigation_mesh_generator.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\gradient.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\noise_texture3d.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\web_socket_multiplayer_peer.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\visual_shader_node_linear_scene_depth.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\mutex.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\gpu_particles_collision_sphere3d.cpp ...
Compiling D:\Godot\Github\godot-cpp\gen\src\classes\render_scene_buffers.cpp ...
```