### PR TITLE
CMake: Handle GODOT_DEV_BUILD flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,12 @@ CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE which was introduced in version 3.17
 Scons Compatibility
 -------------------
 
+There is an understandable conflict between build systems as they define
+similar concepts in different ways. When there isn't a 1:1 relationship,
+compromises need to be made to resolve those differences.
+
 As we are attempting to maintain feature parity, and ease of maintenance, these
-CMake scripts are built to resemble the SCons build system.
+CMake scripts are built to resemble the SCons build system wherever possible.
 
 The file structure and file content are made to match, if not in content then
 in spirit. The closer the two build systems look the easier they will be to
@@ -30,57 +34,11 @@ function is run.
     cpp_tool = Tool("godotcpp", toolpath=["tools"])
     cpp_tool.options(opts, env)
 
-
 The CMake equivalent is below.
 ]=======================================================================]
 
 include( cmake/godotcpp.cmake )
 godotcpp_options()
-
-#[=======================================================================[.rst:
-
-Configurations
---------------
-
-There are two build main configurations, 'Debug' and 'Release', these are not
-related to godot's DEBUG_FEATURES flag. Build configurations change the default
-compiler and linker flags present when building the library, things like debug
-symbols, optimization.
-
-The Scons build scripts don't have this concept, you can think of it like the
-SCons solution has a single default configuration. In both cases overriding the
-defaults is controlled by options on the command line, or in preset files.
-
-Because of this added configuration and that it can be undefined, it becomes
-important to set a default, considering the SCons solution that does not enable
-debug symbols by default, it seemed appropriate to set the default to 'Release'
-if unspecified. This can always be overridden like below.
-
-.. highlight:: shell
-
-    cmake <source> -DCMAKE_BUILD_TYPE:STRING=Debug
-
-.. caution::
-
-A complication arises from `Multi-Config Generators`_ that cannot have
-their configuration set at configure time. This means that the configuration
-must be set on the build command. This is especially important for Visual
-Studio Generators which default to 'Debug'
-
-.. highlight:: shell
-
-    cmake --build . --config Release
-
-.. _Multi-Config Generators:https://cmake.org/cmake/help/latest/prop_gbl/GENERATOR_IS_MULTI_CONFIG.html
-]=======================================================================]
-get_property( IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
-if( NOT IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE )
-    if( GODOT_DEV_BUILD )
-        set( CMAKE_BUILD_TYPE Debug )
-    else ()
-        set( CMAKE_BUILD_TYPE Release )
-    endif ()
-endif ()
 
 #[[ Python is required for code generation ]]
 find_package(Python3 3.4 REQUIRED) # pathlib should be present

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -59,11 +59,7 @@ endfunction()
 
 #[===========================[ Target Generation ]===========================]
 function( windows_generate TARGET_NAME )
-    set( IS_MSVC "$<CXX_COMPILER_ID:MSVC>" )
-    set( IS_CLANG "$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>" )
-    set( NOT_MSVC "$<NOT:${IS_MSVC}>" )
     set( STATIC_CPP "$<BOOL:${GODOT_USE_STATIC_CPP}>")
-    set( DISABLE_EXCEPTIONS "$<BOOL:${GODOT_DISABLE_EXCEPTIONS}>")
     set( DEBUG_CRT "$<BOOL:${GODOT_DEBUG_CRT}>" )
 
     set_target_properties( ${TARGET_NAME}

--- a/doc/cmake.rst
+++ b/doc/cmake.rst
@@ -24,6 +24,20 @@ Configuration examples are listed at the bottom of the page.
 
 .. _godot-cpp-template: https://github.com/godotengine/godot-cpp-template
 
+SCons Deviations
+----------------
+
+Not everything from SCons can be perfectly representable in CMake, here are
+the notable differences.
+
+- debug_symbols
+    No longer has an explicit option, and is enabled via Debug-like CMake
+    build configurations; Debug, RelWithDebInfo.
+
+- dev_build
+    Does not define NDEBUG when disabled, NDEBUG is set via Release-like
+    CMake build configurations; Release, MinSizeRel.
+
 Basic walkthrough
 -----------------
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ get_target_property( GODOT_TARGET godot-cpp::${TEST_TARGET} GODOT_TARGET )
 get_target_property( GODOT_ARCH godot-cpp::${TEST_TARGET} GODOT_ARCH )
 
 set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
+set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
 
 set_target_properties( godot-cpp-test
         PROPERTIES
@@ -45,7 +46,7 @@ set_target_properties( godot-cpp-test
         PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
 
         PREFIX "lib"
-        OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}.${GODOT_ARCH}"
+        OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
 )
 
 if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
@@ -58,7 +59,7 @@ if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
             LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
             RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
 
-            OUTPUT_NAME "gdexample.macos.${TEST_TARGET}"
+            OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}"
             SUFFIX ""
 
             #macos options


### PR DESCRIPTION
When SCons has dev_build=yes enabled, there is a "dev" feature flag added to the compile artifact.
it enables debug_symbols unless otherwise specified
It changes the debug symbol generation
it sets the optimisation level to none
It sets DEV_ENABLED mutually exclusive to NDEBUG

Representing how dev_build and debug_symbols interact in CMake was harder than anticipated, I think I have struck a good balance.

debug_symbols will not be an option in CMake.
The generation of debug symbols is controlled by the build configuration. This is how it normally works in CMake and is the closest match to what the option means in SCons. For single configuration generators this is expressed by adding `-DCMAKE_BUILD_TYPE=Debug` or `RelWithDebInfo` which will generate debug symbols as expected by all software interacting with a cmake build system. And for multi-config generators adding `--config=Debug` or `RelWithDebInfo` to the build command. In both cases Debug is the default if not specified.

How this interacts with GODOT_DEV_BUILD
GODOT_DEV_BUILD does not enable debug genaration, but it will change the debug level
DEV_ENABLED will not be mutually exclusive with NDEBUG. A warning is presented if single config generator has both `CMAKE_BUILD_TYPE=Release` and `GODOT_DEV_BUILD`. For multi-config generators there is no way to warn for this exact mix, but they would both have to be set explicitly by the consumer.
Optimisation levels are not yet implemented.

I have updated documentation to descrive the deviations to SCons
Tidied existing debug flag handling that is now redundant
And tidied the helper variables and comments

Before I mark as ready for review I want to go over the documentation and comment strings at least once more. And perform a build option comparison on all three host platforms for all target platforms available to me.

Reminder, that Single-Config generators are Makefiles, Ninja, and Multi-Config generators are VisualStudio, XCode, 'Ninja Multi-Config'

SCons to CMake equivalency

debug_symbols=yes
 - SCons : `scons target=template_debug debug_symbols=yes`
 - CMake Single-Config gen : `cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build .`
 - CMake Multi-Config gen `cmake ../ && cmake --build . --config RelWithDebInfo`

dev_build=yes (automatically adds debug_symbols=yes)
 - SCons : `scons target=template_debug dev_build=yes`
 - CMake Single-Config gen : `cmake ../ -DGODOT_DEV_BUILD=YES -DCMAKE_BUILD_TYPE=Debug && cmake --build .`
 - CMake Multi-Config gen `cmake ../ -DGODOT_DEV_BUILD=YES && cmake --build . --config Debug`

dev_build=yes debug_symbols=no
 - SCons : `scons target=template_debug dev_build=yes debug_symbols=no`
 - CMake Single-Config gen : `cmake ../ -DGODOT_DEV_BUILD=YES -DCMAKE_BUILD_TYPE=Release && cmake --build .`
 - CMake Multi-Config gen `cmake ../ -DGODOT_DEV_BUILD=YES && cmake --build . --config Release`


Comparison Spreadsheet, sub sheets contain so far MSVC, Msys, and MacOS.
 - [google-sheet](https://docs.google.com/spreadsheets/d/1MG3eTeI7X8Zggl5lE6DHVURaQ6YWIBIOu6xDGTCh794/edit?usp=sharing)