### PR TITLE
Support arm64 target with MSVC

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -88,6 +88,8 @@ def generate(env):
             env["TARGET_ARCH"] = "amd64"
         elif env["arch"] == "x86_32":
             env["TARGET_ARCH"] = "x86"
+        else:
+            env["TARGET_ARCH"] = env["arch"]
         env["is_msvc"] = True
 
         # MSVC, linker, and archiver.


### PR DESCRIPTION
Since Godot 4.3 will have an official Windows ARM64 build, this seems relevant now.

If you try an unsupported arch, SCons will raise `MSVCUnsupportedTargetArch`, so I didn't add any redundant checks.

Verified that it now builds for the correct arch without any further changes:
```
Microsoft (R) COFF/PE Dumper Version 14.40.33812.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file libgdexample.windows.template_debug.arm64.dll

PE signature found

File Type: DLL

FILE HEADER VALUES
            AA64 machine (ARM64)
```