### PR TITLE
Style: Replace `_NO_DISCARD_` macro with `[[nodiscard]]`

### DIFF
--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -74,10 +74,6 @@ namespace godot {
 #endif
 #endif
 
-#ifndef _NO_DISCARD_
-#define _NO_DISCARD_ [[nodiscard]]
-#endif
-
 // Windows badly defines a lot of stuff we'll never use. Undefine it.
 #ifdef _WIN32
 #undef min // override standard definition

--- a/include/godot_cpp/variant/aabb.hpp
+++ b/include/godot_cpp/variant/aabb.hpp
@@ -43,7 +43,7 @@ namespace godot {
 
 class Variant;
 
-struct _NO_DISCARD_ AABB {
+struct [[nodiscard]] AABB {
 	Vector3 position;
 	Vector3 size;
 

--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -37,7 +37,7 @@
 
 namespace godot {
 
-struct _NO_DISCARD_ Basis {
+struct [[nodiscard]] Basis {
 	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),

--- a/include/godot_cpp/variant/color.hpp
+++ b/include/godot_cpp/variant/color.hpp
@@ -37,7 +37,7 @@ namespace godot {
 
 class String;
 
-struct _NO_DISCARD_ Color {
+struct [[nodiscard]] Color {
 	union {
 		struct {
 			float r;

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -38,7 +38,7 @@ namespace godot {
 
 class Variant;
 
-struct _NO_DISCARD_ Plane {
+struct [[nodiscard]] Plane {
 	Vector3 normal;
 	real_t d = 0;
 

--- a/include/godot_cpp/variant/projection.hpp
+++ b/include/godot_cpp/variant/projection.hpp
@@ -44,7 +44,7 @@ struct Rect2;
 struct Transform3D;
 struct Vector2;
 
-struct _NO_DISCARD_ Projection {
+struct [[nodiscard]] Projection {
 	enum Planes {
 		PLANE_NEAR,
 		PLANE_FAR,

--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -37,7 +37,7 @@
 
 namespace godot {
 
-struct _NO_DISCARD_ Quaternion {
+struct [[nodiscard]] Quaternion {
 	union {
 		struct {
 			real_t x;

--- a/include/godot_cpp/variant/rect2.hpp
+++ b/include/godot_cpp/variant/rect2.hpp
@@ -40,7 +40,7 @@ class String;
 struct Rect2i;
 struct Transform2D;
 
-struct _NO_DISCARD_ Rect2 {
+struct [[nodiscard]] Rect2 {
 	Point2 position;
 	Size2 size;
 

--- a/include/godot_cpp/variant/rect2i.hpp
+++ b/include/godot_cpp/variant/rect2i.hpp
@@ -39,7 +39,7 @@ namespace godot {
 class String;
 struct Rect2;
 
-struct _NO_DISCARD_ Rect2i {
+struct [[nodiscard]] Rect2i {
 	Point2i position;
 	Size2i size;
 

--- a/include/godot_cpp/variant/transform2d.hpp
+++ b/include/godot_cpp/variant/transform2d.hpp
@@ -39,7 +39,7 @@ namespace godot {
 
 class String;
 
-struct _NO_DISCARD_ Transform2D {
+struct [[nodiscard]] Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of columns array, the basis matrix looks like "on paper":
 	// M = (columns[0][0] columns[1][0])
 	//     (columns[0][1] columns[1][1])

--- a/include/godot_cpp/variant/transform3d.hpp
+++ b/include/godot_cpp/variant/transform3d.hpp
@@ -39,7 +39,7 @@
 
 namespace godot {
 
-struct _NO_DISCARD_ Transform3D {
+struct [[nodiscard]] Transform3D {
 	Basis basis;
 	Vector3 origin;
 

--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -39,7 +39,7 @@ namespace godot {
 class String;
 struct Vector2i;
 
-struct _NO_DISCARD_ Vector2 {
+struct [[nodiscard]] Vector2 {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -39,7 +39,7 @@ namespace godot {
 class String;
 struct Vector2;
 
-struct _NO_DISCARD_ Vector2i {
+struct [[nodiscard]] Vector2i {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -41,7 +41,7 @@ struct Basis;
 struct Vector2;
 struct Vector3i;
 
-struct _NO_DISCARD_ Vector3 {
+struct [[nodiscard]] Vector3 {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -39,7 +39,7 @@ namespace godot {
 class String;
 struct Vector3;
 
-struct _NO_DISCARD_ Vector3i {
+struct [[nodiscard]] Vector3i {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -38,7 +38,7 @@ namespace godot {
 
 class String;
 
-struct _NO_DISCARD_ Vector4 {
+struct [[nodiscard]] Vector4 {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {

--- a/include/godot_cpp/variant/vector4i.hpp
+++ b/include/godot_cpp/variant/vector4i.hpp
@@ -39,7 +39,7 @@ namespace godot {
 class String;
 struct Vector4;
 
-struct _NO_DISCARD_ Vector4i {
+struct [[nodiscard]] Vector4i {
 	static const int AXIS_COUNT = 4;
 
 	enum Axis {


### PR DESCRIPTION
- Related: godotengine/godot#90582

C++17 natively accepts the attribute syntax, so the macro was entirely vestigial.