### PR TITLE
[DRAFT] Add `ScriptInstanceExtension` class which mimicks the API of Godot's internal `ScriptInstance` class

### DIFF
--- a/include/godot_cpp/classes/script_instance_extension.hpp
+++ b/include/godot_cpp/classes/script_instance_extension.hpp
@@ -1,0 +1,82 @@
+/**************************************************************************/
+/*  script_instance_extension.hpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_SCRIPT_INSTANCE_EXTENSION_HPP
+#define GODOT_SCRIPT_INSTANCE_EXTENSION_HPP
+
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/variant/string_name.hpp>
+
+namespace godot {
+
+class Script;
+class ScriptLanguage;
+
+class ScriptInstanceExtension {
+	static GDExtensionScriptInstanceInfo3 script_instance_info;
+
+public:
+	static GDExtensionScriptInstancePtr create_native_instance(ScriptInstanceExtension *p_instance) {
+		return internal::gdextension_interface_script_instance_create3(&script_instance_info, p_instance);
+	}
+
+	virtual bool set(const StringName &p_name, const Variant &p_value) = 0;
+	virtual bool get(const StringName &p_name, Variant &r_ret) const = 0;
+	virtual const GDExtensionPropertyInfo *get_property_list(uint32_t *r_count) const = 0;
+	virtual void free_property_list(const GDExtensionPropertyInfo *p_list, uint32_t p_count) const = 0;
+	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const = 0;
+	virtual bool validate_property(GDExtensionPropertyInfo &p_property) const = 0;
+	virtual bool get_class_category(GDExtensionPropertyInfo &r_class_category) const;
+	virtual bool property_can_revert(const StringName &p_name) const = 0;
+	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const = 0;
+	virtual Object *get_owner() = 0;
+	virtual void get_property_state(GDExtensionScriptInstancePropertyStateAdd p_add_func, void *p_userdata) = 0;
+	virtual const GDExtensionMethodInfo *get_method_list(uint32_t *r_count) const = 0;
+	virtual void free_method_list(const GDExtensionMethodInfo *p_list, uint32_t p_count) const = 0;
+	virtual bool has_method(const StringName &p_method) const = 0;
+	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const = 0;
+	// @todo Should godot-cpp have a Callable::CallError?
+	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, GDExtensionCallError &r_error) = 0;
+	virtual void notification(int p_notification, bool p_reversed) = 0;
+	virtual String to_string(bool *r_valid) = 0;
+	virtual void refcount_incremented() = 0;
+	virtual bool refcount_decremented() = 0;
+	virtual Ref<Script> get_script() const = 0;
+	virtual bool is_placeholder() const = 0;
+	virtual void property_set_fallback(const StringName &p_name, const Variant &p_value, bool *r_valid) = 0;
+	virtual Variant property_get_fallback(const StringName &p_name, bool *r_valid) = 0;
+	virtual ScriptLanguage *get_language() = 0;
+
+	virtual ~ScriptInstanceExtension(){};
+};
+
+}; // namespace godot
+
+#endif // GODOT_SCRIPT_INSTANCE_EXTENSION_HPP

--- a/src/classes/script_instance_extension.cpp
+++ b/src/classes/script_instance_extension.cpp
@@ -1,0 +1,243 @@
+/**************************************************************************/
+/*  script_instance_extension.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include <godot_cpp/classes/script_instance_extension.hpp>
+
+#include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/script_language_extension.hpp>
+
+using namespace godot;
+
+static GDExtensionBool gdextension_script_instance_set(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+	const Variant *value = reinterpret_cast<const Variant *>(p_value);
+
+	return instance->set(*name, *value);
+}
+
+static GDExtensionBool gdextension_script_instance_get(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+	Variant *ret = reinterpret_cast<Variant *>(r_ret);
+
+	return instance->get(*name, *ret);
+}
+
+static const GDExtensionPropertyInfo *gdextension_script_instance_get_property_list(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+
+	return instance->get_property_list(r_count);
+}
+
+static void gdextension_script_instance_free_property_list(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo *p_list, uint32_t p_count) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	instance->free_property_list(p_list, p_count);
+}
+
+static GDExtensionBool gdextension_script_instance_get_class_category(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *r_class_category) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->get_class_category(*r_class_category);
+}
+
+static GDExtensionVariantType gdextension_script_instance_get_property_type(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+
+	bool is_valid;
+	GDExtensionVariantType ret = (GDExtensionVariantType)instance->get_property_type(*name, &is_valid);
+	*r_is_valid = is_valid;
+
+	return ret;
+}
+
+static GDExtensionBool gdextension_script_instance_validate_property(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionPropertyInfo *p_property) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->validate_property(*p_property);
+}
+
+static GDExtensionBool gdextension_script_instance_property_can_revert(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+
+	return instance->property_can_revert(*name);
+}
+
+static GDExtensionBool gdextension_script_instance_property_get_revert(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+	Variant *ret = reinterpret_cast<Variant *>(r_ret);
+
+	return instance->property_get_revert(*name, *ret);
+}
+
+static GDExtensionObjectPtr gdextension_script_instance_get_owner(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+
+	Object *ret = instance->get_owner();
+	return ret->_owner;
+}
+
+static void gdextension_script_instance_get_property_state(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionScriptInstancePropertyStateAdd p_add_func, void *p_userdata) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	instance->get_property_state(p_add_func, p_userdata);
+}
+
+static const GDExtensionMethodInfo *gdextension_script_instance_get_method_list(GDExtensionScriptInstanceDataPtr p_instance, uint32_t *r_count) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->get_method_list(r_count);
+}
+
+static void gdextension_script_instance_free_method_list(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionMethodInfo *p_list, uint32_t p_count) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->free_method_list(p_list, p_count);
+}
+
+static GDExtensionBool gdextension_script_instance_has_method(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+
+	return instance->has_method(*name);
+}
+
+static GDExtensionInt gdextension_script_instance_get_method_argument_count(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool *r_is_valid) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+
+	bool is_valid;
+	GDExtensionInt ret = instance->get_method_argument_count(*name, &is_valid);
+	*r_is_valid = is_valid;
+
+	return ret;
+}
+
+static void gdextension_script_instance_call(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_method, const GDExtensionConstVariantPtr *p_args, GDExtensionInt p_argument_count, GDExtensionVariantPtr r_return, GDExtensionCallError *r_error) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *method = reinterpret_cast<const StringName *>(p_method);
+	const Variant **args = reinterpret_cast<const Variant **>(const_cast<const void **>(p_args));
+	Variant *ret = reinterpret_cast<Variant *>(r_return);
+
+	*ret = instance->callp(*method, args, p_argument_count, *r_error);
+}
+
+static void gdextension_script_instance_notification(GDExtensionScriptInstanceDataPtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	instance->notification(p_what, p_reversed);
+}
+
+static void gdextension_script_instance_to_string(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionBool *r_is_valid, GDExtensionStringPtr r_out) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	String *out = reinterpret_cast<String *>(r_out);
+
+	bool is_valid = false;
+	*out = instance->to_string(&is_valid);
+	*r_is_valid = is_valid;
+}
+
+static void gdextension_script_instance_refcount_incremented(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	instance->refcount_incremented();
+}
+
+static GDExtensionBool gdextension_script_instance_refcount_decremented(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->refcount_decremented();
+}
+
+static GDExtensionObjectPtr gdextension_script_instance_get_script(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->get_script()->_owner;
+}
+
+static GDExtensionBool gdextension_script_instance_is_placeholder(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->is_placeholder();
+}
+
+static GDExtensionBool gdextension_script_instance_set_fallback(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+	const Variant *value = reinterpret_cast<const Variant *>(p_value);
+
+	bool is_valid = false;
+	instance->property_set_fallback(*name, *value, &is_valid);
+	return is_valid;
+}
+
+static GDExtensionBool gdextension_script_instance_get_fallback(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionVariantPtr r_ret) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	const StringName *name = reinterpret_cast<const StringName *>(p_name);
+	Variant *ret = reinterpret_cast<Variant *>(r_ret);
+
+	bool is_valid = false;
+	instance->property_get_fallback(*name, &is_valid);
+	return is_valid;
+}
+
+static GDExtensionScriptLanguagePtr gdextension_script_instance_get_language(GDExtensionScriptInstanceDataPtr p_instance) {
+	ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+	return instance->get_language()->_owner;
+}
+
+static void gdextension_script_instance_free(GDExtensionScriptInstanceDataPtr p_instance) {
+	if (p_instance) {
+		ScriptInstanceExtension *instance = reinterpret_cast<ScriptInstanceExtension *>(p_instance);
+		memdelete(instance);
+	}
+}
+
+GDExtensionScriptInstanceInfo3 ScriptInstanceExtension::script_instance_info = {
+	&gdextension_script_instance_set,
+	&gdextension_script_instance_get,
+	&gdextension_script_instance_get_property_list,
+	&gdextension_script_instance_free_property_list,
+	&gdextension_script_instance_get_class_category,
+	&gdextension_script_instance_property_can_revert,
+	&gdextension_script_instance_property_get_revert,
+	&gdextension_script_instance_get_owner,
+	&gdextension_script_instance_get_property_state,
+	&gdextension_script_instance_get_method_list,
+	&gdextension_script_instance_free_method_list,
+	&gdextension_script_instance_get_property_type,
+	&gdextension_script_instance_validate_property,
+	&gdextension_script_instance_has_method,
+	&gdextension_script_instance_get_method_argument_count,
+	&gdextension_script_instance_call,
+	&gdextension_script_instance_notification,
+	&gdextension_script_instance_to_string,
+	&gdextension_script_instance_refcount_incremented,
+	&gdextension_script_instance_refcount_decremented,
+	&gdextension_script_instance_get_script,
+	&gdextension_script_instance_is_placeholder,
+	&gdextension_script_instance_set_fallback,
+	&gdextension_script_instance_get_fallback,
+	&gdextension_script_instance_get_language,
+	&gdextension_script_instance_free,
+};


### PR DESCRIPTION
## Background

Godot's internal `ScriptInstance` class (which is used in implementing scripting languages, like GDScript) isn't exposed the normal way, because we don't want scripts (ex a user script written in GDScript) to be able to directly interact with it.

Instead, GDExtensions get a special API from `gdextension_interface.h` to create script instances, allowing GDExtensions to provide new scripting languages for Godot.

However, working directly with that C API from C++ isn't ideal. And it also means big differences between GDExtensions and modules.

A number of extension projects have made their own C++ wrapper classes over this API to make life easier:

- https://github.com/Fumohouse/godot-luau-script/blob/master/src/scripting/luau_script.h#L216
- https://gitlab.com/snopek-games/godot-gravity-lang/-/blob/main/src/gravity_script_instance.h?ref_type=heads#L40

Given that this is something frequently done, I personally think it makes sense to have a wrapper in godot-cpp, so each project doesn't need to recreate it.

## Implementation

This PR has the implementation I used in 'godot-gravity-lang', updated for the latest `gdextension_interface.h`, but I haven't re-tested it.

The main thing I don't like about it, is that it doesn't _exactly_ mimick the API of `ScriptInstance` because it uses some types from `gdextension_interface.h`, rather than the equivalent Godot types (most of which also exist in godot-cpp).

The reason for this is that we'd need to copy data back and forth between the Godot types and `gdextension_interface.h` types, but script instances need to aim to be fairly performant. However, complete API compatibility may be worth it? It's something we'll need to discuss.

Making a DRAFT for now so that we can discuss whether or not we want this in godot-cpp, and if this implementation makes sense.