### PR TITLE
[4.3] Revert "Unexpose `UtilityFunctions::is_instance_valid()`"

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2166,12 +2166,6 @@ def generate_utility_functions(api, output_dir):
     header.append("public:")
 
     for function in api["utility_functions"]:
-        if function["name"] == "is_instance_valid":
-            # The `is_instance_valid()` function doesn't work as developers expect, and unless used very
-            # carefully will cause crashes. Instead, developers should use `ObjectDB::get_instance()`
-            # with object ids to ensure that an instance is still valid.
-            continue
-
         vararg = "is_vararg" in function and function["is_vararg"]
 
         function_signature = "\t"
@@ -2206,9 +2200,6 @@ def generate_utility_functions(api, output_dir):
     source.append("")
 
     for function in api["utility_functions"]:
-        if function["name"] == "is_instance_valid":
-            continue
-
         vararg = "is_vararg" in function and function["is_vararg"]
 
         function_signature = make_signature("UtilityFunctions", function)


### PR DESCRIPTION
This reverts commit 56cd3fd99eb76ca3da33dafb694828a7306b2c81 aka PR https://github.com/godotengine/godot-cpp/pull/1513.

It fixes issue https://github.com/godotengine/godot-cpp/issues/1587 (for Godot 4.3 and earlier), which pointed out that there is a use-case that can't be currently be replicated using `ObjectID` and `ObjectDB`.

(See PR https://github.com/godotengine/godot/pull/97119 for a way to keep the removal of `UtilityFunctions::is_instance_valid()` while still allowing for this use-case, but it will need to be Godot 4.4+)