### PR TITLE
CMake: GodotCPPModule.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,6 @@ include( cmake/godotcpp.cmake )
 
 godotcpp_options()
 
-#[[ Python is required for code generation ]]
-find_package(Python3 3.4 REQUIRED) # pathlib should be present
-
 # Define our project.
 project( godot-cpp
         VERSION 4.4

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -23,6 +23,7 @@ project directive, it means that
   directive was
 
 ]=======================================================================]
+include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/GodotCPPModule.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/common_compiler_flags.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/android.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ios.cmake)
@@ -30,7 +31,7 @@ include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/linux.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/web.cmake)
 include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/windows.cmake)
-include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/python_callouts.cmake)
+
 
 # Detect number of processors
 include(ProcessorCount)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,9 +13,6 @@ file( GLOB_RECURSE DOC_XML
     CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml" )
 
-set( DOC_DATA_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/src/gen/doc_data.gen.cpp" )
-generate_doc_source( "${DOC_DATA_SOURCE}" "${DOC_XML}" )
-
 foreach( TARGET_ALIAS template_debug template_release editor )
     set( TARGET_NAME "godot-cpp.test.${TARGET_ALIAS}" )
 
@@ -30,12 +27,12 @@ foreach( TARGET_ALIAS template_debug template_release editor )
             src/tests.h
     )
 
-    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
-
     # conditionally add doc data to compile output
     if( TARGET_ALIAS MATCHES "editor|template_debug" )
-        target_sources( ${TARGET_NAME} PRIVATE "${DOC_DATA_SOURCE}" )
+        target_doc_sources( ${TARGET_NAME} ${DOC_XML} )
     endif()
+
+    set( OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/" )
 
     # Link to godot-cpp target
     set( LINK_TARGET "godot-cpp::${TARGET_ALIAS}" )


### PR DESCRIPTION
After @Naros pointed out that for orchestrator the doc_source.cpp file was not being generated it made me think that a more predictable and obvious method is desirable.

Changes:
* Renamed `python_callouts.cmake` to `GodotCPPModule.cmake`
* Moved the `find_package(Python3 3.4 REQUIRED)` to top of `GodotCPPModule.cmake` to guarantee its availability.
* Added `target_doc_sources` CMake function

It's typical of CMake projects to APPEND to the CMAKE_MODULES_PATH to include scripts from dependencies.
Renaming the `python_callouts.cmake` to `GodotCPPModule.cmake` creates a very clear location to place any CMake functionality which is public facing.

In consumer CMakeLists.txt it would be recommended that after including the godot-cpp project to:
```cmake
list(APPEND CMAKE_MODULE_PATH "${godot-cpp_SOURCE_DIR}/cmake")
include( GodotCPPModule )
```

To simpify the addition of documentation to a gdextension library a new function `target_doc_sources` has been created
which adds a dependency to generate the files on build. It also adds a new target `doc_gen` which will perform the doc_source.cpp generation on demand. (I can add this behind a flag, or leave it exposed by default or customise it to include the name of the target.)

This reduces the complexity of including documentation sources to a project by relieving the user of having to explicitly put the `OUTPUT_PATH` of the `generate_doc_source` function in the sources list of their target.

```cmake
add_library( my_extension SHARED )

target_sources( my_extension
        PRIVATE
        src/my_source.cpp
        src/my_source.h
        src/...
)

file( GLOB_RECURSE XML_FILES_LIST LIST_DIRECTORIES NO CONFIGURE_DEPENDS
    "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml" )

target_doc_sources( my_extension ${XML_FILES_LIST} )
```