### PR TITLE
Add support for LLVM/MinGW and ARM64 Windows builds.

### DIFF
--- a/tools/common_compiler_flags.py
+++ b/tools/common_compiler_flags.py
@@ -74,7 +74,7 @@ def generate(env):
             else:
                 env.Append(CCFLAGS=["-g2"])
         else:
-            if using_clang(env) and not is_vanilla_clang(env):
+            if using_clang(env) and not is_vanilla_clang(env) and not env["use_mingw"]:
                 # Apple Clang, its linker doesn't like -s.
                 env.Append(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
             else:

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import common_compiler_flags
@@ -72,10 +73,14 @@ def silence_msvc(env):
 
 
 def options(opts):
+    mingw = os.getenv("MINGW_PREFIX", "")
+
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True))
     opts.Add(BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting errors to stderr.", True))
+    opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler", False))
+    opts.Add("mingw_prefix", "MinGW prefix", mingw)
 
 
 def exists(env):
@@ -86,12 +91,22 @@ def generate(env):
     if not env["use_mingw"] and msvc.exists(env):
         if env["arch"] == "x86_64":
             env["TARGET_ARCH"] = "amd64"
+        elif env["arch"] == "arm64":
+            env["TARGET_ARCH"] = "arm64"
+        elif env["arch"] == "arm32":
+            env["TARGET_ARCH"] = "arm"
         elif env["arch"] == "x86_32":
             env["TARGET_ARCH"] = "x86"
+
+        env["MSVC_SETUP_RUN"] = False  # Need to set this to re-run the tool
+        env["MSVS_VERSION"] = None
+        env["MSVC_VERSION"] = None
+
         env["is_msvc"] = True
 
         # MSVC, linker, and archiver.
         msvc.generate(env)
+        env.Tool("msvc")
         env.Tool("mslib")
         env.Tool("mslink")
 
@@ -111,7 +126,7 @@ def generate(env):
         if env["silence_msvc"] and not env.GetOption("clean"):
             silence_msvc(env)
 
-    elif sys.platform == "win32" or sys.platform == "msys":
+    elif (sys.platform == "win32" or sys.platform == "msys") and not env["mingw_prefix"]:
         env["use_mingw"] = True
         mingw.generate(env)
         # Don't want lib prefixes
@@ -137,12 +152,32 @@ def generate(env):
     else:
         env["use_mingw"] = True
         # Cross-compilation using MinGW
-        prefix = "i686" if env["arch"] == "x86_32" else env["arch"]
-        env["CXX"] = prefix + "-w64-mingw32-g++"
-        env["CC"] = prefix + "-w64-mingw32-gcc"
-        env["AR"] = prefix + "-w64-mingw32-ar"
-        env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
-        env["LINK"] = prefix + "-w64-mingw32-g++"
+        prefix = ""
+        if env["mingw_prefix"]:
+            prefix = env["mingw_prefix"] + "/bin/"
+
+        if env["arch"] == "x86_64":
+            prefix += "x86_64"
+        elif env["arch"] == "arm64":
+            prefix += "aarch64"
+        elif env["arch"] == "arm32":
+            prefix += "armv7"
+        elif env["arch"] == "x86_32":
+            prefix += "i686"
+
+        if env["use_llvm"]:
+            env["CXX"] = prefix + "-w64-mingw32-clang++"
+            env["CC"] = prefix + "-w64-mingw32-clang"
+            env["AR"] = prefix + "-w64-mingw32-llvm-ar"
+            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+            env["LINK"] = prefix + "-w64-mingw32-clang"
+        else:
+            env["CXX"] = prefix + "-w64-mingw32-g++"
+            env["CC"] = prefix + "-w64-mingw32-gcc"
+            env["AR"] = prefix + "-w64-mingw32-gcc-ar"
+            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+            env["LINK"] = prefix + "-w64-mingw32-g++"
+
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
 
@@ -156,6 +191,11 @@ def generate(env):
                     "-static-libstdc++",
                 ]
             )
+        if env["use_llvm"]:
+            env.Append(LINKFLAGS=["-lstdc++"])
+
+        if sys.platform == "win32" or sys.platform == "msys":
+            my_spawn.configure(env)
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED"])
 


### PR DESCRIPTION
Similar to the recent https://github.com/bruvzg/godot-nir-static/ and https://github.com/bruvzg/godot-angle-static/ changes for ARM64 Windows support.

- Fixes MSVC architecture detection.
- Adds MinGW-LLVM support.
- Adds `mingw_prefix` to specify custom toolchain.

Tested with:
- MSVC 2022 - (arm64, x86_64, x86_32)
- MinGW-GCC MSYS2 on Windows - (x86_64, x86_32)
- MinGW-LLVM on Windows - (arm64, x86_64, x86_32)
- MinGW-GCC cross build from macOS - (x86_64)
- MinGW-LLVM cross build from macOS - (x86_64)