### PR TITLE
CMake: fix break for build prior to modernisation PR

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -293,4 +293,8 @@ function( godotcpp_generate )
 
     endforeach ()
 
+    # Added for backwards compatibility with prior cmake solution so that builds dont immediately break
+    # from a missing target.
+    add_library( godot::cpp ALIAS template_debug )
+
 endfunction()


### PR DESCRIPTION
While reviewing tutorials and discussing with users, I thought of a way to mitigate breaking changes to cmake solution.
By re-adding the godot::cpp target alias as a template_debug lib it will solve a great deal of pain from users migrating.