### PR TITLE
CMake: XCode dependency chain fixes

### DIFF
--- a/cmake/GodotCPPModule.cmake
+++ b/cmake/GodotCPPModule.cmake
@@ -116,6 +116,8 @@ function(
         DEPENDS ${godot-cpp_SOURCE_DIR}/binding_generator.py
         COMMENT "Generating bindings"
     )
+    add_custom_target(generate_bindings DEPENDS ${GENERATED_FILES_LIST})
+    set_target_properties(generate_bindings PROPERTIES FOLDER "godot-cpp")
 endfunction()
 
 #[[ Generate doc_data.cpp
@@ -145,19 +147,19 @@ function(generate_doc_source OUTPUT_PATH SOURCES)
         COMMAND "${Python3_EXECUTABLE}" "-c" "${PYTHON_SCRIPT}"
         VERBATIM
         WORKING_DIRECTORY "${godot-cpp_SOURCE_DIR}"
-        DEPENDS
         DEPENDS #
             "${godot-cpp_SOURCE_DIR}/doc_source_generator.py"
             "${SOURCES}"
         COMMENT "Generating: ${OUTPUT_PATH}"
     )
+    add_custom_target(generate_doc_source DEPENDS "${OUTPUT_PATH}")
+    set_target_properties(generate_doc_source PROPERTIES FOLDER "godot-cpp")
 endfunction()
 
 #[[ target_doc_sources
 A simpler interface to add xml files as doc source to a output target.
 TARGET: The gdexension library target
-SOURCES: a list of xml files to use for source generation and inclusion.
-This function also adds a doc_gen target to test source generation.]]
+SOURCES: a list of xml files to use for source generation and inclusion.]]
 function(target_doc_sources TARGET SOURCES)
     # set the generated file name
     set(DOC_SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/gen/doc_source.cpp")
@@ -169,11 +171,6 @@ function(target_doc_sources TARGET SOURCES)
     # Add DOC_SOURCE_FILE as a dependency to TARGET
     target_sources(${TARGET} PRIVATE "${DOC_SOURCE_FILE}")
 
-    # Create a dummy target that depends on the source so that users can
-    # test the file generation task.
-    if(TARGET doc_gen)
-    else()
-        add_custom_target(doc_gen)
-    endif()
-    target_sources(doc_gen PRIVATE "${DOC_SOURCE_FILE}")
+    # Without adding this dependency to the doc_source_generator, XCode will complain.
+    add_dependencies(${TARGET} generate_doc_source)
 endfunction()

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -271,9 +271,6 @@ function(godotcpp_generate)
             "${CMAKE_CURRENT_BINARY_DIR}"
     )
 
-    add_custom_target(godot-cpp.generate_bindings DEPENDS ${GENERATED_FILES_LIST})
-    set_target_properties(godot-cpp.generate_bindings PROPERTIES FOLDER "godot-cpp")
-
     ### Platform is derived from the toolchain target
     # See GeneratorExpressions PLATFORM_ID and CMAKE_SYSTEM_NAME
     string(
@@ -331,6 +328,9 @@ function(godotcpp_generate)
 
     # the godot-cpp.* library targets
     add_library(godot-cpp STATIC)
+
+    # Without adding this dependency to the binding generator, XCode will complain.
+    add_dependencies(godot-cpp generate_bindings)
 
     # Added for backwards compatibility with prior cmake solution so that builds dont immediately break
     # from a missing target.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,13 +7,6 @@ The Test target used to validate changes in the GitHub CI.
 
 message(STATUS "Testing Integration targets are enabled.")
 
-# Generate Doc Data
-file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
-
-set(DOC_SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/gen/doc_source.cpp")
-
-generate_doc_source( "${DOC_SOURCE_FILE}" ${DOC_XML} )
-
 set(TARGET_NAME "godot-cpp-test")
 
 add_library(${TARGET_NAME} SHARED EXCLUDE_FROM_ALL)
@@ -25,7 +18,8 @@ target_sources(
 
 # conditionally add doc data to compile output
 if(GODOTCPP_TARGET MATCHES "editor|template_debug")
-    target_sources(${TARGET_NAME} PRIVATE "${DOC_SOURCE_FILE}")
+    file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
+    target_doc_sources( ${TARGET_NAME} ${DOC_XML} )
 endif()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/")


### PR DESCRIPTION
This has been rebased onto #1733

I was working on the github CI and XCode was failing to compile due to the target dependency chain not meeting their requirements.

Turns out it has other implications for dependency generation that I found when compiling a real extension.

This PR brings the dependency chain inline with XCode's expectations, and simplifies some things.

Fixes https://github.com/godotengine/godot-cpp/issues/1739