### PR TITLE
Add support for `initializer_list` to Array and TypedArray

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -541,7 +541,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
         result.append("#include <godot_cpp/variant/vector4.hpp>")
         result.append("")
 
-    if is_packed_array(class_name):
+    if is_packed_array(class_name) or class_name == "Array":
         result.append("#include <godot_cpp/core/error_macros.hpp>")
         result.append("#include <initializer_list>")
         result.append("")
@@ -953,6 +953,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
 	_FORCE_INLINE_ ConstIterator begin() const;
 	_FORCE_INLINE_ ConstIterator end() const;
 	""")
+        result.append("\t_FORCE_INLINE_ Array(std::initializer_list<Variant> p_init);")
 
     if class_name == "Dictionary":
         result.append("\tconst Variant &operator[](const Variant &p_key) const;")

--- a/include/godot_cpp/variant/typed_array.hpp
+++ b/include/godot_cpp/variant/typed_array.hpp
@@ -53,6 +53,8 @@ public:
 			assign(p_array);
 		}
 	}
+	_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :
+			TypedArray(Array(p_init)) {}
 	_FORCE_INLINE_ TypedArray() {
 		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
 	}
@@ -67,6 +69,9 @@ public:
 		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
 			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
 			_ref(p_array);                                                                                       \
+		}                                                                                                        \
+		_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :                                       \
+				Array(Array(p_init), m_variant_type, StringName(), Variant()) {                                  \
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
 				TypedArray(Array(p_variant)) {                                                                   \

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -408,6 +408,15 @@ Array::ConstIterator Array::end() const {
 	return Array::ConstIterator(ptr() + size());
 }
 
+Array::Array(std::initializer_list<Variant> p_init) {
+	ERR_FAIL_COND(resize(p_init.size()) != 0);
+
+	size_t i = 0;
+	for (const Variant &element : p_init) {
+		set(i++, element);
+	}
+}
+
 #include <godot_cpp/variant/builtin_vararg_methods.hpp>
 
 #ifdef REAL_T_IS_DOUBLE


### PR DESCRIPTION
This PR adds support for initializer_list syntax, allowing `TypedArray`s to be assigned more easily, with syntax such as: `TypedArray<int> x = { 1, 2, 3 };`

Its a nice to have feature that I've found missing while developing gdextensions, I'm also writing a gdscript to gdextension transpiler and this syntax would help to make that possible.