### PR TITLE
CMake: Grab bag of tiny refactors and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if( GODOT_ENABLE_TESTING )
     add_subdirectory( test )
 endif()
 
-# If this is the top level CMakeLists.txt, Generators which honor the
-# USE_FOLDERS flag will organize godot-cpp targets under the subfolder
-# 'godot-cpp'. This is enable by default from CMake version 3.26
+#[[ If this is the top level CMakeLists.txt, Generators which honor the
+USE_FOLDERS flag will organize godot-cpp targets under the subfolder
+'godot-cpp'. This is enable by default from CMake version 3.26 ]]
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/cmake/android.cmake
+++ b/cmake/android.cmake
@@ -25,10 +25,21 @@ Android platforms.
 There is further information and examples in the doc/cmake.rst file.
 
 ]=======================================================================]
+
+#[============================[ Android Options ]============================]
 function( android_options )
-    # Android Options
+    #[[ The options present in the SCons build shown below are managed by
+    toolchain files, further information can be found in doc/cmake.rst
+
+    android_api_level : Target Android API level.
+        Default = 21
+
+    ANDROID_HOME : Path to your Android SDK installation.
+        Default = os.environ.get("ANDROID_HOME", os.environ.get("ANDROID_SDK_ROOT")
+    ]]
 endfunction()
 
+#[===========================[ Target Generation ]===========================]
 function( android_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC

--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -8,7 +8,7 @@ features. For target platform specific flags look to each of the
 ``cmake/<platform>.cmake`` files.
 
 The default compile and link options CMake adds can be found in the
-platform modules_. When a project is created it initialises its variables from
+platform modules_. When a project is created it initializes its variables from
 the ``CMAKE_*`` values. The cleanest way I have found to alter these defaults
 is the use of the ``CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE`` as demonstrated by
 the emsdkHack.cmake to overcome the limitation on shared library creation.
@@ -35,6 +35,7 @@ set( GT_V11 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11>" )
 set( LT_V11 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>" )
 set( GE_V12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>" )
 
+#[===========================[ compiler_detection ]===========================]
 #[[ Check for clang-cl with MSVC frontend
 The compiler is tested and set when the project command is called.
 The variable CXX_COMPILER_FRONTEND_VARIANT was introduced in 3.14
@@ -54,6 +55,9 @@ function( compiler_detection )
     endif ()
 endfunction(  )
 
+#[=========================[ common_compiler_flags ]=========================]
+#[[ This function assumes it is being called from within one of the platform
+generate functions, with all the variables from lower scopes defined. ]]
 function( common_compiler_flags )
 
     # These compiler options reflect what is in godot/SConstruct.

--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -7,6 +7,16 @@ configuration. It includes flags like optimization levels, warnings, and
 features. For target platform specific flags look to each of the
 ``cmake/<platform>.cmake`` files.
 
+The default compile and link options CMake adds can be found in the
+platform modules_. When a project is created it initialises its variables from
+the ``CMAKE_*`` values. The cleanest way I have found to alter these defaults
+is the use of the ``CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE`` as demonstrated by
+the emsdkHack.cmake to overcome the limitation on shared library creation.
+
+So far the emsdkHack is the only modification to the defaults we have made.
+
+.. _modules: https://github.com/Kitware/CMake/blob/master/Modules/Platform/
+
 ]=======================================================================]
 
 #[[ Compiler Configuration, not to be confused with build targets ]]
@@ -19,11 +29,11 @@ set( IS_GNU "$<CXX_COMPILER_ID:GNU>" )
 set( IS_MSVC "$<CXX_COMPILER_ID:MSVC>" )
 set( NOT_MSVC "$<NOT:$<CXX_COMPILER_ID:MSVC>>" )
 
-set( GNU_LT_V8 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,8>" )
-set( GNU_GE_V9 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,9>" )
-set( GNU_GT_V11 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11>" )
-set( GNU_LT_V11 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>" )
-set( GNU_GE_V12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>" )
+set( LT_V8  "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,8>" )
+set( GE_V9  "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,9>" )
+set( GT_V11 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11>" )
+set( LT_V11 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11>" )
+set( GE_V12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>" )
 
 #[[ Check for clang-cl with MSVC frontend
 The compiler is tested and set when the project command is called.
@@ -46,19 +56,14 @@ endfunction(  )
 
 function( common_compiler_flags )
 
-    target_compile_features(${TARGET_NAME}
-            PUBLIC
-            cxx_std_17
-    )
-
     # These compiler options reflect what is in godot/SConstruct.
     target_compile_options( ${TARGET_NAME}
+        # The public flag tells CMake that the following options are transient,
+        #and will propagate to consumers.
         PUBLIC
             # Disable exception handling. Godot doesn't use exceptions anywhere, and this
             # saves around 20% of binary size and very significant build time.
-            $<${DISABLE_EXCEPTIONS}:
-                $<${NOT_MSVC}:-fno-exceptions>
-            >
+            $<${DISABLE_EXCEPTIONS}:$<${NOT_MSVC}:-fno-exceptions>>
 
             # Enabling Debug Symbols
             $<${DEBUG_SYMBOLS}:
@@ -70,20 +75,19 @@ function( common_compiler_flags )
                 >
             >
 
-            $<${IS_DEV_BUILD}:
-                $<${NOT_MSVC}:-fno-omit-frame-pointer -O0>
-            >
+            $<${IS_DEV_BUILD}:$<${NOT_MSVC}:-fno-omit-frame-pointer -O0>>
 
-            $<${HOT_RELOAD}:
-                $<${IS_GNU}:-fno-gnu-unique>
-            >
+            $<${HOT_RELOAD}:$<${IS_GNU}:-fno-gnu-unique>>
+
+        # Warnings below, these do not need to propagate to consumers.
+        PRIVATE
 
         # MSVC only
         $<${IS_MSVC}:
             # /MP isn't valid for clang-cl with msvc frontend
             $<$<CXX_COMPILER_ID:MSVC>:/MP${PROC_N}>
-            /W4
 
+            /W4      # Warning level 4 (informational) warnings that aren't off by default.
             # Disable warnings which we don't plan to fix.
             /wd4100  # C4100 (unreferenced formal parameter): Doesn't play nice with polymorphism.
             /wd4127  # C4127 (conditional expression is constant)
@@ -124,21 +128,22 @@ function( common_compiler_flags )
             -Wplacement-new=1
             -Wshadow-local
             -Wstringop-overflow=4
-
-            # Bogus warning fixed in 8+.
-            $<${GNU_LT_V8}:-Wno-strict-overflow>
-
-            $<${GNU_GE_V9}:-Wattribute-alias=2>
-
-            # Broke on MethodBind templates before GCC 11.
-            $<${GNU_GT_V11}:-Wlogical-op>
-
-            # Regression in GCC 9/10, spams so much in our variadic templates that we need to outright disable it.
-            $<${GNU_LT_V11}:-Wno-type-limits>
-
-            # False positives in our error macros, see GH-58747.
-            $<${GNU_GE_V12}:-Wno-return-type>
         >
+
+        # Bogus warning fixed in 8+.
+        $<${IS_GNU}:$<${LT_V8}:-Wno-strict-overflow>>
+
+        $<${IS_GNU}:$<${GE_V9}:-Wattribute-alias=2>>
+
+        # Broke on MethodBind templates before GCC 11.
+        $<${IS_GNU}:$<${GT_V11}:-Wlogical-op>>
+
+        # Regression in GCC 9/10, spams so much in our variadic templates that we need to outright disable it.
+        $<${IS_GNU}:$<${LT_V11}:-Wno-type-limits>>
+
+        # False positives in our error macros, see GH-58747.
+        $<${IS_GNU}:$<${GE_V12}:-Wno-return-type>>
+
     )
 
     target_compile_definitions(${TARGET_NAME}
@@ -158,13 +163,11 @@ function( common_compiler_flags )
     )
 
     target_link_options( ${TARGET_NAME}
-        PUBLIC
-            $<${IS_MSVC}:
-                /WX             # treat link warnings as errors.
-                /MANIFEST:NO    # We dont need a manifest
-            >
+        PRIVATE
+            $<${IS_MSVC}:/WX /MANIFEST:NO>
+            # /WX             # treat link warnings as errors.
+            # /MANIFEST:NO    # We dont need a manifest
 
-            $<${DEBUG_SYMBOLS}:$<${IS_MSVC}:/DEBUG:FULL>>
             $<$<NOT:${DEBUG_SYMBOLS}>:
                 $<${IS_GNU}:-s>
                 $<${IS_CLANG}:-s>

--- a/cmake/emsdkHack.cmake
+++ b/cmake/emsdkHack.cmake
@@ -31,7 +31,7 @@ if( EMSCRIPTEN )
     set(CMAKE_STRIP FALSE)  # used by default in pybind11 on .so modules
 
     # The Emscripten toolchain sets the default value for EMSCRIPTEN_SYSTEM_PROCESSOR to x86
-    # and CMAKE_SYSTEM_PROCESSOR to this value. I don't want that.
+    # and copies that to CMAKE_SYSTEM_PROCESSOR. We dont want that.
     set(CMAKE_SYSTEM_PROCESSOR "wasm32" )
     # the above prevents the need for logic like:
     #if( ${CMAKE_SYSTEM_NAME} STREQUAL Emscripten )

--- a/cmake/emsdkHack.cmake
+++ b/cmake/emsdkHack.cmake
@@ -27,7 +27,7 @@ if( EMSCRIPTEN )
     set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
     set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-sSIDE_MODULE=1")
     set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-sSIDE_MODULE=1")
-    set(CMAKE_SHARED_LIBRARY_SUFFIX) # remove the suffix from the shared lib
+    set(CMAKE_SHARED_LIBRARY_SUFFIX ".wasm") # SCons uses .wasm as a suffix
     set(CMAKE_STRIP FALSE)  # used by default in pybind11 on .so modules
 
     # The Emscripten toolchain sets the default value for EMSCRIPTEN_SYSTEM_PROCESSOR to x86

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -266,8 +266,6 @@ function( godotcpp_generate )
         message( WARNING "=> GODOT_DEV_BUILD implies a Debug-like build but CMAKE_BUILD_TYPE is '${CMAKE_BUILD_TYPE}'")
     endif ()
     set( IS_DEV_BUILD "$<BOOL:${GODOT_DEV_BUILD}>")
-    # The .dev portion of the name if GODOT_DEV_BUILD is true.
-    set( DEV_TAG "$<${IS_DEV_BUILD}:.dev>" )
 
     ### Define our godot-cpp library targets
     foreach ( TARGET_ALIAS template_debug template_release editor )
@@ -276,6 +274,17 @@ function( godotcpp_generate )
         # Generator Expressions that rely on the target
         set( DEBUG_FEATURES "$<NOT:$<STREQUAL:${TARGET_ALIAS},template_release>>" )
         set( HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},${DEBUG_FEATURES},$<BOOL:${GODOT_USE_HOT_RELOAD}>>" )
+
+        # Suffix
+        string( JOIN "" GODOT_SUFFIX
+                "$<1:.${SYSTEM_NAME}>"
+                "$<1:.${TARGET_ALIAS}>"
+                "$<${IS_DEV_BUILD}:.dev>"
+                "$<$<STREQUAL:${GODOT_PRECISION},double>:.double>"
+                "$<1:.${SYSTEM_ARCH}>"
+                # missing IOS_SIMULATOR
+                # missing THREADS
+        )
 
         # the godot-cpp.* library targets
         add_library( ${TARGET_NAME} STATIC EXCLUDE_FROM_ALL )
@@ -306,14 +315,17 @@ function( godotcpp_generate )
                 POSITION_INDEPENDENT_CODE ON
                 INTERFACE_POSITION_INDEPENDENT_CODE ON
 
-                PREFIX lib
-                OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_ALIAS}${DEV_TAG}.${SYSTEM_ARCH}"
+                PREFIX      "lib"
+                OUTPUT_NAME "${PROJECT_NAME}${GODOT_SUFFIX}"
+
                 ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/bin>"
 
                 # Things that are handy to know for dependent targets
-                GODOT_PLATFORM "${SYSTEM_NAME}"
-                GODOT_TARGET "${TARGET_ALIAS}"
-                GODOT_ARCH "${SYSTEM_ARCH}"
+                GODOT_PLATFORM  "${SYSTEM_NAME}"
+                GODOT_TARGET    "${TARGET_ALIAS}"
+                GODOT_ARCH      "${SYSTEM_ARCH}"
+                GODOT_PRECISION "${GODOT_PRECISION}"
+                GODOT_SUFFIX    "${GODOT_SUFFIX}"
 
                 # Some IDE's respect this property to logically group targets
                 FOLDER "godot-cpp"

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -240,16 +240,15 @@ function( godotcpp_generate )
 
     ### Platform is derived from the toolchain target
     # See GeneratorExpressions PLATFORM_ID and CMAKE_SYSTEM_NAME
-    set( SYSTEM_NAME
-            $<$<PLATFORM_ID:Android>:android>
-            $<$<PLATFORM_ID:iOS>:ios>
-            $<$<PLATFORM_ID:Linux>:linux>
-            $<$<PLATFORM_ID:Darwin>:macos>
-            $<$<PLATFORM_ID:Emscripten>:web>
-            $<$<PLATFORM_ID:Windows>:windows>
-            $<$<PLATFORM_ID:Msys>:windows>
+    string( APPEND SYSTEM_NAME
+            "$<$<PLATFORM_ID:Android>:android.${ANDROID_ABI}>"
+            "$<$<PLATFORM_ID:iOS>:ios>"
+            "$<$<PLATFORM_ID:Linux>:linux>"
+            "$<$<PLATFORM_ID:Darwin>:macos>"
+            "$<$<PLATFORM_ID:Emscripten>:web>"
+            "$<$<PLATFORM_ID:Windows>:windows>"
+            "$<$<PLATFORM_ID:Msys>:windows>"
     )
-    string(REPLACE ";" "" SYSTEM_NAME "${SYSTEM_NAME}")
 
     ### Use the arch from the toolchain if it isn't set manually
     if( GODOT_ARCH )

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -11,18 +11,12 @@ This if statement simply silences that warning.
 if( CMAKE_C_COMPILER )
 endif ()
 
-#[=======================================================================[.rst:
-Include Platform Files
-----------------------
-
-Because these files are included into the top level CMakelists.txt before the
+#[[ Include Platform Files
+Because these files are included into the top level CMakeLists.txt before the
 project directive, it means that
 
-* ``CMAKE_CURRENT_SOURCE_DIR`` is the location of godot-cpp's CMakeLists.txt
-* ``CMAKE_SOURCE_DIR`` is the location where any prior ``project(...)``
-  directive was
-
-]=======================================================================]
+CMAKE_CURRENT_SOURCE_DIR is the location of godot-cpp's CMakeLists.txt
+CMAKE_SOURCE_DIR is the location where any prior project() directive was ]]
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/common_compiler_flags.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/android.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ios.cmake)
@@ -43,7 +37,8 @@ set( PLATFORM_LIST linux macos windows android ios web )
 # List of known architectures
 set( ARCH_LIST universal x86_32 x86_64 arm32 arm64 rv64 ppc32 ppc64 wasm32 )
 
-# Function to map processors to known architectures
+#[=============================[ godot_arch_map ]=============================]
+#[[ Function to map CMAKE_SYSTEM_PROCESSOR names to godot arch equivalents ]]
 function( godot_arch_map ALIAS PROC )
     string( TOLOWER "${PROC}" PROC )
 
@@ -157,7 +152,7 @@ function( godotcpp_options )
     windows_options()
 endfunction()
 
-# Function to configure and generate the targets
+#[===========================[ Target Generation ]===========================]
 function( godotcpp_generate )
     #[[ Multi-Threaded MSVC Compilation
     When using the MSVC compiler the build command -j <n> only specifies

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -307,8 +307,9 @@ function( godotcpp_generate )
                 CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
                 COMPILE_WARNING_AS_ERROR ${GODOT_WARNING_AS_ERROR}
+
                 POSITION_INDEPENDENT_CODE ON
-                BUILD_RPATH_USE_ORIGIN ON
+                INTERFACE_POSITION_INDEPENDENT_CODE ON
 
                 PREFIX lib
                 OUTPUT_NAME "${PROJECT_NAME}.${SYSTEM_NAME}.${TARGET_ALIAS}${DEV_TAG}.${SYSTEM_ARCH}"

--- a/cmake/ios.cmake
+++ b/cmake/ios.cmake
@@ -6,10 +6,20 @@ This file contains functions for options and configuration for targeting the
 Ios platform
 
 ]=======================================================================]
+
+#[==============================[ iOS Options ]==============================]
 function(ios_options)
-    # iOS options
+#    TODO "ios_simulator", "Target iOS Simulator", False
+#    TODO "ios_min_version", "Target minimum iphoneos/iphonesimulator version", "12.0"
+#    TODO "IOS_TOOLCHAIN_PATH",
+#        "Path to iOS toolchain",
+#        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
+#    TODO "IOS_SDK_PATH", "Path to the iOS SDK", ""
+#
+#    TODO if has_ios_osxcross(): "ios_triple", "Triple for ios toolchain", ""
 endfunction()
 
+#[===========================[ Target Generation ]===========================]
 function(ios_generate)
     target_compile_definitions(${TARGET_NAME}
             PUBLIC

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -6,10 +6,18 @@ This file contains functions for options and configuration for targeting the
 Linux platform
 
 ]=======================================================================]
+
+#[=============================[ Linux Options ]=============================]
 function( linux_options )
-    # Linux Options
+    #[[ The options present in the SCons build shown below are managed by
+    toolchain files, further information can be found in doc/cmake.rst
+
+    use_llvm : Use the LLVM compiler
+        Default: False
+]]
 endfunction()
 
+#[===========================[ Target Generation ]===========================]
 function( linux_generate )
     target_compile_definitions( ${TARGET_NAME}
             PUBLIC

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -7,6 +7,7 @@ MacOS platform
 
 ]=======================================================================]
 
+#[===========================[ Find Dependencies ]===========================]
 # APPLE is set to True when the target system is an Apple platform
 # (macOS, iOS, tvOS, visionOS or watchOS).
 if( APPLE )
@@ -18,12 +19,14 @@ if( APPLE )
         NO_DEFAULT_PATH )
 endif( APPLE )
 
+#[=============================[ MacOS Options ]=============================]
 function( macos_options )
     # TODO "macos_deployment_target" "macOS deployment target" "default"
     # TODO "macos_sdk_path" "macOS SDK path" ""
     # TODO if has_osxcross(): "osxcross_sdk" "OSXCross SDK version" "darwin16"
 endfunction()
 
+#[===========================[ Target Generation ]===========================]
 function( macos_generate )
 
     # OSX_ARCHITECTURES does not support generator expressions.

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -7,21 +7,22 @@ MacOS platform
 
 ]=======================================================================]
 
-# Find Requirements
-IF(APPLE)
+# APPLE is set to True when the target system is an Apple platform
+# (macOS, iOS, tvOS, visionOS or watchOS).
+if( APPLE )
     set( CMAKE_OSX_SYSROOT $ENV{SDKROOT} )
     find_library( COCOA_LIBRARY REQUIRED
         NAMES Cocoa
         PATHS ${CMAKE_OSX_SYSROOT}/System/Library
         PATH_SUFFIXES Frameworks
-        NO_DEFAULT_PATH)
-ENDIF (APPLE)
-
+        NO_DEFAULT_PATH )
+endif( APPLE )
 
 function( macos_options )
-    # macos options here
+    # TODO "macos_deployment_target" "macOS deployment target" "default"
+    # TODO "macos_sdk_path" "macOS SDK path" ""
+    # TODO if has_osxcross(): "osxcross_sdk" "OSXCross SDK version" "darwin16"
 endfunction()
-
 
 function( macos_generate )
 
@@ -36,7 +37,9 @@ function( macos_generate )
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
 
+            # Specify multiple architectures for universal builds
             OSX_ARCHITECTURES "${OSX_ARCH}"
+            GODOT_ARCH ${SYSTEM_ARCH}
     )
 
     target_compile_definitions(${TARGET_NAME}

--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -10,11 +10,12 @@ Web platform
 # Emscripten requires this hack for use of the SHARED option
 set( CMAKE_PROJECT_godot-cpp_INCLUDE cmake/emsdkHack.cmake )
 
+#[==============================[ Web Options ]==============================]
 function( web_options )
     # web options
 endfunction()
 
-
+#[===========================[ Target Generation ]===========================]
 function( web_generate )
     target_compile_definitions(${TARGET_NAME}
             PUBLIC

--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -27,7 +27,6 @@ function( web_generate )
             PUBLIC
             -sSIDE_MODULE
             -sSUPPORT_LONGJMP=wasm
-            -fno-exceptions
     )
 
     target_link_options( ${TARGET_NAME}

--- a/cmake/windows.cmake
+++ b/cmake/windows.cmake
@@ -37,6 +37,8 @@ that dependent targets rely on it, and point them to these comments as to why.
 .. https://discourse.cmake.org/t/mt-staticrelease-doesnt-match-value-md-dynamicrelease/5428/4
 
 ]=======================================================================]
+
+# FIXME INVALID LOGIC: consumers may also have not called project() yet.
 if( PROJECT_NAME ) # we are not the top level if this is true
     if( DEFINED CMAKE_MSVC_RUNTIME_LIBRARY )
         # Warning that we are clobbering the variable.
@@ -55,6 +57,20 @@ function( windows_options )
 
     option( GODOT_DEBUG_CRT "Compile with MSVC's debug CRT (/MDd)" OFF )
 
+    # NOT PLANNED:  silence_msvc : Silence MSVC's cl/link stdout bloat, redirecting errors to stderr. Default = True
+
+    #[[ The options present in the SCons build shown below are managed by
+    toolchain files, further information can be found in doc/cmake.rst
+
+    use_mingw : Use the MinGW compiler instead of MSVC
+        Default = False
+
+    mingw_prefix : MinGW prefix
+        Default = os.getenv("MINGW_PREFIX", "")
+
+    use_llvm : Use the LLVM compiler
+        Default = False
+    ]]
 endfunction()
 
 #[===========================[ Target Generation ]===========================]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,14 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             FOLDER "godot-cpp"
     )
 
+    target_compile_options(  ${TARGET_NAME}
+            PRIVATE
+            # The test project uses utf-8 characters in its source files:
+            # example.h:282.283, and example.cpp:774,8775,778
+            # which require interpretation of source files as utf-8 by MSVC
+            $<${IS_MSVC}:/utf-8>
+    )
+
     # Only blank the suffix on osx to match SCons
     if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
         set_target_properties( ${TARGET_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,22 @@ foreach( TARGET_ALIAS template_debug template_release editor )
     set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
     set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )
 
+    ### Get useful properties of the library
+    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
+    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
+    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
+    get_target_property( OSX_ARCH       ${LINK_TARGET} OSX_ARCHITECTURES )
+
+    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
+
+    if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
+        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
+        set( OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}" )
+    else()
+        set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
+        set( OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}" )
+    endif()
+
     add_library( ${TARGET_NAME} SHARED EXCLUDE_FROM_ALL )
 
     target_sources( ${TARGET_NAME}
@@ -37,14 +53,6 @@ foreach( TARGET_ALIAS template_debug template_release editor )
     endif(   )
 
     target_link_libraries( ${TARGET_NAME} PRIVATE ${LINK_TARGET} )
-
-    ### Get useful properties of the library
-    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
-    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
-    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
-
-    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
 
     set_target_properties( ${TARGET_NAME}
             PROPERTIES
@@ -68,27 +76,20 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             PREFIX "lib"
             OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
 
+            #macos options, ignored on other platforms
+            OSX_ARCHITECTURES "${OSX_ARCH}"
+
+            # enable RPATH on MACOS, with the BUILD_RPATH_USE_ORIGIN
+            # this should allow loading libraries from relative paths on macos.
+            MACOSX_RPATH ON
+
             # Some IDE's respect this property to logically group targets
             FOLDER "godot-cpp"
     )
 
-    # CMAKE_SYSTEM_NAME refers to the target system
+    # Only blank the suffix on osx to match SCons
     if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-        get_target_property( OSX_ARCH ${LINK_TARGET} OSX_ARCHITECTURES )
-
-        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
-
-        set_target_properties( ${TARGET_NAME}
-                PROPERTIES
-                LIBRARY_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-                RUNTIME_OUTPUT_DIRECTORY "$<1:${OUTPUT_DIR}>"
-
-                OUTPUT_NAME "gdexample.macos.${TARGET_ALIAS}${DEV_TAG}"
-                SUFFIX ""
-
-                #macos options
-                OSX_ARCHITECTURES "${OSX_ARCH}"
-        )
+        set_target_properties( ${TARGET_NAME} PROPERTIES SUFFIX "" )
     endif ()
 
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             CXX_EXTENSIONS OFF
             CXX_VISIBILITY_PRESET ${GODOT_SYMBOL_VISIBILITY}
 
-            POSITION_INDEPENDENT_CODE ON
+            # This flag adds the runtime path at build time
             BUILD_RPATH_USE_ORIGIN ON
 
             # Try to ensure only static libraries are selected to be linked to.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,20 +21,10 @@ foreach( TARGET_ALIAS template_debug template_release editor )
     set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )
 
     ### Get useful properties of the library
-    get_target_property( GODOT_PLATFORM ${LINK_TARGET} GODOT_PLATFORM   )
-    get_target_property( GODOT_TARGET   ${LINK_TARGET} GODOT_TARGET     )
-    get_target_property( GODOT_ARCH     ${LINK_TARGET} GODOT_ARCH       )
+    get_target_property( GODOT_SUFFIX   ${LINK_TARGET} GODOT_SUFFIX      )
     get_target_property( OSX_ARCH       ${LINK_TARGET} OSX_ARCHITECTURES )
 
-    set( DEV_TAG "$<$<BOOL:${GODOT_DEV_BUILD}>:.dev>" )
-
-    if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-        set( OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TEST_TARGET}.framework")
-        set( OUTPUT_NAME "gdexample.macos.${TEST_TARGET}${DEV_TAG}" )
-    else()
-        set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-        set( OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}" )
-    endif()
+    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
 
     add_library( ${TARGET_NAME} SHARED EXCLUDE_FROM_ALL )
 
@@ -74,7 +64,7 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             PDB_OUTPUT_DIRECTORY     "$<1:${OUTPUT_DIR}>" #MSVC Only, ignored on other platforms
 
             PREFIX "lib"
-            OUTPUT_NAME "gdexample.${GODOT_PLATFORM}.${GODOT_TARGET}${DEV_TAG}.${GODOT_ARCH}"
+            OUTPUT_NAME "gdexample${GODOT_SUFFIX}"
 
             #macos options, ignored on other platforms
             OSX_ARCHITECTURES "${OSX_ARCH}"
@@ -89,7 +79,11 @@ foreach( TARGET_ALIAS template_debug template_release editor )
 
     # Only blank the suffix on osx to match SCons
     if( CMAKE_SYSTEM_NAME STREQUAL Darwin )
-        set_target_properties( ${TARGET_NAME} PROPERTIES SUFFIX "" )
+        set_target_properties( ${TARGET_NAME}
+                PROPERTIES
+                SUFFIX ""
+                OUTPUT_DIR "${OUTPUT_DIR}/libgdexample.macos.${TARGET_ALIAS}.framework"
+        )
     endif ()
 
 endforeach()


### PR DESCRIPTION
While working on actual features I ran into a fair few small refactors I could make to improve the quality of the solution that didnt necessarily square with the subject of said features.

This PR has each of these under a different commit and will require squashing before merging.
I don't know if this is an acceptable style of change though, so I'm making a draft PR to get feedback.

I can pull out any of these into their own PR or re-arrange as desired.

### List of changes:
#### SYSTEM_NAME
Was set using a list and then using regex replace on the ';' to transform it into a long string.
This was completely unnecessary as `string( APPEND` does the equivalent thing in one command

#### Update Target Properties
- Using rpath for a static library is irrelevant, needs to be set in consumers.
- Add INTERFACE_POSITION_INDEPENDENT_CODE to propogate flag to consumers.

#### Update macos.cmake and test target
- Add TODO for missing options
- Fix formatting
- Set GODOT_ARCH in case of arch being 'universal'
- Simplify the test project when SYSTEM_NAME is Darwin

#### Refactor common_compiler_flags.cmake
- remove incorrectly propagated target_compile_features
- remove GNU_ prefix on generic compiler version genex's
- remove line breaks for simple genex's
- make most flags private
- comments

#### Update Comments
- Add TODO items for missing options
- Add missing toolchain managed options commented out
- Homogenise Headings and block comments

#### replace ad-hock name construction with new GODOT_SUFFIX
- This replicates how SCons does it.
- Modify test project to use GODOT_SUFFIX
- Add GODOT_SUFFIX to libgodot-cpp properties

#### web suffix
 - set web shared lib suffix to bring web builds into line with SCons