### PR TITLE
CMake: Support for XML documentation

### DIFF
--- a/doc_source_generator.py
+++ b/doc_source_generator.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import zlib
+
+
+def generate_doc_source(dst, source):
+    g = open(dst, "w", encoding="utf-8")
+    buf = ""
+    docbegin = ""
+    docend = ""
+    for src in source:
+        src_path = str(src)
+        if not src_path.endswith(".xml"):
+            continue
+        with open(src_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        buf += content
+
+    buf = (docbegin + buf + docend).encode("utf-8")
+    decomp_size = len(buf)
+
+    # Use maximum zlib compression level to further reduce file size
+    # (at the cost of initial build times).
+    buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+
+    g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
+    g.write("\n")
+    g.write("#include <godot_cpp/godot.hpp>\n")
+    g.write("\n")
+
+    g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
+    g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
+    g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
+    g.write("static const unsigned char _doc_data_compressed[] = {\n")
+    for i in range(len(buf)):
+        g.write("\t" + str(buf[i]) + ",\n")
+    g.write("};\n")
+    g.write("\n")
+
+    g.write(
+        "static godot::internal::DocDataRegistration _doc_data_registration(_doc_data_hash, _doc_data_uncompressed_size, _doc_data_compressed_size, _doc_data_compressed);\n"
+    )
+    g.write("\n")
+
+    g.close()
+
+
+def scons_generate_doc_source(target, source, env):
+    generate_doc_source(str(target[0]), source)
+
+
+def generate_doc_source_from_directory(target, directory):
+    generate_doc_source(target, glob.glob(os.path.join(directory, "*.xml")))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,18 @@ Integration Testing
 -------------------
 
 The Test target used to validate changes in the GitHub CI.
-
 ]=======================================================================]
 
 message( STATUS "Testing Integration targets are enabled.")
+
+# Generate Doc Data
+file( GLOB_RECURSE DOC_XML
+    LIST_DIRECTORIES NO
+    CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml" )
+
+set( DOC_DATA_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/src/gen/doc_data.gen.cpp" )
+generate_doc_source( "${DOC_DATA_SOURCE}" "${DOC_XML}" )
 
 foreach( TARGET_ALIAS template_debug template_release editor )
     set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
@@ -22,6 +30,11 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             src/register_types.h
             src/tests.h
     )
+
+    # conditionally add doc data to compile output
+    if( TARGET_ALIAS MATCHES "editor|template_debug" )
+        target_sources( ${TARGET_NAME} PRIVATE "${DOC_DATA_SOURCE}" )
+    endif(   )
 
     target_link_libraries( ${TARGET_NAME} PRIVATE ${LINK_TARGET} )
 


### PR DESCRIPTION
This PR extends #1499 - [DRAFT] Add CMake support for XML documentation
which follows #1374 - Allow submitting documentation to the Godot editor

This is also built upon #1670 - CMake: Support for using build_profile.json

This PR adds the equivalent functionality to the CMake build scripts. A summary below.


The SCons implementation adds a BUILDER to the env in tools/godotcpp.py:513
```python
    # Builders
    env.Append(
        BUILDERS={
            "GodotCPPBindings": Builder(action=Action(scons_generate_bindings, "$GENCOMSTR"), emitter=scons_emit_files),
            "GodotCPPDocData": Builder(action=scons_generate_doc_source),
        }
    )
```
Which is then available for consumers to use, with the test example showing how at test/SConstruct:18
```python
if env["target"] in ["editor", "template_debug"]:
    doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))
    sources.append(doc_data)
```

This CMake implementationa mirrors this with a function in cmake/python_callouts.cmake:109
```cmake
function( generate_doc_source OUTPUT_PATH XML_SOURCES )
- - - <snip> - - - 
```
which calls the python function of the same name from doc_source_generator.py to create the cpp file at OUTPUT_PATH which can then be added to the sources list of the target. The test extension shows this starting in test/CMakeLists.txt:10
```cmake
# Generate Doc Data
file( GLOB_RECURSE DOC_XML
    LIST_DIRECTORIES NO
    CONFIGURE_DEPENDS
    ${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml )

set( DOC_DATA_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/src/gen/doc_data.gen.cpp" )
generate_doc_source( "${DOC_DATA_SOURCE}" "${DOC_XML}" )

- - - <snip> - - - 

    # conditionally add doc data to compile output
    if( TARGET_ALIAS MATCHES "editor|template_debug" )
        target_sources( ${TARGET_NAME} PRIVATE "${DOC_DATA_SOURCE}" )
    endif(   )

```