### PR TITLE
Don't print an error when decoding a null Ref<T>

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -230,7 +230,9 @@ template <typename T>
 struct PtrToArg<Ref<T>> {
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 		GDExtensionRefPtr ref = (GDExtensionRefPtr)p_ptr;
-		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
+		if (unlikely(!p_ptr)) {
+			return Ref<T>();
+		}
 		return Ref<T>(reinterpret_cast<T *>(godot::internal::get_object_instance_binding(godot::internal::gdextension_interface_ref_get_object(ref))));
 	}
 
@@ -254,7 +256,9 @@ struct PtrToArg<const Ref<T> &> {
 
 	_FORCE_INLINE_ static Ref<T> convert(const void *p_ptr) {
 		GDExtensionRefPtr ref = const_cast<GDExtensionRefPtr>(p_ptr);
-		ERR_FAIL_NULL_V(p_ptr, Ref<T>());
+		if (unlikely(!p_ptr)) {
+			return Ref<T>();
+		}
 		return Ref<T>(reinterpret_cast<T *>(godot::internal::get_object_instance_binding(godot::internal::gdextension_interface_ref_get_object(ref))));
 	}
 };


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1615

It's not an error to receive a null pointer for a `Ref<T>` - that's just how null reference values are encoded - so we shouldn't print an error message. This switches away from `ERR_FAIL_NULL_V()` to just a normal `if` statement.