### PR TITLE
CMake: Fix unknown architecture and simplify OSX_ARCHITECTURES

### DIFF
--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -5,6 +5,10 @@ MacOS
 This file contains functions for options and configuration for targeting the
 MacOS platform
 
+# To build universal binaries, ie targeting both x86_64 and arm64, use
+# the CMAKE_OSX_ARCHITECTURES variable prior to any project calls.
+# https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html
+
 ]=======================================================================]
 
 # Find Requirements
@@ -17,27 +21,10 @@ IF(APPLE)
         NO_DEFAULT_PATH)
 ENDIF (APPLE)
 
-
 function( macos_options )
-    # macos options here
 endfunction()
 
-
 function( macos_generate )
-
-    # OSX_ARCHITECTURES does not support generator expressions.
-    if( NOT GODOT_ARCH OR GODOT_ARCH STREQUAL universal )
-        set( OSX_ARCH "x86_64;arm64" )
-        set( SYSTEM_ARCH universal )
-    else()
-        set( OSX_ARCH ${GODOT_ARCH} )
-    endif()
-
-    set_target_properties( ${TARGET_NAME}
-            PROPERTIES
-
-            OSX_ARCHITECTURES "${OSX_ARCH}"
-    )
 
     target_compile_definitions(${TARGET_NAME}
             PUBLIC


### PR DESCRIPTION
It was brought to my attention that @Naros was getting builds with the architecture name tag set to `unknown`

This is cosmetic and doesnt effect the build, but did expose an underlying problem with how I was treating the `CMAKE_SYSTEM_PROCESSOR` flag, and how I was generating the `OUTPUT_NAME`

It also made me re-examine how I was treating the `OSX_ARCHITECTURES`, in light of the recent `MSVC_RUNTIME_LIBRARIES` #1701 discussion

Changes:
* Remove `GODOT_ARCH` option, it's managed by the toolchain files, or build vars.
* Rename `godot_arch_map` to `godot_arch_name` to better describe its use
* Add the known Android architectures to the `godot_arch_name` internal lists
* Return `${CMAKE_SYSTEM_PROCESSOR}` when architecture is unknown instead of `unknown`
* Remove all reference to `OSX_ARCHITECTURES`, and `universal` and provide links to documentation on how to use `OSX_ARCHITEXTURES` in the `cmake/macos.cmake` header

This simplifies the case for MacOS, iOS, and makes the resulting naming more predictable 