### PR TITLE
Add `print_line` for compatibility with engine modules

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -37,6 +37,7 @@
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/method_bind.hpp>
 #include <godot_cpp/core/object.hpp>
+#include <godot_cpp/core/print_string.hpp>
 
 #include <godot_cpp/classes/class_db_singleton.hpp>
 

--- a/include/godot_cpp/core/print_string.hpp
+++ b/include/godot_cpp/core/print_string.hpp
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  print_string.hpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GODOT_PRINT_STRING_HPP
+#define GODOT_PRINT_STRING_HPP
+
+#include <godot_cpp/variant/utility_functions.hpp>
+
+namespace godot {
+inline void print_error(const Variant &p_variant) {
+	UtilityFunctions::printerr(p_variant);
+}
+
+inline void print_line(const Variant &p_variant) {
+	UtilityFunctions::print(p_variant);
+}
+
+inline void print_line_rich(const Variant &p_variant) {
+	UtilityFunctions::print_rich(p_variant);
+}
+
+template <typename... Args>
+void print_error(const Variant &p_variant, Args... p_args) {
+	UtilityFunctions::printerr(p_variant, p_args...);
+}
+
+template <typename... Args>
+void print_line(const Variant &p_variant, Args... p_args) {
+	UtilityFunctions::print(p_variant, p_args...);
+}
+
+template <typename... Args>
+void print_line_rich(const Variant &p_variant, Args... p_args) {
+	UtilityFunctions::print_rich(p_variant, p_args...);
+}
+
+bool is_print_verbose_enabled();
+
+// Checking the condition before evaluating the text to be printed avoids processing unless it actually has to be printed, saving some CPU usage.
+#define print_verbose(m_variant)          \
+	{                                     \
+		if (is_print_verbose_enabled()) { \
+			print_line(m_variant);        \
+		}                                 \
+	}
+} // namespace godot
+
+#endif // GODOT_PRINT_STRING_HPP

--- a/src/core/print_string.cpp
+++ b/src/core/print_string.cpp
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  print_string.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include <godot_cpp/core/print_string.hpp>
+
+#include <godot_cpp/classes/os.hpp>
+
+namespace godot {
+bool is_print_verbose_enabled() {
+	return OS::get_singleton()->is_stdout_verbose();
+}
+} // namespace godot


### PR DESCRIPTION
Fixes #1596. This PR adds most of the function signatures from the engine's `print_string.h` and places them in a file called `print_string.hpp`. The implementation from the engine is not copied, instead these wrap around the functions in `UtilityFunctions`. Personally I only need the non-vararg `print_line` but I've included the rest for parity.

`print_string.hpp` is included in `class_db.hpp` just like in the engine's `class_db.h`, which means these functions are available for anywhere that includes `class_db.hpp`. For the verbose function, I had to put the OS call into a separate file since `os.hpp` depends on `class_db.hpp` so there was a circular dependency if I did not. Also, the templates need to exist in the header, so I kept them and most of the functions in the header for simplicity.

Reference: https://github.com/godotengine/godot/blob/master/core/string/print_string.h