### PR TITLE
Rename Vector4.components -> coord

### DIFF
--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -55,16 +55,16 @@ struct _NO_DISCARD_ Vector4 {
 			real_t z;
 			real_t w;
 		};
-		real_t components[4] = { 0, 0, 0, 0 };
+		real_t coord[4] = { 0, 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 	_FORCE_INLINE_ const real_t &operator[](const int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 
 	Vector4::Axis min_axis_index() const;


### PR DESCRIPTION
To bring it in-line with all the other vectors, they all use `coord`.

I think it's pretty obvious that this is a breaking change, though it will not introduce bugs, just cause people to need to adjust their usages when they update.