### PR TITLE
Avoid hardcoded type conversion for metadata

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2719,8 +2719,6 @@ def correct_type(type_name, meta=None, use_alias=True):
     if meta is not None:
         if "int" in meta:
             return f"{meta}_t"
-        elif meta in type_conversion:
-            return type_conversion[type_name]
         else:
             return meta
     if type_name in type_conversion:


### PR DESCRIPTION
The engine uses the names `int` and `float` to refer to the 64-bit types, so in the bindings generator we have a hardcoded conversion for those types.

But this type conversion should not be used for metadata. Even though the underlying type should still be 64-bit for interop, metadata is meant to specify the correct type to expose. So if metadata says `float` it means the type is really meant to be a 32-bit `float` and not `double`. Other hardcoded type conversions (`int` and `Nil`) won't ever be metadata.

This change corrects the `float` type, to use the right type in the generated C++ code. Before we were always using `double` due to this type conversion.

---

For example, the `InputEventMouseButton::get_factor` API changes with this PR to return `float` which matches the method signature in the engine:

https://github.com/godotengine/godot/blob/826de7976a6add282c7b14d4be2a7e6d775821d8/core/input/input_event.h#L245