### PR TITLE
Core: Change BitField internal value to `uint64_t`

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -68,17 +68,17 @@ namespace godot {
 	template <>                                                                  \
 	struct VariantCaster<BitField<m_enum>> {                                     \
 		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) {  \
-			return BitField<m_enum>(p_variant.operator int64_t());               \
+			return BitField<m_enum>(p_variant.operator uint64_t());              \
 		}                                                                        \
 	};                                                                           \
 	template <>                                                                  \
 	struct PtrToArg<BitField<m_enum>> {                                          \
 		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {      \
-			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));  \
+			return BitField<m_enum>(*reinterpret_cast<const uint64_t *>(p_ptr)); \
 		}                                                                        \
-		typedef int64_t EncodeT;                                                 \
+		typedef uint64_t EncodeT;                                                \
 		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, void *p_ptr) { \
-			*reinterpret_cast<int64_t *>(p_ptr) = p_val;                         \
+			*reinterpret_cast<uint64_t *>(p_ptr) = p_val;                        \
 		}                                                                        \
 	};                                                                           \
 	}

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -260,14 +260,14 @@ inline StringName _gde_constant_get_enum_name(T param, StringName p_constant) {
 
 template <typename T>
 class BitField {
-	int64_t value = 0;
+	uint64_t value = 0;
 
 public:
 	_FORCE_INLINE_ void set_flag(T p_flag) { value |= p_flag; }
 	_FORCE_INLINE_ bool has_flag(T p_flag) const { return value & p_flag; }
 	_FORCE_INLINE_ void clear_flag(T p_flag) { value &= ~p_flag; }
-	_FORCE_INLINE_ BitField(int64_t p_value) { value = p_value; }
-	_FORCE_INLINE_ operator int64_t() const { return value; }
+	_FORCE_INLINE_ BitField(uint64_t p_value) { value = p_value; }
+	_FORCE_INLINE_ operator uint64_t() const { return value; }
 	_FORCE_INLINE_ operator Variant() const { return value; }
 };
 


### PR DESCRIPTION
- Depends on godotengine/godot#94270

Discussed at the GDExtension meeting.

This aims to reduce ambiguity in how bitfields are expected to be handled, without actually altering any existing bindings.