### PR TITLE
add owner when object is created by Godot

### DIFF
--- a/src/variant/variant.cpp
+++ b/src/variant/variant.cpp
@@ -441,7 +441,10 @@ Variant::operator Object *() const {
 	if (obj == nullptr) {
 		return nullptr;
 	}
-	return internal::get_object_instance_binding(obj);
+	Object* ret = internal::get_object_instance_binding(obj);
+	if(!ret->_owner)
+		ret->_owner = obj;
+	return ret;
 }
 
 Variant::operator ObjectID() const {


### PR DESCRIPTION
This is more a bandaid - I dont see yet the code path that constructs those incomplete Wrapper objects.

The use case is described here:
https://forum.godotengine.org/t/issues-assigning-an-image-resource-to-a-gdextension-property/79151

The object is created from godot and passed via the editor to the custom node. For some reason the object then ends up having now owner pointer.