### PR TITLE
CMake: template_debug as default target when godot-cpp is top level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,16 @@ function is run.
 
 The CMake equivalent is below.
 ]=======================================================================]
-
 include(cmake/godotcpp.cmake)
 
 godotcpp_options()
+
+#[[ People are compiling godot by itself and expecting template_debug
+Replace this with PROJECT_IS_TOP_LEVEL, <PROJECT-NAME>_IS_TOP_LEVEL when minimum reaches 3.21
+]]
+if(NOT PROJECT_NAME)
+    set(GODOTCPP_IS_TOP_LEVEL ON)
+endif()
 
 # Define our project.
 project(

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -330,8 +330,17 @@ function(godotcpp_generate)
             "$<$<NOT:${THREADS_ENABLED}>:.nothreads>"
         )
 
+        # People are compiling godot by itself.
+        set(EXCLUDE EXCLUDE_FROM_ALL)
+        if(GODOTCPP_IS_TOP_LEVEL)
+            if(TARGET_ALIAS STREQUAL template_debug)
+                set(EXCLUDE "")
+            endif()
+        endif()
+
         # the godot-cpp.* library targets
-        add_library(${TARGET_NAME} STATIC EXCLUDE_FROM_ALL)
+        add_library(${TARGET_NAME} STATIC ${EXCLUDE})
+
         add_library(godot-cpp::${TARGET_ALIAS} ALIAS ${TARGET_NAME})
 
         file(GLOB_RECURSE GODOTCPP_SOURCES LIST_DIRECTORIES NO CONFIGURE_DEPENDS src/*.cpp)


### PR DESCRIPTION
People seem to want to build godot-cpp by itself, without any arguments, not even specifying a target.

So we have to detect if we are top level and make template_debug available for the all target.

This can only happen when we are the top level target, because if we enable template_debug for all when we are part of something larger than its unnecessary compilation.

This adresses #1724 and duplicate #1727
