### PR TITLE
Fix CallableCustom comparison function handling

### DIFF
--- a/src/variant/callable_custom.cpp
+++ b/src/variant/callable_custom.cpp
@@ -110,9 +110,9 @@ Callable::Callable(CallableCustom *p_callable_custom) {
 	info.call_func = &callable_custom_call;
 	info.is_valid_func = &callable_custom_is_valid;
 	info.free_func = &callable_custom_free;
-	info.hash_func = &callable_custom_hash;
-	info.equal_func = &callable_custom_equal_func;
-	info.less_than_func = &callable_custom_less_than_func;
+	info.hash_func = p_callable_custom->hash() != 0 ? &callable_custom_hash : nullptr;
+	info.equal_func = p_callable_custom->get_compare_equal_func() ? &callable_custom_equal_func : nullptr;
+	info.less_than_func = p_callable_custom->get_compare_less_func() ? &callable_custom_less_than_func : nullptr;
 	info.to_string_func = &callable_custom_to_string;
 	info.get_argument_count_func = &custom_callable_get_argument_count_func;
 


### PR DESCRIPTION
In the GDExtension API the CallableCustom interface defines the `hash_func`, `equal_func`, and `less_than_func` methods as optional.

However, in godot-cpp a custom handler was always provided to Godot. This custom provider then failed if both Callables had specified nullptr as their equal or less_than_equal comparison function.

This commit fixes this, and only sets the custom handler, when a custom handler is actually specified by the developer.

Also, if the hash() function returns 0, then no hash function is provided to Godot, so it falls back to its default hash function.

This issue was originally discovered in Godot 4.3, so it might be a good idea to cherry-pick it to that branch.

Developed by [Migeran](https://migeran.com/)