### PR TITLE
Make sure `_get` and `_set` dispatch up the class hierarchy

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -274,23 +274,27 @@ public:                                                                         
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static GDExtensionBool set_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) {                                \
-		if (p_instance && m_class::_get_set()) {                                                                                                                                       \
+		if (p_instance) {                                                                                                                                                              \
+			if (m_inherits::set_bind(p_instance, p_name, p_value)) {                                                                                                                   \
+				return true;                                                                                                                                                           \
+			}                                                                                                                                                                          \
 			if (m_class::_get_set() != m_inherits::_get_set()) {                                                                                                                       \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
 				return cls->_set(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<const ::godot::Variant *>(p_value));                                        \
 			}                                                                                                                                                                          \
-			return m_inherits::set_bind(p_instance, p_name, p_value);                                                                                                                  \
 		}                                                                                                                                                                              \
 		return false;                                                                                                                                                                  \
 	}                                                                                                                                                                                  \
                                                                                                                                                                                        \
 	static GDExtensionBool get_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {                                       \
-		if (p_instance && m_class::_get_get()) {                                                                                                                                       \
+		if (p_instance) {                                                                                                                                                              \
+			if (m_inherits::get_bind(p_instance, p_name, r_ret)) {                                                                                                                     \
+				return true;                                                                                                                                                           \
+			}                                                                                                                                                                          \
 			if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                                                       \
 				m_class *cls = reinterpret_cast<m_class *>(p_instance);                                                                                                                \
 				return cls->_get(*reinterpret_cast<const ::godot::StringName *>(p_name), *reinterpret_cast<::godot::Variant *>(r_ret));                                                \
 			}                                                                                                                                                                          \
-			return m_inherits::get_bind(p_instance, p_name, r_ret);                                                                                                                    \
 		}                                                                                                                                                                              \
 		return false;                                                                                                                                                                  \
 	}                                                                                                                                                                                  \


### PR DESCRIPTION
@dsnopek this is in response to my question from chat.  It seems a bit odd to me that `_get_property_list` dispatches up the class hierarchy while calls to `_get` and `_set` do not and expect the developer to call the super type internally.  I'm not sure whether we want to alter this behavior or leave it as-is and document this nuance for others who may prefer to use these override methods for property management.

This change also seems to align the GDExtension behavior with C++ modules, too.