### PR TITLE
Unexpose `UtilityFunctions::is_instance_valid()`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2166,6 +2166,12 @@ def generate_utility_functions(api, output_dir):
     header.append("public:")
 
     for function in api["utility_functions"]:
+        if function["name"] == "is_instance_valid":
+            # The `is_instance_valid()` function doesn't work as developers expect, and unless used very
+            # carefully will cause crashes. Instead, developers should use `ObjectDB::get_instance()`
+            # with object ids to ensure that an instance is still valid.
+            continue
+
         vararg = "is_vararg" in function and function["is_vararg"]
 
         function_signature = "\t"
@@ -2200,6 +2206,9 @@ def generate_utility_functions(api, output_dir):
     source.append("")
 
     for function in api["utility_functions"]:
+        if function["name"] == "is_instance_valid":
+            continue
+
         vararg = "is_vararg" in function and function["is_vararg"]
 
         function_signature = make_signature("UtilityFunctions", function)


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1390

The `is_instance_valid()` function doesn't work as developers expect, and unless used very carefully, will cause crashes. Instead, developers should use `ObjectDB::get_instance()` with object ids to ensure that an instance is still valid.

This PR unexposes `is_instance_valid()` so that folks aren't tempted to use it.

I'm unsure if we should cherry-pick this or not. Technically it breaks source compatibility, but if developers are using this function, they probably have a bug that's waiting to be exposed. :-)

Note: Bindings aside from godot-cpp may be able to expose `is_instance_valid()` in a non-problematic way. However, since we're trying to match the Godot API and allow raw pointers to objects, we are stuck with this issue. If were able to disallow raw object pointers and require developers to use some kind of "object smart pointer object", that would be a different story.