### PR TITLE
static inline is bad.  Generates too much code that the linker can't remove.

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -219,7 +219,7 @@ public:
 
 	// Used exclusively in the bindings to recreate the Ref Godot encapsulates in return values,
 	// without adding to the refcount.
-	inline static Ref<T> _gde_internal_constructor(Object *obj) {
+	static Ref<T> _gde_internal_constructor(Object *obj) {
 		Ref<T> r;
 		r.reference = (T *)obj;
 		return r;

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -77,7 +77,7 @@ protected:
 		GDExtensionObjectPtr owner;
 		RecreateInstance *next;
 	};
-	inline static RecreateInstance *recreate_instance = nullptr;
+	static RecreateInstance *recreate_instance;
 #endif
 
 	void _notification(int p_what) {}
@@ -408,7 +408,7 @@ private:
 // Don't use this for your classes, use GDCLASS() instead.
 #define GDEXTENSION_CLASS_ALIAS(m_class, m_alias_for, m_inherits) /******************************************************************************************************************/ \
 private:                                                                                                                                                                               \
-	inline static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;                                                                           \
+	static ::godot::internal::EngineClassRegistration<m_class> _gde_engine_class_registration_helper;                                                                                  \
 	void operator=(const m_class &p_rval) {}                                                                                                                                           \
 	friend class ::godot::ClassDB;                                                                                                                                                     \
 	friend class ::godot::Wrapped;                                                                                                                                                     \

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -42,6 +42,10 @@ namespace godot {
 thread_local const StringName *Wrapped::_constructing_extension_class_name = nullptr;
 thread_local const GDExtensionInstanceBindingCallbacks *Wrapped::_constructing_class_binding_callbacks = nullptr;
 
+#ifdef HOT_RELOAD_ENABLED
+Wrapped::RecreateInstance *Wrapped::recreate_instance = nullptr;
+#endif
+
 const StringName *Wrapped::_get_extension_class_name() {
 	return nullptr;
 }


### PR DESCRIPTION
Looking at the dissasembly of a gdextension library, there are way too many unused symbols and code included.  It's bloaty.   1.5MB library for a single gdextension class.  

Everyclass seems to include things like this:

![image](https://github.com/user-attachments/assets/121fa8bb-83f4-4778-b561-7b37a8bcf97b)

Engine class registrations, etc.  Even when no class in my extension used the base engine classes.  The culprit here is `inline statics` which cause a lot of bloat, and are all ultimately unused.  This seems also to be the case in godot main as well.

These cause symbols from every class in godot-cpp to be included in the final link, even if completely unused by the impl lib.  Reworking changes a basic gdextension shared library from being ~1.5MB to now ~200kB.