### PR TITLE
Correct type for `char16` and `char32` meta

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2770,6 +2770,8 @@ def correct_type(type_name, meta=None, use_alias=True):
     if meta is not None:
         if "int" in meta:
             return f"{meta}_t"
+        elif "char" in meta:
+            return f"{meta}_t"
         else:
             return meta
     if type_name in type_conversion:


### PR DESCRIPTION
- Part of https://github.com/godotengine/godot/pull/95840.