### PR TITLE
Add hot reload support when building with GCC and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,6 @@ else()
 	endif()
 endif()
 
-if (GODOT_ENABLE_HOT_RELOAD)
-    set(GODOT_COMPILE_FLAGS "${GODOT_COMPILE_FLAGS} -D HOT_RELOAD_ENABLED")
-endif()
-
 # Generate source from the bindings file
 find_package(Python3 3.4 REQUIRED) # pathlib should be present
 if(GENERATE_TEMPLATE_GET_NODE)
@@ -169,6 +165,11 @@ target_compile_features(${PROJECT_NAME}
 	PRIVATE
 		cxx_std_17
 )
+
+if(GODOT_ENABLE_HOT_RELOAD)
+	target_compile_definitions(${PROJECT_NAME} PUBLIC HOT_RELOAD_ENABLED)
+	target_compile_options(${PROJECT_NAME} PUBLIC $<${compiler_is_gnu}:-fno-gnu-unique>)
+endif()
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC
 	$<$<CONFIG:Debug>:


### PR DESCRIPTION
This is a small continuation to PR #1330 which adds hot reloading options for CMake

However when compiling with GCC, the option ```-fno-gnu-unique``` must also be enabled to allow hot reloading.
This is done in the SCons script: https://github.com/godotengine/godot-cpp/blob/9b98377a62ae456b0ee082062dbe98d1a13e7bda/tools/linux.py#L20