### PR TITLE
CMake: Align MSVC runtime (MD[d], MT) options to engine

### DIFF
--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -11,10 +11,8 @@ function( windows_options )
 
     option( GODOT_USE_STATIC_CPP "Link MinGW/MSVC C++ runtime libraries statically" ON )
 
-    # The below scons variables are controlled via toolchain files instead
-    # "mingw_prefix"    "MinGW prefix"
-    # "use_llvm"        "Use the LLVM compiler (MVSC or MinGW depending on the use_mingw flag)"
-    # "use_mingw"       "Use the MinGW compiler instead of MSVC - only effective on Windows"
+    option( GODOT_DEBUG_CRT "Compile with MSVC's debug CRT (/MDd)" OFF )
+
 endfunction()
 
 function( windows_generate TARGET_NAME )
@@ -23,10 +21,13 @@ function( windows_generate TARGET_NAME )
     set( NOT_MSVC "$<NOT:${IS_MSVC}>" )
     set( STATIC_CPP "$<BOOL:${GODOT_USE_STATIC_CPP}>")
     set( DISABLE_EXCEPTIONS "$<BOOL:${GODOT_DISABLE_EXCEPTIONS}>")
+    set( DEBUG_CRT "$<BOOL:${GODOT_DEBUG_CRT}>" )
 
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
             PDB_OUTPUT_DIRECTORY "$<1:${CMAKE_SOURCE_DIR}/bin>"
+            INTERFACE_MSVC_RUNTIME_LIBRARY
+                "$<IF:${DEBUG_CRT},MultiThreadedDebugDLL,$<IF:${STATIC_CPP},MultiThreaded,MultiThreadedDLL>>"
     )
 
     target_compile_definitions( ${TARGET_NAME}
@@ -38,12 +39,6 @@ function( windows_generate TARGET_NAME )
             >
     )
 
-    target_compile_options( ${TARGET_NAME}
-        PUBLIC
-            $<${IS_MSVC}:
-                $<IF:${STATIC_CPP},/MT,/MD>$<${IS_DEV}:d> # Link microsoft runtime
-            >
-    )
     target_link_options( ${TARGET_NAME}
             PUBLIC
 


### PR DESCRIPTION
SCons does not link to /MDd or /MTd
If needed in the future a flag can be introduced like the engine code at platforms/windows/detect.py:459

This solves issue #1459 