### PR TITLE
[SCons] Remove use_clang_cl windows flag in favor of generic use_llvm

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -76,10 +76,9 @@ def options(opts):
     mingw = os.getenv("MINGW_PREFIX", "")
 
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
-    opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", True))
     opts.Add(BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting errors to stderr.", True))
-    opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler", False))
+    opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler (MVSC or MinGW depending on the use_mingw flag)", False))
     opts.Add("mingw_prefix", "MinGW prefix", mingw)
 
 
@@ -114,7 +113,7 @@ def generate(env):
         env.Append(CCFLAGS=["/utf-8"])
         env.Append(LINKFLAGS=["/WX"])
 
-        if env["use_clang_cl"]:
+        if env["use_llvm"]:
             env["CC"] = "clang-cl"
             env["CXX"] = "clang-cl"
 


### PR DESCRIPTION
This is consistent with Godot upstream.

As discussed in https://github.com/godotengine/godot-cpp/pull/1601#discussion_r1770526612 it seems that we have a discrepancy between [upstream Godot](https://github.com/godotengine/godot/blob/346cbc7f1f206f4540520a92bf7def97b9be0af8/platform/windows/detect.py#L384-L388) and godot-cpp which uses a special `use_clang_cl` instead of the generic `use_llvm` flag for building Windows with the clang MSVC backend.