### PR TITLE
Correctly set instance bindings on reload

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -61,6 +61,10 @@ class Wrapped {
 	thread_local static const StringName *_constructing_extension_class_name;
 	thread_local static const GDExtensionInstanceBindingCallbacks *_constructing_class_binding_callbacks;
 
+#ifdef HOT_RELOAD_ENABLED
+	thread_local static GDExtensionObjectPtr _constructing_recreate_owner;
+#endif
+
 	template <typename T>
 	_ALWAYS_INLINE_ static void _set_construct_info() {
 		_constructing_extension_class_name = T::_get_extension_class_name();
@@ -70,15 +74,6 @@ class Wrapped {
 protected:
 	virtual bool _is_extension_class() const { return false; }
 	static const StringName *_get_extension_class_name(); // This is needed to retrieve the class name before the godot object has its _extension and _extension_instance members assigned.
-
-#ifdef HOT_RELOAD_ENABLED
-	struct RecreateInstance {
-		GDExtensionClassInstancePtr wrapper;
-		GDExtensionObjectPtr owner;
-		RecreateInstance *next;
-	};
-	inline static RecreateInstance *recreate_instance = nullptr;
-#endif
 
 	void _notification(int p_what) {}
 	bool _set(const StringName &p_name, const Variant &p_property) { return false; }

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -129,9 +129,8 @@ private:
 	static GDExtensionClassInstancePtr _recreate_instance_func(void *data, GDExtensionObjectPtr obj) {
 		if constexpr (!std::is_abstract_v<T>) {
 #ifdef HOT_RELOAD_ENABLED
+			Wrapped::_constructing_recreate_owner = obj;
 			T *new_instance = (T *)memalloc(sizeof(T));
-			Wrapped::RecreateInstance recreate_data = { new_instance, obj, Wrapped::recreate_instance };
-			Wrapped::recreate_instance = &recreate_data;
 			memnew_placement(new_instance, T);
 			return new_instance;
 #else


### PR DESCRIPTION
In PR https://github.com/godotengine/godot-cpp/pull/1446, we forgot to make sure that instance bindings were being set when recreating an instance with a pre-existing owner (which is what happens on hot reload), leading to incomplete reload.

This fixes that, while also making the code more consistent with the approach used in #1446.

Fixes https://github.com/godotengine/godot-cpp/issues/1589
Fixes https://github.com/godotengine/godot-cpp/issues/1502
