### PR TITLE
[Web/SCons] Use CCFLAGS for SIDE_MODULE option

### DIFF
--- a/tools/web.py
+++ b/tools/web.py
@@ -39,7 +39,7 @@ def generate(env):
         env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
 
     # Build as side module (shared library).
-    env.Append(CPPFLAGS=["-sSIDE_MODULE=1"])
+    env.Append(CCFLAGS=["-sSIDE_MODULE=1"])
     env.Append(LINKFLAGS=["-sSIDE_MODULE=1"])
 
     # Force wasm longjmp mode.


### PR DESCRIPTION
Was using CPPFLAGS, but should use the explicit scons CCFLAGS which makes it clear they are applied to both the C and C++ compiler.
    
CPPFLAGS was also fine (they are preprocessor flags, also applied to both C and C++), but we should try to stay consistent with what we do in Godot.
