### PR TITLE
Fix buffer overrun with enums pointers cast to int64_t* when enum is only 32-bit

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -2350,6 +2350,10 @@ def get_encoded_arg(arg_name, type_name, type_meta):
         result.append(f"\t{get_gdextension_type(arg_type)} {name}_encoded;")
         result.append(f"\tPtrToArg<{correct_type(type_name)}>::encode({name}, &{name}_encoded);")
         name = f"&{name}_encoded"
+    elif is_enum(type_name) and not is_bitfield(type_name):
+        result.append(f"\tint64_t {name}_encoded;")
+        result.append(f"\tPtrToArg<int64_t>::encode({name}, &{name}_encoded);")
+        name = f"&{name}_encoded"
     elif is_engine_class(type_name):
         # `{name}` is a C++ wrapper, it contains a field which is the object's pointer Godot expects.
         # We have to check `nullptr` because when the caller sends `nullptr`, the wrapper itself will be null.


### PR DESCRIPTION
This replaces https://github.com/godotengine/godot/pull/101639

Bug description (copied from that issue):
the affected code receives a pointer to an enum as a void pointer, and reinterpret casts it to an int64 pointer, probably because int64 is the size used for variants. But enums are not 64 bit by default, and the majority of enums in the godot codebase use the default size, which is usually int (32 bit on most platforms), and never larger unless absolutely needed, see [C++ standard on enum size](https://timsong-cpp.github.io/cppwp/n4140/dcl.enum#7)
Since the code immediately does a truncating C-style cast of this int64 to the enum type, the 4 extra bytes will be discarded immediately and not result in any program logic errors.

I verified my changes by diffing the `gen/` directories before and after my changes. As intended, only regular enums are affected, bitfields are already 64 bit and do not require an extra copy.