### PR TITLE
CMake: transitive target properties, macos rpath handling

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -264,8 +264,12 @@ function( godotcpp_generate )
                 CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
                 COMPILE_WARNING_AS_ERROR ${GODOT_WARNING_AS_ERROR}
+
                 POSITION_INDEPENDENT_CODE ON
-                BUILD_RPATH_USE_ORIGIN ON
+                INTERFACE_POSITION_INDEPENDENT_CODE ON
+
+                # Tell the linker to add the $ORIGIN relative location at build time
+                INTERFACE_BUILD_RPATH_USE_ORIGIN ON
 
                 PREFIX lib
                 OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_NAME}.${SYSTEM_ARCH}"

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -35,8 +35,13 @@ function( macos_generate TARGET_NAME )
 
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
+            # enable RPATH on MACOS, with the BUILD_RPATH_USE_ORIGIN
+            # this should allow loading libraries from relative paths on macos.
+            INTERFACE_MACOSX_RPATH ON
 
+            # Specify multiple architectures for universal builds
             OSX_ARCHITECTURES "${OSX_ARCH}"
+            INTERFACE_OSX_ARCHITECTURES "${OSX_ARCH}"
     )
 
     target_compile_definitions(${TARGET_NAME}

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -22,12 +22,15 @@ function( windows_generate TARGET_NAME )
     set( STATIC_CPP "$<BOOL:${GODOT_USE_STATIC_CPP}>")
     set( DISABLE_EXCEPTIONS "$<BOOL:${GODOT_DISABLE_EXCEPTIONS}>")
     set( DEBUG_CRT "$<BOOL:${GODOT_DEBUG_CRT}>" )
+    set( MSVC_RUNTIME "$<IF:${DEBUG_CRT},MultiThreadedDebugDLL,$<IF:${STATIC_CPP},MultiThreaded,MultiThreadedDLL>>" )
 
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
             PDB_OUTPUT_DIRECTORY "$<1:${CMAKE_SOURCE_DIR}/bin>"
-            INTERFACE_MSVC_RUNTIME_LIBRARY
-                "$<IF:${DEBUG_CRT},MultiThreadedDebugDLL,$<IF:${STATIC_CPP},MultiThreaded,MultiThreadedDLL>>"
+
+            # set msvc runtime to link against and for our consumers
+            MSVC_RUNTIME_LIBRARY "${MSVC_RUNTIME}"
+            INTERFACE_MSVC_RUNTIME_LIBRARY "${MSVC_RUNTIME}"
     )
 
     target_compile_definitions( ${TARGET_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,8 +33,6 @@ set_target_properties( godot-cpp-test
         CXX_EXTENSIONS OFF
         CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
-        POSITION_INDEPENDENT_CODE ON
-        BUILD_RPATH_USE_ORIGIN ON
         LINK_SEARCH_START_STATIC ON
         LINK_SEARCH_END_STATIC ON
 
@@ -49,8 +47,6 @@ set_target_properties( godot-cpp-test
 )
 
 if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-    get_target_property( OSX_ARCH godot-cpp::${TEST_TARGET} OSX_ARCHITECTURES )
-
     set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
 
     set_target_properties( godot-cpp-test
@@ -60,8 +56,5 @@ if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
 
             OUTPUT_NAME "gdexample.macos.${TEST_TARGET}"
             SUFFIX ""
-
-            #macos options
-            OSX_ARCHITECTURES "${OSX_ARCH}"
     )
 endif ()


### PR DESCRIPTION
While working on the debug MSVC runtime linking, I found the information on making target properties transitive.

prepending target properties with INTERFACE_ makes the property transitive to consumers.
add normal MSVC_RUNTIME_LIBRARY to windows properties
add INTERFACE_ to BUILD_RPATH_USE_ORIGIN
add INTERFACE_ to POSITION_INDEPENDENT_CODE
add INTERFACE_ to OSX_ARCHITECTURES
enable INTERFACE_MACOSX_RPATH for origin rpath on macos