### PR TITLE
CMake: Replace empty ${EXCLUDE} variable with EXCLUDE_FROM_ALL

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -240,7 +240,7 @@ function( godotcpp_generate )
         set( HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},$<NOT:${IS_RELEASE}>,$<BOOL:${GODOT_USE_HOT_RELOAD}>>" )
 
         # the godot-cpp.* library targets
-        add_library( ${TARGET_NAME} STATIC ${EXCLUDE} )
+        add_library( ${TARGET_NAME} STATIC EXCLUDE_FROM_ALL )
         add_library( godot-cpp::${TARGET_NAME} ALIAS ${TARGET_NAME} )
 
         file( GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp )


### PR DESCRIPTION
This was a mistake left over from the modernise PR

Left over from when I had a default target of template_debug, but it still wanted to build even if it was not depended on.
the targets should be excluded so that they dont all build all the time.