### PR TITLE
binding_generator.py: Don't error if directory already exists

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -285,7 +285,7 @@ def _generate_bindings(api, use_template_get_node, bits="64", precision="single"
     target_dir = Path(output_dir) / "gen"
 
     shutil.rmtree(target_dir, ignore_errors=True)
-    target_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True, exist_ok=True)
 
     real_t = "double" if precision == "double" else "float"
     print("Built-in type config: " + real_t + "_" + bits)


### PR DESCRIPTION
It should be ok when folds exist. It will fail to build without this patch,  in vs code on windows with compiler ( visual studio community 2022 amd 64) .