### PR TITLE
CMake: Add generate_bindings custom target

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -252,6 +252,9 @@ function( godotcpp_generate )
             "${GODOT_PRECISION}"
             "${CMAKE_CURRENT_BINARY_DIR}" )
 
+    add_custom_target( godot-cpp.generate_bindings DEPENDS ${GENERATED_FILES_LIST} )
+    set_target_properties( godot-cpp.generate_bindings PROPERTIES FOLDER "godot-cpp" )
+
     ### Platform is derived from the toolchain target
     # See GeneratorExpressions PLATFORM_ID and CMAKE_SYSTEM_NAME
     string( CONCAT SYSTEM_NAME


### PR DESCRIPTION
I was working on something today and wanted to just generate the bindings separately to compilation.

This PR adds a custom target to do just that.

Would be the same as running SCons with build_library=no