### PR TITLE
Rename Vector4.components -> coords.

### DIFF
--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -55,16 +55,17 @@ struct _NO_DISCARD_ Vector4 {
 			real_t z;
 			real_t w;
 		};
-		real_t components[4] = { 0, 0, 0, 0 };
+		[[deprecated("Use coord instead")]] real_t components[4];
+		real_t coord[4] = { 0, 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](const int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 	_FORCE_INLINE_ const real_t &operator[](const int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 
 	Vector4::Axis min_axis_index() const;


### PR DESCRIPTION
Follow-up of https://github.com/godotengine/godot/pull/97487#pullrequestreview-2331113052
Fixes #1608 

As mentioned, a discussion could be had about just removing the 'components' alias, but I think there's no harm just using deprecations as is usually done.