### PR TITLE
SCons: Don't cache librarys

### DIFF
--- a/test/SConstruct
+++ b/test/SConstruct
@@ -42,4 +42,5 @@ else:
         source=sources,
     )
 
+env.NoCache(library)
 Default(library)

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -552,6 +552,7 @@ def _godot_cpp(env):
 
     if env["build_library"]:
         library = env.StaticLibrary(target=env.File("bin/%s" % library_name), source=sources)
+        env.NoCache(library)
         default_args = [library]
 
         # Add compiledb if the option is set


### PR DESCRIPTION
It was discovered in one of my PRs on the main repo[^1] that the cache size for godot-cpp is **huge**. After a bit more digging, I *believe* that the main culprits are the library files; the equivalents of which are not cached in the main repo. This PR makes them uncached explicitly.

[^1]: https://github.com/godotengine/godot/pull/97166#discussion_r1766720006