### PR TITLE
VSProj Configure type on build command - to resolve #1582

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,9 +264,9 @@ jobs:
       - name: Build godot-cpp
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 16 2019" .
-          cmake --build . --verbose
+          cmake --build . --verbose --config Release
 
       - name: Build test GDExtension library
         run: |
           cd test && cmake -DCMAKE_BUILD_TYPE=Release -DGODOT_HEADERS_PATH="../godot-headers" -DCPP_BINDINGS_PATH=".." -G"Visual Studio 16 2019" .
-          cmake --build . --verbose
+          cmake --build . --verbose --config Release


### PR DESCRIPTION
Visual Studio projects are multi-config projects like Ninja-MultiConfig which means you can't set the configuration at configure time as there are multiple, it always chooses the first one by default when not specified in the build command.

Instead of this:
cmake -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 17 2022" .
cmake --build . --verbose

It should be this
cmake -G"Visual Studio 17 2022" .
cmake --build . --verbose --config Release

Because the existing cmake solution does not use generator expressions for its per config configuration, we actually have to specify it in both commands :(

cmake -DCMAKE_BUILD_TYPE=Release -G"Visual Studio 17 2022" .
cmake --build . --verbose --config Release

Fixes https://github.com/godotengine/godot-cpp/issues/1582