### PR TITLE
Cherrypicks "[SCons] Enable WASM_BIGINT in web builds" into 4.3 branch

### DIFF
--- a/tools/web.py
+++ b/tools/web.py
@@ -42,6 +42,10 @@ def generate(env):
     env.Append(CCFLAGS=["-sSIDE_MODULE=1"])
     env.Append(LINKFLAGS=["-sSIDE_MODULE=1"])
 
+    # Enable WebAssembly BigInt <-> i64 conversion.
+    # This must match the flag used to build Godot (true in official builds since 4.3)
+    env.Append(LINKFLAGS=["-sWASM_BIGINT"])
+
     # Force wasm longjmp mode.
     env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
     env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])


### PR DESCRIPTION
This was marked as cherrypick-4.3 in the original PR #1603

Godot Sandbox and godot-sqlite are among the known extensions needing this for Web export to function