### PR TITLE
Use namespace in defs.hpp

### DIFF
--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -35,6 +35,8 @@
 #include <cstdint>
 #include <cstring>
 
+namespace godot {
+
 #if !defined(GDE_EXPORT)
 #if defined(_WIN32)
 #define GDE_EXPORT __declspec(dllexport)
@@ -126,5 +128,11 @@ struct BuildIndexSequence : BuildIndexSequence<N - 1, N - 1, Is...> {};
 
 template <size_t... Is>
 struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
+
+} //namespace godot
+
+// To maintain compatibility an alias is defined outside the namespace.
+// Consider it deprecated.
+using real_t = godot::real_t;
 
 #endif // GODOT_DEFS_HPP


### PR DESCRIPTION
Code in `defs.hpp` is not in namespace `godot` and I don't see any reason for that. Fixing the namesapce has no effect to the other files in the library as they are already in it. From users' perspective they will need to add prefix `godot::` to `real_t`, `IndexSequence`, `BuildIndexSequence` if they don't use `using namespace godot;` (like me). This breaks the compatibility to the old versions but the impact should be small.