### PR TITLE
Fix incorrect generation of some C++ operators

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -872,14 +872,14 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
 
     if "operators" in builtin_api:
         for operator in builtin_api["operators"]:
-            if operator["name"] not in ["in", "xor"]:
+            if is_valid_cpp_operator(operator["name"]):
                 if "right_type" in operator:
                     result.append(
-                        f'\t{correct_type(operator["return_type"])} operator{operator["name"]}({type_for_parameter(operator["right_type"])}p_other) const;'
+                        f'\t{correct_type(operator["return_type"])} operator{get_operator_cpp_name(operator["name"])}({type_for_parameter(operator["right_type"])}p_other) const;'
                     )
                 else:
                     result.append(
-                        f'\t{correct_type(operator["return_type"])} operator{operator["name"].replace("unary", "")}() const;'
+                        f'\t{correct_type(operator["return_type"])} operator{get_operator_cpp_name(operator["name"])}() const;'
                     )
 
     # Copy assignment.
@@ -1316,10 +1316,10 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
 
     if "operators" in builtin_api:
         for operator in builtin_api["operators"]:
-            if operator["name"] not in ["in", "xor"]:
+            if is_valid_cpp_operator(operator["name"]):
                 if "right_type" in operator:
                     result.append(
-                        f'{correct_type(operator["return_type"])} {class_name}::operator{operator["name"]}({type_for_parameter(operator["right_type"])}p_other) const {{'
+                        f'{correct_type(operator["return_type"])} {class_name}::operator{get_operator_cpp_name(operator["name"])}({type_for_parameter(operator["right_type"])}p_other) const {{'
                     )
                     (encode, arg_name) = get_encoded_arg("other", operator["right_type"], None)
                     result += encode
@@ -1329,7 +1329,7 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
                     result.append("}")
                 else:
                     result.append(
-                        f'{correct_type(operator["return_type"])} {class_name}::operator{operator["name"].replace("unary", "")}() const {{'
+                        f'{correct_type(operator["return_type"])} {class_name}::operator{get_operator_cpp_name(operator["name"])}() const {{'
                     )
                     result.append(
                         f'\treturn internal::_call_builtin_operator_ptr<{get_gdextension_type(correct_type(operator["return_type"]))}>(_method_bindings.operator_{get_operator_id_name(operator["name"])}, (GDExtensionConstTypePtr)&opaque, (GDExtensionConstTypePtr) nullptr);'
@@ -2881,6 +2881,38 @@ def get_operator_id_name(op):
         "in": "in",
     }
     return op_id_map[op]
+
+
+def get_operator_cpp_name(op):
+    op_cpp_map = {
+        "==": "==",
+        "!=": "!=",
+        "<": "<",
+        "<=": "<=",
+        ">": ">",
+        ">=": ">=",
+        "+": "+",
+        "-": "-",
+        "*": "*",
+        "/": "/",
+        "unary-": "-",
+        "unary+": "+",
+        "%": "%",
+        "<<": "<<",
+        ">>": ">>",
+        "&": "&",
+        "|": "|",
+        "^": "^",
+        "~": "~",
+        "and": "&&",
+        "or": "||",
+        "not": "!",
+    }
+    return op_cpp_map[op]
+
+
+def is_valid_cpp_operator(op):
+    return op not in ["**", "xor", "in"]
 
 
 def get_default_value_for_type(type_name):


### PR DESCRIPTION
Fixes #1556.

This fixes the generation of `operator!`, `operator&&` and `operator||`, as they were not being mapped correctly from their `extension_api.json` name of `not`, `and` and `or` respectively, resulting in them showing up as `operatornot`, `operatorand` and `operatoror` respectively.

Note that `operatorand` and `operatoror` never actually showed up anywhere in the generated C++ headers, as they only exist on built-in types in `extension_api.json` currently.

I also fixed another related issue, which is that the `**` operator wasn't being skipped like the `in` and `xor` operators have been until now, neither of which make no sense in C++ of course. This is now done through a new helper function called `is_valid_cpp_operator`.

I suppose this is technically a breaking change, so I'm not sure if there's perhaps some argument for leaving the old `operatornot` methods intact.