### PR TITLE
Added options to enable/disable targets to be added to a cmake build.

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -173,6 +173,28 @@ function(godotcpp_options)
 
     # Enable Testing
     option(GODOTCPP_ENABLE_TESTING "Enable the godot-cpp.test.<target> integration testing targets" OFF)
+    # Define which targets create for build. By default all targets are included
+    # Not presented in SCons
+    option(GODOTCPP_ADD_TARGET_TEMPLATE_RELEASE "Add template_release target to build" ON)
+    option(GODOTCPP_ADD_TARGET_TEMPLATE_DEBUG "Add template_debug target to build" ON)
+    option(GODOTCPP_ADD_TARGET_EDITOR "Add editor target to build" ON)
+    if(GODOTCPP_ADD_TARGET_TEMPLATE_DEBUG)
+        list(APPEND GODOTCPP_TARGETS "template_debug")
+    endif()
+    if(GODOTCPP_ADD_TARGET_TEMPLATE_RELEASE)
+        list(APPEND GODOTCPP_TARGETS "template_release")
+    endif()
+    if(GODOTCPP_ADD_TARGET_EDITOR)
+        list(APPEND GODOTCPP_TARGETS "editor")
+    endif()
+    if(NOT GODOTCPP_TARGETS)
+        message(
+            FATAL_ERROR
+            "No targets were chosen to be build.See GODOTCPP_ADD_TARGET_* variables: at least one of the should be ON"
+        )
+    endif()
+    # parent scoping GODOTCPP_TARGETS
+    set(GODOTCPP_TARGETS ${GODOTCPP_TARGETS} PARENT_SCOPE)
 
     #[[ Target Platform Options ]]
     android_options()
@@ -310,7 +332,7 @@ function(godotcpp_generate)
     set(IS_DEV_BUILD "$<BOOL:${GODOTCPP_DEV_BUILD}>")
 
     ### Define our godot-cpp library targets
-    foreach(TARGET_ALIAS template_debug template_release editor)
+    foreach(TARGET_ALIAS ${GODOTCPP_TARGETS})
         set(TARGET_NAME "godot-cpp.${TARGET_ALIAS}")
 
         # Generator Expressions that rely on the target

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ message(STATUS "Testing Integration targets are enabled.")
 # Generate Doc Data
 file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
 
-foreach(TARGET_ALIAS template_debug template_release editor)
+foreach(TARGET_ALIAS ${GODOTCPP_TARGETS})
     set(TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}")
 
     add_library(${TARGET_NAME} SHARED EXCLUDE_FROM_ALL)


### PR DESCRIPTION
In CMake build system all of the targets were added to build (solution for Visual Studio), which might case confusion 
and unnecessary additional build time. 
I have added following options to CMake:
- `GODOT_ADD_TARGET_TEMPLATE_RELEASE` - for target template_release
- `GODOT_ADD_TARGET_TEMPLATE_DEBUG` - for target template_debug 
- `GODOT_ADD_TARGET_EDITOR` - for target editor
These options are all `ON` by default to preserve the same default behavior as prior their addition. By turning options `OFF` correlating targets will be excluded from build. If all options are `OFF` CMake will rise an error during configuration phase.

Additionally to make sure that 'Test' target dependency stays valid, the following logic was added. If dependency gets turned off by corresponding `GODOT_ADD_TARGET_*`, then the dependency is switched to next target in following order `template_debug` -> `template_release` ->`editor`.

Also separate flag `GODOT_CPP_USE_TEST` with default value ON was added to have an ability to turn off testing as well.

These changes can be further supported in [Fix break prior modernization PR](https://github.com/godotengine/godot-cpp/pull/1649) by adding `${GODOT_DEFAULT_TARGET}` ALIAS instead of hardcoded `template_debug` after both PRs are merged. Even without the change default behavior of CMake build should stay the same as it was before
