### PR TITLE
SCons: fix #1672 Incorrect compiler detection in msystem based environments

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -204,7 +204,7 @@ def options(opts, env):
         default_platform = "linux"
     elif sys.platform == "darwin":
         default_platform = "macos"
-    elif sys.platform == "win32" or sys.platform == "msys":
+    elif sys.platform == "win32":
         default_platform = "windows"
     elif ARGUMENTS.get("platform", ""):
         default_platform = ARGUMENTS.get("platform")


### PR DESCRIPTION
As described in issue #1672 msys2 environments don't use a mingw prefix for their compiler binaries.

This patch detects MSYSTEM environment variable detects compilers directly