### PR TITLE
Add a separate setup-godot-cpp github action.

### DIFF
--- a/.github/actions/setup-godot-cpp/action.yml
+++ b/.github/actions/setup-godot-cpp/action.yml
@@ -1,0 +1,62 @@
+name: Setup godot-cpp
+description: Setup build dependencies for godot-cpp.
+
+inputs:
+  platform:
+    required: true
+    description: Target platform.
+  em-version:
+    default: 3.1.62
+    description: Emscripten version.
+  windows-compiler:
+    required: true
+    description: The compiler toolchain to use on Windows ('mingw' or 'msvc').
+    type: choice
+    options:
+      - mingw
+      - msvc
+    default: mingw
+  mingw-version:
+    default: 12.2.0
+    description: MinGW version.
+  ndk-version:
+    default: r23c
+    description: Android NDK version.
+  scons-version:
+    default: 4.4.0
+    description: SCons version.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Python (for SCons)
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - name: Setup Android dependencies
+      if: inputs.platform == 'android'
+      uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: ${{ inputs.ndk-version }}
+        link-to-sdk: true
+
+    - name: Setup Web dependencies
+      if: inputs.platform == 'web'
+      uses: mymindstorm/setup-emsdk@v14
+      with:
+        version: ${{ inputs.em-version }}
+        no-cache: true
+
+    - name: Setup MinGW for Windows/MinGW build
+      if: inputs.platform == 'windows' && inputs.windows-compiler == 'mingw'
+      uses: egor-tensin/setup-mingw@v2
+      with:
+        version: ${{ inputs.mingw-version }}
+
+    - name: Setup SCons
+      shell: bash
+      run: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install scons==${{ inputs.scons-version }}
+        scons --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,34 +108,11 @@ jobs:
           cache-name: ${{ matrix.cache-name }}
         continue-on-error: true
 
-      - name: Set up Python (for SCons)
-        uses: actions/setup-python@v5
+      - name: Setup godot-cpp
+        uses: ./.github/actions/setup-godot-cpp
         with:
-          python-version: 3.x
-
-      - name: Android dependencies
-        if: matrix.platform == 'android'
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r23c
-          link-to-sdk: true
-
-      - name: Web dependencies
-        if: matrix.platform == 'web'
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: ${{ env.EM_VERSION }}
-          no-cache: true
-
-      - name: Setup MinGW for Windows/MinGW build
-        if: matrix.platform == 'windows' && matrix.flags == 'use_mingw=yes'
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          version: 12.2.0
-
-      - name: Install scons
-        run: |
-          python -m pip install scons==4.0.0
+          platform: ${{ matrix.platform }}
+          windows-compiler: ${{ contains(matrix.flags, 'use_mingw=yes') && 'mingw' || 'msvc' }}
 
       - name: Generate godot-cpp sources only
         run: |


### PR DESCRIPTION
As discussed in the godot-cpp meeting. This action is specifically intended to be used by dependants of godot-cpp, to set up godot-cpp in their own github workflows. A follow-up PR will use this github action in godot-cpp-template (edit: https://github.com/godotengine/godot-cpp-template/pull/70).

There are quite a few differences to godot-cpp-template's setup steps. I don't know if they started the same but diverged later, or if godot-cpp-template has always made different decisions from godot-cpp itself. Here is [godot-cpp-template's version](https://github.com/godotengine/godot-cpp-template/blob/main/.github/actions/build/action.yml#L34-L99) for reference. 

I based my implementation mostly on godot-cpp. Here are the key differences I see:
- `actions/setup-java@v4` and `android-actions/setup-android@v3` are used on godot-cpp-template, while `nttld/setup-ndk@v1` is used on godot-cpp.
    - godot-cpp-template also manually edits a bunch of variable files to get android set up.
- emsdk caches are used by `godot-cpp-template`, while they are explicitly disabled on `godot-cpp`. This was recently decided in #1639 and should not be reverted.
- godot-cpp-template installs `build-essential pkg-config` on linux. godot-cpp only installs these dependencies for the cmake build. I conclude they may not be needed for scons builds.

I _think_ that's all of the differences, though the github runner shall smite my PR if it's not compatible anymore.