### PR TITLE
Cherry-picks for the godot-cpp 4.0 branch - 1st batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Web dependencies
         if: ${{ matrix.platform == 'web' }}
-        uses: mymindstorm/setup-emsdk@v12
+        uses: mymindstorm/setup-emsdk@v13
         with:
           version: ${{env.EM_VERSION}}
           actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             cache-name: windows-x86_64-mingw
 
           - name: 🍎 macOS (universal)
-            os: macos-11
+            os: macos-latest
             platform: macos
             artifact-name: godot-cpp-macos-universal-release
             artifact-path: bin/libgodot-cpp.macos.template_release.universal.a
@@ -65,7 +65,7 @@ jobs:
             cache-name: android-arm64
 
           - name: 🍏 iOS (arm64)
-            os: macos-11
+            os: macos-latest
             platform: ios
             artifact-name: godot-cpp-ios-arm64-release
             artifact-path: bin/libgodot-cpp.ios.template_release.arm64.a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
             platform: android
             artifact-name: godot-cpp-android-arm64-release
             artifact-path: bin/libgodot-cpp.android.template_release.arm64.a
-            flags: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME arch=arm64
+            flags: arch=arm64
+            run-tests: false
             cache-name: android-arm64
 
           - name: 🍏 iOS (arm64)
@@ -73,6 +74,8 @@ jobs:
 
     env:
       SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+      EM_VERSION: 3.1.39
+      EM_CACHE_FOLDER: "emsdk-cache"
 
     steps:
       - name: Checkout
@@ -91,21 +94,29 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Linux dependencies
-        if: ${{ matrix.platform == 'linux' }}
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qqq build-essential pkg-config
+      - name: Android dependencies
+        if: ${{ matrix.platform == 'android' }}
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r23c
+          link-to-sdk: true
 
-      - name: Install scons
-        run: |
-          python -m pip install scons==4.0.0
+      - name: Web dependencies
+        if: ${{ matrix.platform == 'web' }}
+        uses: mymindstorm/setup-emsdk@v12
+        with:
+          version: ${{env.EM_VERSION}}
+          actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
 
       - name: Setup MinGW for Windows/MinGW build
         if: ${{ matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes' }}
         uses: egor-tensin/setup-mingw@v2
         with:
           version: 12.2.0
+
+      - name: Install scons
+        run: |
+          python -m pip install scons==4.0.0
 
       - name: Generate godot-cpp sources only
         run: |


### PR DESCRIPTION
The 1st batch of PR's marked with `cherrypick:4.0`

These are all CI changes, so I won't know if they work until CI runs.