### PR TITLE
Add lto scons option

### DIFF
--- a/tools/android.py
+++ b/tools/android.py
@@ -120,4 +120,9 @@ def generate(env):
 
     env.Append(CPPDEFINES=["ANDROID_ENABLED", "UNIX_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/android/detect.py
+    # LTO benefits for Android (size, performance) haven't been clearly established yet.
+    if env["lto"] == "auto":
+        env["lto"] = "none"
+
     common_compiler_flags.generate(env)

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -326,6 +326,14 @@ def options(opts, env):
             ("none", "custom", "debug", "speed", "speed_trace", "size"),
         )
     )
+    opts.Add(
+        EnumVariable(
+            "lto",
+            "Link-time optimization",
+            "none",
+            ("none", "auto", "thin", "full"),
+        )
+    )
     opts.Add(BoolVariable("debug_symbols", "Build with debugging symbols", True))
     opts.Add(BoolVariable("dev_build", "Developer build with dev-only debugging code (DEV_ENABLED)", False))
     opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))

--- a/tools/ios.py
+++ b/tools/ios.py
@@ -97,4 +97,9 @@ def generate(env):
 
     env.Append(CPPDEFINES=["IOS_ENABLED", "UNIX_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/ios/detect.py:
+    # Disable by default as it makes linking in Xcode very slow.
+    if env["lto"] == "auto":
+        env["lto"] = "none"
+
     common_compiler_flags.generate(env)

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -39,4 +39,8 @@ def generate(env):
 
     env.Append(CPPDEFINES=["LINUX_ENABLED", "UNIX_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/linuxbsd/detect.py
+    if env["lto"] == "auto":
+        env["lto"] = "full"
+
     common_compiler_flags.generate(env)

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -73,4 +73,9 @@ def generate(env):
 
     env.Append(CPPDEFINES=["MACOS_ENABLED", "UNIX_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/macos/detect.py
+    # LTO benefits for macOS (size, performance) haven't been clearly established yet.
+    if env["lto"] == "auto":
+        env["lto"] = "none"
+
     common_compiler_flags.generate(env)

--- a/tools/web.py
+++ b/tools/web.py
@@ -48,4 +48,8 @@ def generate(env):
 
     env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/web/detect.py
+    if env["lto"] == "auto":
+        env["lto"] = "full"
+
     common_compiler_flags.generate(env)

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -199,4 +199,12 @@ def generate(env):
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED"])
 
+    # Refer to https://github.com/godotengine/godot/blob/master/platform/windows/detect.py
+    if env["lto"] == "auto":
+        if env.get("is_msvc", False):
+            # No LTO by default for MSVC, doesn't help.
+            env["lto"] = "none"
+        else:  # Release
+            env["lto"] = "full"
+
     common_compiler_flags.generate(env)


### PR DESCRIPTION
The behavior mimics almost the exact behavior (minus "progress" options) of Godot scons:
- [SConstruct](https://github.com/godotengine/godot/blob/master/SConstruct) (option declaration).
- [Web](https://github.com/godotengine/godot/blob/master/platform/web/detect.py)
- [Windows](https://github.com/godotengine/godot/blob/master/platform/windows/detect.py)
- [Linux](https://github.com/godotengine/godot/blob/master/platform/linuxbsd/detect.py)
- [macOS](https://github.com/godotengine/godot/blob/master/platform/macos/detect.py)
- [Android](https://github.com/godotengine/godot/blob/master/platform/android/detect.py)
- [iOS](https://github.com/godotengine/godot/blob/master/platform/ios/detect.py)

This is an _active_ change (edit: not anymore, defaults to 'none' by default now): Once merged, _all projects depending on godot-cpp_ (and updating the submodule) will gain LTO for release builds. I tested a similar setup in my own project, not the exact same though (because I don't have all combinations of windows, msvc, mingw and use_llvm available). However, since that it mimics what Godot does already, it should be good, given I did not make mistakes.

One important difference is that in my implementation (edit: not anymore, consistently 'none' by default now), "auto" is consistent across platforms ("full" in production, "none" in dev). I saw small, but consistent gains in all platforms, and don't see why LTO should be avoided in some platforms by default.