### PR TITLE
Fix build location of macos of the test project.

### DIFF
--- a/test/project/example.gdextension
+++ b/test/project/example.gdextension
@@ -5,8 +5,8 @@ compatibility_minimum = "4.1"
 
 [libraries]
 
-macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
-macos.release = "res://bin/libgdexample.macos.template_release.framework"
+macos.debug = "res://bin/libgdexample.macos.template_debug.framework/libgdexample.macos.template_debug"
+macos.release = "res://bin/libgdexample.macos.template_release.framework/libgdexample.macos.template_release"
 windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
 windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
 windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"


### PR DESCRIPTION
Without this fix, macOS users won't be able to run the tests.

This is in-line with how the SConstruct currently generates the files, which is not optimal (e.g. .dylib missing) but should be addressed in a different PR.