### PR TITLE
Privatise and Tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,8 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake ../ -DTEST_TARGET=template_release
-          cmake --build . --verbose -j $(nproc) -t godot-cpp-test --config Release
+          cmake ../ -DGODOT_ENABLE_TESTING=YES
+          cmake --build . --verbose -j $(nproc) -t godot-cpp.test.template_release --config Release
 
   windows-msvc-cmake:
     name: 🏁 Build (Windows, MSVC, CMake)
@@ -218,5 +218,5 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake ../ -DTEST_TARGET=template_release
-          cmake --build . --verbose -t godot-cpp-test --config Release
+          cmake ../ -DGODOT_ENABLE_TESTING=YES
+          cmake --build . --verbose -t godot-cpp.test.template_release --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ The CMake equivalent is below.
 ]=======================================================================]
 
 include( cmake/godotcpp.cmake )
+
 godotcpp_options()
 
 #[[ Python is required for code generation ]]
@@ -53,5 +54,12 @@ project( godot-cpp
 compiler_detection()
 godotcpp_generate()
 
-# Test Example
-add_subdirectory( test )
+# Conditionally enable the godot-cpp.test.<target> integration testing targets
+if( GODOT_ENABLE_TESTING )
+    add_subdirectory( test )
+endif()
+
+# If this is the top level CMakeLists.txt, Generators which honor the
+# USE_FOLDERS flag will organize godot-cpp targets under the subfolder
+# 'godot-cpp'. This is enable by default from CMake version 3.26
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/cmake/android.cmake
+++ b/cmake/android.cmake
@@ -29,13 +29,12 @@ function( android_options )
     # Android Options
 endfunction()
 
-function( android_generate TARGET_NAME )
-
+function( android_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             ANDROID_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -19,11 +19,11 @@ set( IS_GNU "$<CXX_COMPILER_ID:GNU>" )
 set( IS_MSVC "$<CXX_COMPILER_ID:MSVC>" )
 set( NOT_MSVC "$<NOT:$<CXX_COMPILER_ID:MSVC>>" )
 
-set( GNU_LT_V8 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,8>" )
-set( GNU_GE_V9 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,9>" )
-set( GNU_GT_V11 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11>" )
-set( GNU_LT_V11 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>" )
-set( GNU_GE_V12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>" )
+set( LT_V8  "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,8>" )
+set( GE_V9  "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,9>" )
+set( GT_V11 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11>" )
+set( LT_V11 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>" )
+set( GE_V12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>" )
 
 #[[ Check for clang-cl with MSVC frontend
 The compiler is tested and set when the project command is called.
@@ -46,19 +46,14 @@ endfunction(  )
 
 function( common_compiler_flags )
 
-    target_compile_features(${TARGET_NAME}
-            PUBLIC
-            cxx_std_17
-    )
-
     # These compiler options reflect what is in godot/SConstruct.
     target_compile_options( ${TARGET_NAME}
+        # The public flag tells CMake that the following options are transient,
+        #and will propagate to consumers.
         PUBLIC
             # Disable exception handling. Godot doesn't use exceptions anywhere, and this
             # saves around 20% of binary size and very significant build time.
-            $<${DISABLE_EXCEPTIONS}:
-                $<${NOT_MSVC}:-fno-exceptions>
-            >
+            $<${DISABLE_EXCEPTIONS}:$<${NOT_MSVC}:-fno-exceptions>>
 
             # Enabling Debug Symbols
             $<${DEBUG_SYMBOLS}:
@@ -70,20 +65,19 @@ function( common_compiler_flags )
                 >
             >
 
-            $<${IS_DEV_BUILD}:
-                $<${NOT_MSVC}:-fno-omit-frame-pointer -O0>
-            >
+            $<${IS_DEV_BUILD}:$<${NOT_MSVC}:-fno-omit-frame-pointer -O0>>
 
-            $<${HOT_RELOAD}:
-                $<${IS_GNU}:-fno-gnu-unique>
-            >
+            $<${HOT_RELOAD}:$<${IS_GNU}:-fno-gnu-unique>>
+
+        # Warnings below, these do not need to propagate to consumers.
+        PRIVATE
 
         # MSVC only
         $<${IS_MSVC}:
             # /MP isn't valid for clang-cl with msvc frontend
             $<$<CXX_COMPILER_ID:MSVC>:/MP${PROC_N}>
-            /W4
 
+            /W4      # Warning level 4 (informational) warnings that aren't off by default.
             # Disable warnings which we don't plan to fix.
             /wd4100  # C4100 (unreferenced formal parameter): Doesn't play nice with polymorphism.
             /wd4127  # C4127 (conditional expression is constant)
@@ -95,8 +89,6 @@ function( common_compiler_flags )
             /wd4514  # C4514 (unreferenced inline function has been removed)
             /wd4714  # C4714 (function marked as __forceinline not inlined)
             /wd4820  # C4820 (padding added after construct)
-
-            /utf-8
         >
 
         # Clang and GNU common options
@@ -124,21 +116,22 @@ function( common_compiler_flags )
             -Wplacement-new=1
             -Wshadow-local
             -Wstringop-overflow=4
-
-            # Bogus warning fixed in 8+.
-            $<${GNU_LT_V8}:-Wno-strict-overflow>
-
-            $<${GNU_GE_V9}:-Wattribute-alias=2>
-
-            # Broke on MethodBind templates before GCC 11.
-            $<${GNU_GT_V11}:-Wlogical-op>
-
-            # Regression in GCC 9/10, spams so much in our variadic templates that we need to outright disable it.
-            $<${GNU_LT_V11}:-Wno-type-limits>
-
-            # False positives in our error macros, see GH-58747.
-            $<${GNU_GE_V12}:-Wno-return-type>
         >
+
+        # Bogus warning fixed in 8+.
+        $<${IS_GNU}:$<${LT_V8}:-Wno-strict-overflow>>
+
+        $<${IS_GNU}:$<${GE_V9}:-Wattribute-alias=2>>
+
+        # Broke on MethodBind templates before GCC 11.
+        $<${IS_GNU}:$<${GT_V11}:-Wlogical-op>>
+
+        # Regression in GCC 9/10, spams so much in our variadic templates that we need to outright disable it.
+        $<${IS_GNU}:$<${LT_V11}:-Wno-type-limits>>
+
+        # False positives in our error macros, see GH-58747.
+        $<${IS_GNU}:$<${GE_V12}:-Wno-return-type>>
+
     )
 
     target_compile_definitions(${TARGET_NAME}
@@ -158,13 +151,11 @@ function( common_compiler_flags )
     )
 
     target_link_options( ${TARGET_NAME}
-        PUBLIC
-            $<${IS_MSVC}:
-                /WX             # treat link warnings as errors.
-                /MANIFEST:NO    # We dont need a manifest
-            >
+        PRIVATE
+            $<${IS_MSVC}:/WX /MANIFEST:NO>
+            # /WX             # treat link warnings as errors.
+            # /MANIFEST:NO    # We dont need a manifest
 
-            $<${DEBUG_SYMBOLS}:$<${IS_MSVC}:/DEBUG:FULL>>
             $<$<NOT:${DEBUG_SYMBOLS}>:
                 $<${IS_GNU}:-s>
                 $<${IS_CLANG}:-s>

--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -44,7 +44,7 @@ function( compiler_detection )
     endif ()
 endfunction(  )
 
-function( common_compiler_flags TARGET_NAME )
+function( common_compiler_flags )
 
     target_compile_features(${TARGET_NAME}
             PUBLIC

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -193,32 +193,21 @@ function( godotcpp_generate )
         set(GODOT_SYSTEM_HEADERS_ATTRIBUTE SYSTEM)
     endif ()
 
-    #[[ Generate Bindings ]]
-    if(NOT DEFINED BITS)
-        set(BITS 32)
-        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-            set(BITS 64)
-        endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    endif()
-
+    #[[ Configure Binding Variables ]]
     set(GODOT_GDEXTENSION_API_FILE "${GODOT_GDEXTENSION_DIR}/extension_api.json")
-    if (NOT "${GODOT_CUSTOM_API_FILE}" STREQUAL "")  # User-defined override.
+    if( GODOT_CUSTOM_API_FILE )  # User-defined override.
         set(GODOT_GDEXTENSION_API_FILE "${GODOT_CUSTOM_API_FILE}")
     endif()
 
-    # Code Generation option
-    if(GODOT_GENERATE_TEMPLATE_GET_NODE)
-        set(GENERATE_BINDING_PARAMETERS "True")
-    else()
-        set(GENERATE_BINDING_PARAMETERS "False")
-    endif()
+    set( GENERATE_BINDING_PARAMETERS "$<IF:$<BOOL:${GODOT_GENERATE_TEMPLATE_GET_NODE}>,True,False>" )
+    math( EXPR BITS "${CMAKE_SIZEOF_VOID_P} * 8" )
 
     execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; binding_generator.print_file_list('${GODOT_GDEXTENSION_API_FILE}', '${CMAKE_CURRENT_BINARY_DIR}', headers=True, sources=True)"
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             OUTPUT_VARIABLE GENERATED_FILES_LIST
             OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-
+    
     add_custom_command(OUTPUT ${GENERATED_FILES_LIST}
             COMMAND "${Python3_EXECUTABLE}" "-c" "import binding_generator; binding_generator.generate_bindings('${GODOT_GDEXTENSION_API_FILE}', '${GENERATE_BINDING_PARAMETERS}', '${BITS}', '${GODOT_PRECISION}', '${CMAKE_CURRENT_BINARY_DIR}')"
             VERBATIM
@@ -298,8 +287,9 @@ function( godotcpp_generate )
                 CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
                 COMPILE_WARNING_AS_ERROR ${GODOT_WARNING_AS_ERROR}
+
                 POSITION_INDEPENDENT_CODE ON
-                BUILD_RPATH_USE_ORIGIN ON
+                INTERFACE_POSITION_INDEPENDENT_CODE ON
 
                 PREFIX lib
                 OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_ALIAS}${DEV_TAG}.${SYSTEM_ARCH}"

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -142,6 +142,9 @@ function( godotcpp_options )
     option( GODOT_SYSTEM_HEADERS "Expose headers as SYSTEM." OFF )
     option( GODOT_WARNING_AS_ERROR "Treat warnings as errors" OFF )
 
+    # Enable Testing
+    option( GODOT_ENABLE_TESTING "Enable the godot-cpp.test.<target> integration testing targets" OFF )
+
     #[[ Target Platform Options ]]
     android_options()
     ios_options()
@@ -263,7 +266,8 @@ function( godotcpp_generate )
     set( DEV_TAG "$<${IS_DEV_BUILD}:.dev>" )
 
     ### Define our godot-cpp library targets
-    foreach ( TARGET_NAME template_debug template_release editor )
+    foreach ( TARGET_ALIAS template_debug template_release editor )
+        set( TARGET_NAME "godot-cpp.${TARGET_ALIAS}" )
 
         # Generator Expressions that rely on the target
         set( DEBUG_FEATURES "$<NOT:$<STREQUAL:${TARGET_NAME},template_release>>" )
@@ -271,7 +275,7 @@ function( godotcpp_generate )
 
         # the godot-cpp.* library targets
         add_library( ${TARGET_NAME} STATIC EXCLUDE_FROM_ALL )
-        add_library( godot-cpp::${TARGET_NAME} ALIAS ${TARGET_NAME} )
+        add_library( godot-cpp::${TARGET_ALIAS} ALIAS ${TARGET_NAME} )
 
         file( GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp )
 
@@ -298,33 +302,36 @@ function( godotcpp_generate )
                 BUILD_RPATH_USE_ORIGIN ON
 
                 PREFIX lib
-                OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_NAME}${DEV_TAG}.${SYSTEM_ARCH}"
+                OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_ALIAS}${DEV_TAG}.${SYSTEM_ARCH}"
                 ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/bin>"
 
                 # Things that are handy to know for dependent targets
                 GODOT_PLATFORM "${SYSTEM_NAME}"
-                GODOT_TARGET "${TARGET_NAME}"
+                GODOT_TARGET "${TARGET_ALIAS}"
                 GODOT_ARCH "${SYSTEM_ARCH}"
+
+                # Some IDE's respect this property to logically group targets
+                FOLDER "godot-cpp"
         )
 
         if( CMAKE_SYSTEM_NAME STREQUAL Android )
-            android_generate( ${TARGET_NAME} )
+            android_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL iOS )
-            ios_generate( ${TARGET_NAME} )
+            ios_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Linux )
-            linux_generate( ${TARGET_NAME} )
+            linux_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-            macos_generate( ${TARGET_NAME} )
+            macos_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Emscripten )
-            web_generate( ${TARGET_NAME} )
+            web_generate()
         elseif ( CMAKE_SYSTEM_NAME STREQUAL Windows )
-            windows_generate( ${TARGET_NAME} )
+            windows_generate()
         endif ()
 
     endforeach ()
 
     # Added for backwards compatibility with prior cmake solution so that builds dont immediately break
     # from a missing target.
-    add_library( godot::cpp ALIAS template_debug )
+    add_library( godot::cpp ALIAS godot-cpp.template_debug )
 
 endfunction()

--- a/cmake/ios.cmake
+++ b/cmake/ios.cmake
@@ -10,13 +10,12 @@ function(ios_options)
     # iOS options
 endfunction()
 
-function(ios_generate TARGET_NAME)
-
+function(ios_generate)
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             IOS_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags(${TARGET_NAME})
+    common_compiler_flags()
 endfunction()

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -10,13 +10,12 @@ function( linux_options )
     # Linux Options
 endfunction()
 
-function( linux_generate TARGET_NAME )
-
+function( linux_generate )
     target_compile_definitions( ${TARGET_NAME}
             PUBLIC
             LINUX_ENABLED
             UNIX_ENABLED
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -36,7 +36,9 @@ function( macos_generate )
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
 
+            # Specify multiple architectures for universal builds
             OSX_ARCHITECTURES "${OSX_ARCH}"
+            GODOT_ARCH ${SYSTEM_ARCH}
     )
 
     target_compile_definitions(${TARGET_NAME}

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -23,7 +23,7 @@ function( macos_options )
 endfunction()
 
 
-function( macos_generate TARGET_NAME )
+function( macos_generate )
 
     # OSX_ARCHITECTURES does not support generator expressions.
     if( NOT GODOT_ARCH OR GODOT_ARCH STREQUAL universal )
@@ -55,5 +55,5 @@ function( macos_generate TARGET_NAME )
             ${COCOA_LIBRARY}
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -15,8 +15,7 @@ function( web_options )
 endfunction()
 
 
-function( web_generate TARGET_NAME )
-
+function( web_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC
             WEB_ENABLED
@@ -38,5 +37,5 @@ function( web_generate TARGET_NAME )
             -shared
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -58,7 +58,7 @@ function( windows_options )
 endfunction()
 
 #[===========================[ Target Generation ]===========================]
-function( windows_generate TARGET_NAME )
+function( windows_generate )
     set( STATIC_CPP "$<BOOL:${GODOT_USE_STATIC_CPP}>")
     set( DEBUG_CRT "$<BOOL:${GODOT_DEBUG_CRT}>" )
 
@@ -96,5 +96,5 @@ function( windows_generate TARGET_NAME )
             $<${IS_CLANG}:-lstdc++>
     )
 
-    common_compiler_flags( ${TARGET_NAME} )
+    common_compiler_flags()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,22 @@ foreach( TARGET_ALIAS template_debug template_release editor )
     set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
     set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )
 
+    ### Get useful properties of the library
+    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
+    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
+    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
+    get_target_property( OSX_ARCH       ${LINK_TARGET} OSX_ARCHITECTURES )
+
+    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
+
+    if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
+        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
+        set( OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}" )
+    else()
+        set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
+        set( OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}" )
+    endif()
+
     add_library( ${TARGET_NAME} SHARED EXCLUDE_FROM_ALL )
 
     target_sources( ${TARGET_NAME}
@@ -25,21 +41,13 @@ foreach( TARGET_ALIAS template_debug template_release editor )
 
     target_link_libraries( ${TARGET_NAME} PRIVATE ${LINK_TARGET} )
 
-    ### Get useful properties of the library
-    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
-    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
-    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
-
-    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
-
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
             CXX_STANDARD 17
             CXX_EXTENSIONS OFF
             CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
-            POSITION_INDEPENDENT_CODE ON
+            # This flag adds the runtime path at build time
             BUILD_RPATH_USE_ORIGIN ON
 
             # Try to ensure only static libraries are selected to be linked to.
@@ -55,27 +63,20 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             PREFIX "lib"
             OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
 
+            #macos options, ignored on other platforms
+            OSX_ARCHITECTURES "${OSX_ARCH}"
+
+            # enable RPATH on MACOS, with the BUILD_RPATH_USE_ORIGIN
+            # this should allow loading libraries from relative paths on macos.
+            MACOSX_RPATH ON
+
             # Some IDE's respect this property to logically group targets
             FOLDER "godot-cpp"
     )
 
-    # CMAKE_SYSTEM_NAME refers to the target system
+    # Only blank the suffix on osx to match SCons
     if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-        get_target_property( OSX_ARCH ${LINK_TARGET} OSX_ARCHITECTURES )
-
-        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
-
-        set_target_properties( ${TARGET_NAME}
-                PROPERTIES
-                LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-                RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-
-                OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}"
-                SUFFIX ""
-
-                #macos options
-                OSX_ARCHITECTURES "${OSX_ARCH}"
-        )
+        set_target_properties( ${TARGET_NAME} PROPERTIES SUFFIX "" )
     endif ()
 
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,68 +1,81 @@
-# Testing Extension
-# This is only linked to the template_release config.
-# so it requires the template_release version of godot to run.
+#[=======================================================================[.rst:
+Integration Testing
+-------------------
 
-add_library( godot-cpp-test SHARED EXCLUDE_FROM_ALL )
+The Test target used to validate changes in the GitHub CI.
 
-target_sources( godot-cpp-test
-        PRIVATE
-        src/example.cpp
-        src/example.h
-        src/register_types.cpp
-        src/register_types.h
-        src/tests.h
-)
+]=======================================================================]
 
-set( TEST_TARGET "template_debug" CACHE STRING "Which godot-cpp::target to link against" )
-set_property( CACHE TEST_TARGET PROPERTY STRINGS "template_debug;template_release;editor" )
+message( STATUS "Testing Integration targets are enabled.")
 
-target_link_libraries( godot-cpp-test
-        PRIVATE
-        godot-cpp::${TEST_TARGET} )
+foreach( TARGET_ALIAS template_debug template_release editor )
+    set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
+    set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )
 
-### Get useful properties of the library
-get_target_property( GODOT_PLATFORM godot-cpp::${TEST_TARGET} GODOT_PLATFORM )
-get_target_property( GODOT_TARGET godot-cpp::${TEST_TARGET} GODOT_TARGET )
-get_target_property( GODOT_ARCH godot-cpp::${TEST_TARGET} GODOT_ARCH )
+    add_library( ${TARGET_NAME} SHARED EXCLUDE_FROM_ALL )
 
-set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
+    target_sources( ${TARGET_NAME}
+            PRIVATE
+            src/example.cpp
+            src/example.h
+            src/register_types.cpp
+            src/register_types.h
+            src/tests.h
+    )
 
-set_target_properties( godot-cpp-test
-        PROPERTIES
-        CXX_STANDARD 17
-        CXX_EXTENSIONS OFF
-        CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
+    target_link_libraries( ${TARGET_NAME} PRIVATE ${LINK_TARGET} )
 
-        POSITION_INDEPENDENT_CODE ON
-        BUILD_RPATH_USE_ORIGIN ON
-        LINK_SEARCH_START_STATIC ON
-        LINK_SEARCH_END_STATIC ON
+    ### Get useful properties of the library
+    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
+    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
+    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
 
-        # NOTE: Wrapping the output variables inside a generator expression
-        # prevents msvc generator from adding addition Config Directories
-        LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-        RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-        PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
+    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
+    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
 
-        PREFIX "lib"
-        OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
-)
-
-if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-    get_target_property( OSX_ARCH godot-cpp::${TEST_TARGET} OSX_ARCHITECTURES )
-
-    set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
-
-    set_target_properties( godot-cpp-test
+    set_target_properties( ${TARGET_NAME}
             PROPERTIES
+            CXX_STANDARD 17
+            CXX_EXTENSIONS OFF
+            CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
+
+            POSITION_INDEPENDENT_CODE ON
+            BUILD_RPATH_USE_ORIGIN ON
+
+            # Try to ensure only static libraries are selected to be linked to.
+            LINK_SEARCH_START_STATIC ON
+            LINK_SEARCH_END_STATIC ON
+
+            # NOTE: Wrapping the output variables inside a generator expression
+            # prevents msvc generator from adding addition Config Directories
             LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
             RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+            PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
 
-            OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}"
-            SUFFIX ""
+            PREFIX "lib"
+            OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
 
-            #macos options
-            OSX_ARCHITECTURES "${OSX_ARCH}"
+            # Some IDE's respect this property to logically group targets
+            FOLDER "godot-cpp"
     )
-endif ()
+
+    # CMAKE_SYSTEM_NAME refers to the target system
+    if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
+        get_target_property( OSX_ARCH ${LINK_TARGET} OSX_ARCHITECTURES )
+
+        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
+
+        set_target_properties( ${TARGET_NAME}
+                PROPERTIES
+                LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+                RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
+
+                OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}"
+                SUFFIX ""
+
+                #macos options
+                OSX_ARCHITECTURES "${OSX_ARCH}"
+        )
+    endif ()
+
+endforeach()


### PR DESCRIPTION
One of the benefits of CMake which is not currently being realised is that target options can be selectively propagated to consumers. For expediency, I had previously made all the flags PUBLIC, which propagates all options to consumers. However, after some investigation, It appears that we can make the majority of them PRIVATE.
The compile_definitions must remain public as they are needed in consumer projects.
The compile_options and link_options can be made private and achieve a successful compile, but investigation is required for what should be propagated.

There are also flags and properties that can be tidied up to be more correct.

Remove RPATH_USE_ORIGIN from static libs
add INTERFACE_POSITION_INDEPENDENT_CODE ON
reset GODOT_ARCH property to SYSTEM_ARCH for macos because universal add MACOSX_RPATH to test target
remove redundant properties from test target
remove redundant and PUBLIC cxx_std_17 compile feature.
Move MSVC flag utf-8 to godot-cpp-test where it is required.