### PR TITLE
CMake: Fix #1690 - DEBUG_FEATURES generator expression

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -280,7 +280,7 @@ function( godotcpp_generate )
         set( TARGET_NAME "godot-cpp.${TARGET_ALIAS}" )
 
         # Generator Expressions that rely on the target
-        set( DEBUG_FEATURES "$<NOT:$<STREQUAL:${TARGET_NAME},template_release>>" )
+        set( DEBUG_FEATURES "$<NOT:$<STREQUAL:${TARGET_ALIAS},template_release>>" )
         set( HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},${DEBUG_FEATURES},$<BOOL:${GODOT_USE_HOT_RELOAD}>>" )
 
         # the godot-cpp.* library targets


### PR DESCRIPTION
As described in issue #1690 the expression needs to depend on TARGET_ALIAS not TARGET_NAME.

This was introduced when I was solving the naming conflict issues and I missed this usage.