### PR TITLE
Update wasm build to use bigint

### DIFF
--- a/tools/web.py
+++ b/tools/web.py
@@ -46,6 +46,10 @@ def generate(env):
     env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
     env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
 
+    # Use big int
+    env.Append(CCFLAGS=["-sWASM_BIGINT"])
+    env.Append(LINKFLAGS=["-sWASM_BIGINT"])
+
     env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
 
     common_compiler_flags.generate(env)


### PR DESCRIPTION
godot-cpp does not use the same compilation flags for wasm as godot. This change fixes import errors from mismatched function signatures.