### PR TITLE
CMake: Fix selection of MSVC Runtime compile flags

### DIFF
--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -5,8 +5,50 @@ Windows
 This file contains functions for options and configuration for targeting the
 Windows platform
 
-]=======================================================================]
+MSVC Runtime Selection
+----------------------
 
+There are two main ways to set the msvc runtime library;
+Using ``target_compile_options()`` to add the flags
+or using the ``CMAKE_MSVC_RUNTIME_LIBRARY`` property_ abstraction, introduced
+in CMake version 3.15 with the policy CMP0091_ to remove the flags from
+``CMAKE_<LANG>_FLAGS_<CONFIG>``.
+
+Default: ``CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"``
+
+This initializes each target's ``MSVC_RUNTIME_LIBRARY`` property at the time of
+target creation.
+
+This creates a conundrum for us, the ``CMAKE_MSVC_RUNTIME_LIBRARY`` needs to be
+correct at the time the target is created, but we have no control over the
+consumers CMake scripts, and the per-target ``MSVC_RUNTIME_LIBRARY`` property
+is not transient.
+
+We need ``CMAKE_MSVC_RUNTIME_LIBRARY`` to be ``"$<1:>"`` to ensure it
+will not add any flags. And then use ``target_compile_options()`` so that our
+flags will propagate to consumers.
+
+In the interests of playing nicely we detect whether we are being consumed
+and notify the consumer that we are setting ``CMAKE_MSVC_RUNTIME_LIBRARY``,
+that dependent targets rely on it, and point them to these comments as to why.
+
+.. _CMP0091:https://cmake.org/cmake/help/latest/policy/CMP0091.html
+.. _property:https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
+.. https://discourse.cmake.org/t/mt-staticrelease-doesnt-match-value-md-dynamicrelease/5428/4
+
+]=======================================================================]
+if( PROJECT_NAME ) # we are not the top level if this is true
+    if( DEFINED CMAKE_MSVC_RUNTIME_LIBRARY )
+        # Warning that we are clobbering the variable.
+        message( WARNING "setting CMAKE_MSVC_RUNTIME_LIBRARY to \"$<1:>\"")
+    else(  )
+        # Notification that we are setting the variable
+        message( STATUS "setting CMAKE_MSVC_RUNTIME_LIBRARY to \"$<1:>\"")
+    endif()
+endif()
+set( CMAKE_MSVC_RUNTIME_LIBRARY "$<1:>" CACHE INTERNAL "Select the MSVC runtime library for use by compilers targeting the MSVC ABI." )
+
+#[============================[ Windows Options ]============================]
 function( windows_options )
 
     option( GODOT_USE_STATIC_CPP "Link MinGW/MSVC C++ runtime libraries statically" ON )
@@ -15,6 +57,7 @@ function( windows_options )
 
 endfunction()
 
+#[===========================[ Target Generation ]===========================]
 function( windows_generate TARGET_NAME )
     set( IS_MSVC "$<CXX_COMPILER_ID:MSVC>" )
     set( IS_CLANG "$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>" )
@@ -26,8 +69,6 @@ function( windows_generate TARGET_NAME )
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
             PDB_OUTPUT_DIRECTORY "$<1:${CMAKE_SOURCE_DIR}/bin>"
-            INTERFACE_MSVC_RUNTIME_LIBRARY
-                "$<IF:${DEBUG_CRT},MultiThreadedDebugDLL,$<IF:${STATIC_CPP},MultiThreaded,MultiThreadedDLL>>"
     )
 
     target_compile_definitions( ${TARGET_NAME}
@@ -37,6 +78,11 @@ function( windows_generate TARGET_NAME )
                 TYPED_METHOD_BIND
                 NOMINMAX
             >
+    )
+
+    target_compile_options( ${TARGET_NAME}
+        PUBLIC
+            $<${IS_MSVC}:$<IF:${DEBUG_CRT},/MDd,$<IF:${STATIC_CPP},/MT,/MD>>>
     )
 
     target_link_options( ${TARGET_NAME}


### PR DESCRIPTION
My last attempt at solving this was not correct, and I apologise for that.

MSVC Runtime Selection
----------------------

There are two main ways to set the msvc runtime library; Using ``target_compile_options()`` to add the flags _or_ using the ``CMAKE_MSVC_RUNTIME_LIBRARY`` property abstraction[^1], introduced in CMake version 3.15 with the policy CMP0091[^2] to
remove the flags from ``CMAKE_<LANG>_FLAGS_<CONFIG>``.

Default: ``CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"``

This initializes each target's ``MSVC_RUNTIME_LIBRARY`` property at the time of target creation.

This creates a conundrum for us, the ``CMAKE_MSVC_RUNTIME_LIBRARY`` needs to be correct at the time the target is created, but we have no control over the consumers CMake scripts, and the per-target ``MSVC_RUNTIME_LIBRARY`` property
is not transient, that is, it doesn't flow to dependent targets.

The previous attempt using INTERFACE_MSVC_RUNTIME_LIBRARY was a complete brain fail on my part, the INTERFACE_ prefix is not a universal concept like I thought it was, this property will do nothing.

We need ``CMAKE_MSVC_RUNTIME_LIBRARY`` to be ``"$<1:>"``[^3] to ensure it will not add any flags. And then use ``target_compile_options()`` so that our flags will propagate to consumers.

In the interests of playing nicely we detect whether we are being consumed and notify the consumer that we are setting ``CMAKE_MSVC_RUNTIME_LIBRARY``, that dependent targets rely on it, and point them to these comments as to why.

Further information from the cmake [forum](https://discourse.cmake.org/t/mt-staticrelease-doesnt-match-value-md-dynamicrelease/5428/4)

[^1]: https://cmake.org/cmake/help/latest/policy/CMP0091.html
[^2]: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
[^3]: This is a generator expression that results in the empty string.
