### PR TITLE
CMake: Alleviate target name clashes, visibility, and grouping.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,8 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake ../ -DTEST_TARGET=template_release
-          cmake --build . --verbose -j $(nproc) -t godot-cpp-test --config Release
+          cmake ../ -DGODOT_ENABLE_TESTING=YES
+          cmake --build . --verbose -j $(nproc) -t godot-cpp.test.template_release --config Release
 
   windows-msvc-cmake:
     name: 🏁 Build (Windows, MSVC, CMake)
@@ -218,5 +218,5 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake ../ -DTEST_TARGET=template_release
-          cmake --build . --verbose -t godot-cpp-test --config Release
+          cmake ../ -DGODOT_ENABLE_TESTING=YES
+          cmake --build . --verbose -t godot-cpp.test.template_release --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ The CMake equivalent is below.
 ]=======================================================================]
 
 include( cmake/godotcpp.cmake )
+
 godotcpp_options()
 
 #[[ Python is required for code generation ]]
@@ -53,5 +54,12 @@ project( godot-cpp
 compiler_detection()
 godotcpp_generate()
 
-# Test Example
-add_subdirectory( test )
+# Conditionally enable the godot-cpp.test.<target> integration testing targets
+if( GODOT_ENABLE_TESTING )
+    add_subdirectory( test )
+endif()
+
+# If this is the top level CMakeLists.txt, Generators which honor the
+# USE_FOLDERS flag will organize godot-cpp targets under the subfolder
+# 'godot-cpp'. This is enable by default from CMake version 3.26
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/cmake/android.cmake
+++ b/cmake/android.cmake
@@ -29,13 +29,12 @@ function( android_options )
     # Android Options
 endfunction()
 
-function( android_generate TARGET_NAME )
-
+function( android_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             ANDROID_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -44,7 +44,7 @@ function( compiler_detection )
     endif ()
 endfunction(  )
 
-function( common_compiler_flags TARGET_NAME )
+function( common_compiler_flags )
 
     target_compile_features(${TARGET_NAME}
             PUBLIC

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -142,6 +142,9 @@ function( godotcpp_options )
     option( GODOT_SYSTEM_HEADERS "Expose headers as SYSTEM." OFF )
     option( GODOT_WARNING_AS_ERROR "Treat warnings as errors" OFF )
 
+    # Enable Testing
+    option( GODOT_ENABLE_TESTING "Enable the godot-cpp.test.<target> integration testing targets" OFF )
+
     #[[ Target Platform Options ]]
     android_options()
     ios_options()
@@ -228,7 +231,7 @@ function( godotcpp_generate )
     ### Platform is derived from the toolchain target
     # See GeneratorExpressions PLATFORM_ID and CMAKE_SYSTEM_NAME
     set( SYSTEM_NAME
-            $<$<PLATFORM_ID:Android>:android.${ANDROID_ABI}>
+            $<$<PLATFORM_ID:Android>:android>
             $<$<PLATFORM_ID:iOS>:ios>
             $<$<PLATFORM_ID:Linux>:linux>
             $<$<PLATFORM_ID:Darwin>:macos>
@@ -263,7 +266,8 @@ function( godotcpp_generate )
     set( DEV_TAG "$<${IS_DEV_BUILD}:.dev>" )
 
     ### Define our godot-cpp library targets
-    foreach ( TARGET_NAME template_debug template_release editor )
+    foreach ( TARGET_ALIAS template_debug template_release editor )
+        set( TARGET_NAME "godot-cpp.${TARGET_ALIAS}" )
 
         # Generator Expressions that rely on the target
         set( DEBUG_FEATURES "$<NOT:$<STREQUAL:${TARGET_NAME},template_release>>" )
@@ -271,7 +275,7 @@ function( godotcpp_generate )
 
         # the godot-cpp.* library targets
         add_library( ${TARGET_NAME} STATIC EXCLUDE_FROM_ALL )
-        add_library( godot-cpp::${TARGET_NAME} ALIAS ${TARGET_NAME} )
+        add_library( godot-cpp::${TARGET_ALIAS} ALIAS ${TARGET_NAME} )
 
         file( GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp )
 
@@ -298,33 +302,36 @@ function( godotcpp_generate )
                 BUILD_RPATH_USE_ORIGIN ON
 
                 PREFIX lib
-                OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_NAME}${DEV_TAG}.${SYSTEM_ARCH}"
+                OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_ALIAS}${DEV_TAG}.${SYSTEM_ARCH}"
                 ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/bin>"
 
                 # Things that are handy to know for dependent targets
                 GODOT_PLATFORM "${SYSTEM_NAME}"
-                GODOT_TARGET "${TARGET_NAME}"
+                GODOT_TARGET "${TARGET_ALIAS}"
                 GODOT_ARCH "${SYSTEM_ARCH}"
+
+                # Some IDE's respect this property to logically group targets
+                FOLDER "godot-cpp"
         )
 
         if( CMAKE_SYSTEM_NAME STREQUAL Android )
-            android_generate( ${TARGET_NAME} )
+            android_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL iOS )
-            ios_generate( ${TARGET_NAME} )
+            ios_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Linux )
-            linux_generate( ${TARGET_NAME} )
+            linux_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-            macos_generate( ${TARGET_NAME} )
+            macos_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Emscripten )
-            web_generate( ${TARGET_NAME} )
+            web_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Windows )
-            windows_generate( ${TARGET_NAME} )
+            windows_generate()
         endif ()
 
     endforeach ()
 
     # Added for backwards compatibility with prior cmake solution so that builds dont immediately break
     # from a missing target.
-    add_library( godot::cpp ALIAS template_debug )
+    add_library( godot::cpp ALIAS godot-cpp.template_debug )
 
 endfunction()

--- a/cmake/ios.cmake
+++ b/cmake/ios.cmake
@@ -10,13 +10,12 @@ function(ios_options)
     # iOS options
 endfunction()
 
-function(ios_generate TARGET_NAME)
-
+function(ios_generate)
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             IOS_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags(${TARGET_NAME})
+    common_compiler_flags()
 endfunction()

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -10,13 +10,12 @@ function( linux_options )
     # Linux Options
 endfunction()
 
-function( linux_generate TARGET_NAME )
-
+function( linux_generate )
     target_compile_definitions( ${TARGET_NAME}
             PUBLIC
             LINUX_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -23,7 +23,7 @@ function( macos_options )
 endfunction()
 
 
-function( macos_generate TARGET_NAME )
+function( macos_generate )
 
     # OSX_ARCHITECTURES does not support generator expressions.
     if( NOT GODOT_ARCH OR GODOT_ARCH STREQUAL universal )
@@ -55,5 +55,5 @@ function( macos_generate TARGET_NAME )
             ${COCOA_LIBRARY}
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -15,8 +15,7 @@ function( web_options )
 endfunction()
 
 
-function( web_generate TARGET_NAME )
-
+function( web_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             WEB_ENABLED
@@ -38,5 +37,5 @@ function( web_generate TARGET_NAME )
             -shared
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -58,7 +58,7 @@ function( windows_options )
 endfunction()
 
 #[===========================[ Target Generation ]===========================]
-function( windows_generate TARGET_NAME )
+function( windows_generate )
     set( STATIC_CPP "$<BOOL:${GODOT_USE_STATIC_CPP}>")
     set( DEBUG_CRT "$<BOOL:${GODOT_DEBUG_CRT}>" )
 
@@ -96,5 +96,5 @@ function( windows_generate TARGET_NAME )
             $<${IS_CLANG}:-lstdc++>
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,68 +1,81 @@
-# Testing Extension
-# This is only linked to the template_release config.
-# so it requires the template_release version of godot to run.
+#[=======================================================================[.rst:
+Integration Testing
+-------------------
 
-add_library( godot-cpp-test SHARED EXCLUDE_FROM_ALL )
+The Test target used to validate changes in the GitHub CI.
 
-target_sources( godot-cpp-test
-        PRIVATE
-        src/example.cpp
-        src/example.h
-        src/register_types.cpp
-        src/register_types.h
-        src/tests.h
-)
+]=======================================================================]
 
-set( TEST_TARGET "template_debug" CACHE STRING "Which godot-cpp::target to link against" )
-set_property( CACHE TEST_TARGET PROPERTY STRINGS "template_debug;template_release;editor" )
+message( STATUS "Testing Integration targets are enabled.")
 
-target_link_libraries( godot-cpp-test
-        PRIVATE
-        godot-cpp::${TEST_TARGET} )
+foreach( TARGET_ALIAS template_debug template_release editor )
+    set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
+    set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )
 
-### Get useful properties of the library
-get_target_property( GODOT_PLATFORM godot-cpp::${TEST_TARGET} GODOT_PLATFORM )
-get_target_property( GODOT_TARGET godot-cpp::${TEST_TARGET} GODOT_TARGET )
-get_target_property( GODOT_ARCH godot-cpp::${TEST_TARGET} GODOT_ARCH )
+    add_library( ${TARGET_NAME} SHARED EXCLUDE_FROM_ALL )
 
-set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
+    target_sources( ${TARGET_NAME}
+            PRIVATE
+            src/example.cpp
+            src/example.h
+            src/register_types.cpp
+            src/register_types.h
+            src/tests.h
+    )
 
-set_target_properties( godot-cpp-test
-        PROPERTIES
-        CXX_STANDARD 17
-        CXX_EXTENSIONS OFF
-        CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
+    target_link_libraries( ${TARGET_NAME} PRIVATE ${LINK_TARGET} )
 
-        POSITION_INDEPENDENT_CODE ON
-        BUILD_RPATH_USE_ORIGIN ON
-        LINK_SEARCH_START_STATIC ON
-        LINK_SEARCH_END_STATIC ON
+    ### Get useful properties of the library
+    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
+    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
+    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
 
-        # NOTE: Wrapping the output variables inside a generator expression
-        # prevents msvc generator from adding addition Config Directories
-        LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-        RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-        PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
+    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
+    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
 
-        PREFIX "lib"
-        OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
-)
-
-if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-    get_target_property( OSX_ARCH godot-cpp::${TEST_TARGET} OSX_ARCHITECTURES )
-
-    set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
-
-    set_target_properties( godot-cpp-test
+    set_target_properties( ${TARGET_NAME}
             PROPERTIES
+            CXX_STANDARD 17
+            CXX_EXTENSIONS OFF
+            CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
+
+            POSITION_INDEPENDENT_CODE ON
+            BUILD_RPATH_USE_ORIGIN ON
+
+            # Try to ensure only static libraries are selected to be linked to.
+            LINK_SEARCH_START_STATIC ON
+            LINK_SEARCH_END_STATIC ON
+
+            # NOTE: Wrapping the output variables inside a generator expression
+            # prevents msvc generator from adding addition Config Directories
             LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
             RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+            PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
 
-            OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}"
-            SUFFIX ""
+            PREFIX "lib"
+            OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
 
-            #macos options
-            OSX_ARCHITECTURES "${OSX_ARCH}"
+            # Some IDE's respect this property to logically group targets
+            FOLDER "godot-cpp"
     )
-endif ()
+
+    # CMAKE_SYSTEM_NAME refers to the target system
+    if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
+        get_target_property( OSX_ARCH ${LINK_TARGET} OSX_ARCHITECTURES )
+
+        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
+
+        set_target_properties( ${TARGET_NAME}
+                PROPERTIES
+                LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+                RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+
+                OUTPUT_NAME "gdexample.macos.${TARGET_ALIAS}${DEV_TAG}"
+                SUFFIX ""
+
+                #macos options
+                OSX_ARCHITECTURES "${OSX_ARCH}"
+        )
+    endif ()
+
+endforeach()


### PR DESCRIPTION
This PR resolves CMake name clashes #1657, Partially resolves optionally disable targets #1650, and tidies IDE usage for VS and XCode by grouping targets under a subfolder.

* Rename CMake internal targets from <target>  to godot-cpp.<target>, Aliases will remain godot-cpp::<target>
* Simplify <platform>_generate cmake function signature, as TARGET_ALIAS and TARGET_NAME are still in scope and do not need to be passed.
* Add `GODOT_ENABLE_TESTING` option default OFF, and guard `add_subdirectory( test )` by default
* Add global property `USE_FOLDERS ON` and target property `FOLDER "godot-cpp"` to group targets in VS and XCode