### PR TITLE
Add a test to ensure that library path is absolute

### DIFF
--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -270,6 +270,12 @@ func _ready():
 	assert_equal(example_child.get_value1(), 11)
 	assert_equal(example_child.get_value2(), 22)
 
+	# Test that the extension's library path is absolute and valid.
+	var library_path = Example.test_library_path()
+	assert_equal(library_path.begins_with("res://"), false)
+	assert_equal(library_path, ProjectSettings.globalize_path(library_path))
+	assert_equal(FileAccess.file_exists(library_path), true)
+
 	exit_with_status()
 
 func _on_Example_custom_signal(signal_name, value):

--- a/test/src/example.cpp
+++ b/test/src/example.cpp
@@ -248,6 +248,8 @@ void Example::_bind_methods() {
 	ClassDB::bind_static_method("Example", D_METHOD("test_static", "a", "b"), &Example::test_static);
 	ClassDB::bind_static_method("Example", D_METHOD("test_static2"), &Example::test_static2);
 
+	ClassDB::bind_static_method("Example", D_METHOD("test_library_path"), &Example::test_library_path);
+
 	{
 		MethodInfo mi;
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "some_argument"));
@@ -693,6 +695,12 @@ String Example::test_virtual_implemented_in_script(const String &p_name, int p_v
 
 String Example::test_use_engine_singleton() const {
 	return OS::get_singleton()->get_name();
+}
+
+String Example::test_library_path() {
+	String library_path;
+	internal::gdextension_interface_get_library_path(internal::library, library_path._native_ptr());
+	return library_path;
 }
 
 void ExampleRuntime::_bind_methods() {

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -194,6 +194,8 @@ public:
 	GDVIRTUAL1(_do_something_virtual_with_control, Control *);
 
 	String test_use_engine_singleton() const;
+
+	static String test_library_path();
 };
 
 VARIANT_ENUM_CAST(Example::Constants);


### PR DESCRIPTION
Two times now we have broken `get_library_path` such that it doesn't return an absolute path.

See:

- https://github.com/godotengine/godot/pull/84620
- https://github.com/godotengine/godot/pull/94373

This is a Godot issue, but this PR adds a test to CI that will verify that the path is absolute, in order to try and help us not break it again.

This will fail CI until PR https://github.com/godotengine/godot/pull/94373 is merged