### PR TITLE
CMake: Enable using clang-cl on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ project( godot-cpp
         HOMEPAGE_URL "https://github.com/godotengine/godot-cpp"
         LANGUAGES CXX)
 
+compiler_detection()
 godotcpp_generate()
 
 # Test Example


### PR DESCRIPTION
As listed here: #1250
clang-cl on windows installed from official llvm website fails because it emulates the msvc interface.

Prior solution assumed that because compiler is clang it uses gnu interface.

CMake offers some helper variables to account for this simulation/emulation of other compilers like:
CMAKE_CXX_COMPILER_FRONTEND_VARIANT

This PR detects the difference and sets the helper variables to match what is in use.
It isn't robust enough to mix and match compiler and linker interfaces though, so using a gnu style linker with an msvc style compiler will fail.

I've tested this on windows and mac, with windows based compilers msvc, msys-gcc msys-clang, llvm, mingw64, without issue.

Fixes https://github.com/godotengine/godot-cpp/issues/1250