### PR TITLE
Update .gitignore to add .idea for the Jetbrains CLion IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,7 @@ compile_commands.json
 # Python development
 .venv
 venv
+
+# Clion Configuration
+.idea/
+cmake-build-*


### PR DESCRIPTION
and also the default cmake build directory when building in clion cmake-build-*

it would be very nice if this could be added to gitignore.