### PR TITLE
Replace header guards style with `#pragma once`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# This file contains a list of Git commit hashes that should be hidden from the
+# regular Git history. Typically, this includes commits involving mass auto-formatting
+# or other normalizations. Commit hashes *must* use the full 40-character notation.
+# To apply the ignore list in your local Git client, you must run:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# This file is automatically used by GitHub.com's blame view.
+
+# Style: Replace header guards with `#pragma once`
+7056c996dd43ae1aa466c94d95cc2fe63853d8a9

--- a/binding_generator.py
+++ b/binding_generator.py
@@ -51,11 +51,7 @@ virtual $RETVAL _##m_name($FUNCARGS) $CONST override; \\
 def generate_wrappers(target):
     max_versions = 12
 
-    txt = """
-#ifndef GDEXTENSION_WRAPPERS_GEN_H
-#define GDEXTENSION_WRAPPERS_GEN_H
-
-"""
+    txt = "#pragma once"
 
     for i in range(max_versions + 1):
         txt += "\n/* Module Wrapper " + str(i) + " Arguments */\n"
@@ -63,8 +59,6 @@ def generate_wrappers(target):
         txt += generate_mod_version(i, False, True)
         txt += generate_mod_version(i, True, False)
         txt += generate_mod_version(i, True, True)
-
-    txt += "\n#endif\n"
 
     with open(target, "w", encoding="utf-8") as f:
         f.write(txt)
@@ -187,8 +181,7 @@ def generate_virtuals(target):
     max_versions = 12
 
     txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
-#ifndef GDEXTENSION_GDVIRTUAL_GEN_H
-#define GDEXTENSION_GDVIRTUAL_GEN_H
+#pragma once
 
 """
 
@@ -202,8 +195,6 @@ def generate_virtuals(target):
         txt += generate_virtual_version(i, False, True, True)
         txt += generate_virtual_version(i, True, False, True)
         txt += generate_virtual_version(i, True, True, True)
-
-    txt += "#endif // GDEXTENSION_GDVIRTUAL_GEN_H\n"
 
     with open(target, "w", encoding="utf-8") as f:
         f.write(txt)
@@ -359,11 +350,8 @@ def generate_builtin_bindings(api, output_dir, build_config):
         variant_size_source = []
         add_header("variant_size.hpp", variant_size_source)
 
-        header_guard = "GODOT_CPP_VARIANT_SIZE_HPP"
-        variant_size_source.append(f"#ifndef {header_guard}")
-        variant_size_source.append(f"#define {header_guard}")
+        variant_size_source.append("#pragma once")
         variant_size_source.append(f'#define GODOT_CPP_VARIANT_SIZE {builtin_sizes["Variant"]}')
-        variant_size_source.append(f"#endif // ! {header_guard}")
 
         variant_size_file.write("\n".join(variant_size_source))
 
@@ -443,8 +431,7 @@ def generate_builtin_bindings(api, output_dir, build_config):
         builtin_header = []
         add_header("builtin_types.hpp", builtin_header)
 
-        builtin_header.append("#ifndef GODOT_CPP_BUILTIN_TYPES_HPP")
-        builtin_header.append("#define GODOT_CPP_BUILTIN_TYPES_HPP")
+        builtin_header.append("#pragma once")
 
         builtin_header.append("")
 
@@ -459,8 +446,6 @@ def generate_builtin_bindings(api, output_dir, build_config):
 
         builtin_header.append("")
 
-        builtin_header.append("#endif // ! GODOT_CPP_BUILTIN_TYPES_HPP")
-
         builtin_header_file.write("\n".join(builtin_header))
 
     # Create a header with bindings for builtin types.
@@ -469,8 +454,7 @@ def generate_builtin_bindings(api, output_dir, build_config):
         builtin_binds = []
         add_header("builtin_binds.hpp", builtin_binds)
 
-        builtin_binds.append("#ifndef GODOT_CPP_BUILTIN_BINDS_HPP")
-        builtin_binds.append("#define GODOT_CPP_BUILTIN_BINDS_HPP")
+        builtin_binds.append("#pragma once")
         builtin_binds.append("")
         builtin_binds.append("#include <godot_cpp/variant/builtin_types.hpp>")
         builtin_binds.append("")
@@ -482,7 +466,6 @@ def generate_builtin_bindings(api, output_dir, build_config):
                         builtin_binds.append(f"VARIANT_ENUM_CAST({builtin_api['name']}::{enum_api['name']});")
 
         builtin_binds.append("")
-        builtin_binds.append("#endif // ! GODOT_CPP_BUILTIN_BINDS_HPP")
 
         builtin_binds_file.write("\n".join(builtin_binds))
 
@@ -498,9 +481,7 @@ def generate_builtin_class_vararg_method_implements_header(builtin_classes):
 
     add_header("builtin_vararg_methods.hpp", result)
 
-    header_guard = "GODOT_CPP_BUILTIN_VARARG_METHODS_HPP"
-    result.append(f"#ifndef {header_guard}")
-    result.append(f"#define {header_guard}")
+    result.append("#pragma once")
     result.append("")
     for builtin_api in builtin_classes:
         if "methods" not in builtin_api:
@@ -515,8 +496,6 @@ def generate_builtin_class_vararg_method_implements_header(builtin_classes):
             )
             result.append("")
 
-    result.append(f"#endif // ! {header_guard}")
-
     return "\n".join(result)
 
 
@@ -526,12 +505,9 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
     class_name = builtin_api["name"]
     snake_class_name = camel_to_snake(class_name).upper()
 
-    header_guard = f"GODOT_CPP_{snake_class_name}_HPP"
-
     add_header(f"{snake_class_name.lower()}.hpp", result)
 
-    result.append(f"#ifndef {header_guard}")
-    result.append(f"#define {header_guard}")
+    result.append("#pragma once")
 
     result.append("")
     result.append("#include <godot_cpp/core/defs.hpp>")
@@ -960,8 +936,6 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
     result.append("")
     result.append("} // namespace godot")
 
-    result.append("")
-    result.append(f"#endif // ! {header_guard}")
     result.append("")
 
     return "\n".join(result)
@@ -1493,9 +1467,7 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
         result = []
         add_header(f"{snake_struct_name}.hpp", result)
 
-        header_guard = f"GODOT_CPP_{snake_struct_name.upper()}_HPP"
-        result.append(f"#ifndef {header_guard}")
-        result.append(f"#define {header_guard}")
+        result.append("#pragma once")
 
         used_classes = []
         expanded_format = native_struct["format"].replace("(", " ").replace(")", ";").replace(",", ";")
@@ -1535,7 +1507,6 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
         result.append("")
         result.append("} // namespace godot")
         result.append("")
-        result.append(f"#endif // ! {header_guard}")
 
         with header_filename.open("w+", encoding="utf-8") as header_file:
             header_file.write("\n".join(result))
@@ -1551,11 +1522,7 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
 
     add_header(f"{snake_class_name.lower()}.hpp", result)
 
-    header_guard = f"GODOT_CPP_{snake_class_name}_HPP"
-
-    result.append(f"#ifndef {header_guard}")
-    result.append(f"#define {header_guard}")
-
+    result.append("#pragma once")
     result.append("")
 
     if len(fully_used_classes) > 0:
@@ -1844,7 +1811,6 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
         result.append("\t")
         result.append("")
 
-    result.append(f"#endif // ! {header_guard}")
     result.append("")
 
     return "\n".join(result)
@@ -2046,9 +2012,7 @@ def generate_global_constants(api, output_dir):
 
     header_filename = include_gen_folder / "global_constants.hpp"
 
-    header_guard = "GODOT_CPP_GLOBAL_CONSTANTS_HPP"
-    header.append(f"#ifndef {header_guard}")
-    header.append(f"#define {header_guard}")
+    header.append("#pragma once")
     header.append("")
     header.append("#include <cstdint>")
     header.append("")
@@ -2078,7 +2042,6 @@ def generate_global_constants(api, output_dir):
     header.append("} // namespace godot")
 
     header.append("")
-    header.append(f"#endif // ! {header_guard}")
 
     with header_filename.open("w+", encoding="utf-8") as header_file:
         header_file.write("\n".join(header))
@@ -2094,9 +2057,7 @@ def generate_version_header(api, output_dir):
 
     header_file_path = include_gen_folder / header_filename
 
-    header_guard = "GODOT_CPP_VERSION_HPP"
-    header.append(f"#ifndef {header_guard}")
-    header.append(f"#define {header_guard}")
+    header.append("#pragma once")
     header.append("")
 
     header.append(f"#define GODOT_VERSION_MAJOR {api['header']['version_major']}")
@@ -2105,8 +2066,6 @@ def generate_version_header(api, output_dir):
     header.append(f"#define GODOT_VERSION_STATUS \"{api['header']['version_status']}\"")
     header.append(f"#define GODOT_VERSION_BUILD \"{api['header']['version_build']}\"")
 
-    header.append("")
-    header.append(f"#endif // {header_guard}")
     header.append("")
 
     with header_file_path.open("w+", encoding="utf-8") as header_file:
@@ -2127,9 +2086,7 @@ def generate_global_constant_binds(api, output_dir):
 
     header_filename = include_gen_folder / "global_constants_binds.hpp"
 
-    header_guard = "GODOT_CPP_GLOBAL_CONSTANTS_BINDS_HPP"
-    header.append(f"#ifndef {header_guard}")
-    header.append(f"#define {header_guard}")
+    header.append("#pragma once")
     header.append("")
     header.append("#include <godot_cpp/classes/global_constants.hpp>")
     header.append("")
@@ -2147,8 +2104,6 @@ def generate_global_constant_binds(api, output_dir):
     header.append("VARIANT_ENUM_CAST(godot::Variant::Type);")
 
     header.append("")
-
-    header.append(f"#endif // ! {header_guard}")
 
     with header_filename.open("w+", encoding="utf-8") as header_file:
         header_file.write("\n".join(header))
@@ -2168,9 +2123,7 @@ def generate_utility_functions(api, output_dir):
 
     header_filename = include_gen_folder / "utility_functions.hpp"
 
-    header_guard = "GODOT_CPP_UTILITY_FUNCTIONS_HPP"
-    header.append(f"#ifndef {header_guard}")
-    header.append(f"#define {header_guard}")
+    header.append("#pragma once")
     header.append("")
     header.append("#include <godot_cpp/variant/builtin_types.hpp>")
     header.append("#include <godot_cpp/variant/variant.hpp>")
@@ -2209,7 +2162,6 @@ def generate_utility_functions(api, output_dir):
     header.append("")
     header.append("} // namespace godot")
     header.append("")
-    header.append(f"#endif // ! {header_guard}")
 
     with header_filename.open("w+", encoding="utf-8") as header_file:
         header_file.write("\n".join(header))

--- a/include/godot_cpp/classes/editor_plugin_registration.hpp
+++ b/include/godot_cpp/classes/editor_plugin_registration.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_EDITOR_PLUGIN_REGISTRATION_HPP
-#define GODOT_EDITOR_PLUGIN_REGISTRATION_HPP
+#pragma once
 
 #include <godot_cpp/templates/vector.hpp>
 
@@ -58,5 +57,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_EDITOR_PLUGIN_REGISTRATION_HPP

--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_REF_HPP
-#define GODOT_REF_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -284,5 +283,3 @@ struct GetTypeInfo<const Ref<T> &, typename EnableIf<TypeInherits<RefCounted, T>
 };
 
 } // namespace godot
-
-#endif // GODOT_REF_HPP

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_WRAPPED_HPP
-#define GODOT_WRAPPED_HPP
+#pragma once
 
 #include <godot_cpp/core/memory.hpp>
 
@@ -511,5 +510,3 @@ private:
 #define GDVIRTUAL_BIND(m_name, ...) ::godot::ClassDB::add_virtual_method(get_class_static(), _gdvirtual_##m_name##_get_method_info(), ::godot::snarray(__VA_ARGS__));
 #define GDVIRTUAL_IS_OVERRIDDEN(m_name) _gdvirtual_##m_name##_overridden()
 #define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overridden()
-
-#endif // GODOT_WRAPPED_HPP

--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_BINDER_COMMON_HPP
-#define GODOT_BINDER_COMMON_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 
@@ -692,5 +691,3 @@ void call_with_ptr_args_static_method_ret(R (*p_method)(P...), const GDExtension
 
 #include <godot_cpp/classes/global_constants_binds.hpp>
 #include <godot_cpp/variant/builtin_binds.hpp>
-
-#endif // GODOT_BINDER_COMMON_HPP

--- a/include/godot_cpp/core/builtin_ptrcall.hpp
+++ b/include/godot_cpp/core/builtin_ptrcall.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_BUILTIN_PTRCALL_HPP
-#define GODOT_BUILTIN_PTRCALL_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/object.hpp>
@@ -88,5 +87,3 @@ T _call_builtin_ptr_getter(const GDExtensionPtrGetter getter, GDExtensionConstTy
 } // namespace internal
 
 } // namespace godot
-
-#endif // GODOT_BUILTIN_PTRCALL_HPP

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CLASS_DB_HPP
-#define GODOT_CLASS_DB_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 
@@ -370,5 +369,3 @@ MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, StringName p_name, M p
 } // namespace godot
 
 CLASSDB_SINGLETON_VARIANT_CAST;
-
-#endif // GODOT_CLASS_DB_HPP

--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_DEFS_HPP
-#define GODOT_DEFS_HPP
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -130,5 +129,3 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 // To maintain compatibility an alias is defined outside the namespace.
 // Consider it deprecated.
 using real_t = godot::real_t;
-
-#endif // GODOT_DEFS_HPP

--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_ENGINE_PTRCALL_HPP
-#define GODOT_ENGINE_PTRCALL_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 
@@ -93,5 +92,3 @@ void _call_utility_no_ret(const GDExtensionPtrUtilityFunction func, const Args &
 } // namespace internal
 
 } // namespace godot
-
-#endif // GODOT_ENGINE_PTRCALL_HPP

--- a/include/godot_cpp/core/error_macros.hpp
+++ b/include/godot_cpp/core/error_macros.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_ERROR_MACROS_HPP
-#define GODOT_ERROR_MACROS_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -802,5 +801,3 @@ void _err_flush_stdout();
 #define CHECK_METHOD_BIND_RET(m_mb, m_ret)
 #define CHECK_METHOD_BIND(m_mb)
 #endif
-
-#endif // GODOT_ERROR_MACROS_HPP

--- a/include/godot_cpp/core/math.hpp
+++ b/include/godot_cpp/core/math.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_MATH_HPP
-#define GODOT_MATH_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -815,5 +814,3 @@ inline float snap_scalar_separation(float p_offset, float p_step, float p_target
 
 } // namespace Math
 } // namespace godot
-
-#endif // GODOT_MATH_HPP

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_MEMORY_HPP
-#define GODOT_MEMORY_HPP
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -216,5 +215,3 @@ struct _GlobalNilClass {
 };
 
 } // namespace godot
-
-#endif // GODOT_MEMORY_HPP

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_METHOD_BIND_HPP
-#define GODOT_METHOD_BIND_HPP
+#pragma once
 
 #include <godot_cpp/core/binder_common.hpp>
 #include <godot_cpp/core/type_info.hpp>
@@ -731,5 +730,3 @@ MethodBind *create_static_method_bind(R (*p_method)(P...)) {
 }
 
 } // namespace godot
-
-#endif // GODOT_METHOD_BIND_HPP

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_METHOD_PTRCALL_HPP
-#define GODOT_METHOD_PTRCALL_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -234,5 +233,3 @@ GDVIRTUAL_NATIVE_PTR(float);
 GDVIRTUAL_NATIVE_PTR(double);
 
 } // namespace godot
-
-#endif // GODOT_METHOD_PTRCALL_HPP

--- a/include/godot_cpp/core/mutex_lock.hpp
+++ b/include/godot_cpp/core/mutex_lock.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_MUTEX_LOCK_HPP
-#define GODOT_MUTEX_LOCK_HPP
+#pragma once
 
 #include <godot_cpp/classes/mutex.hpp>
 
@@ -55,5 +54,3 @@ public:
 #define _THREAD_SAFE_UNLOCK_ _thread_safe_.unlock();
 
 } // namespace godot
-
-#endif // GODOT_MUTEX_LOCK_HPP

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_OBJECT_HPP
-#define GODOT_OBJECT_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -148,5 +147,3 @@ const T *Object::cast_to(const Object *p_object) {
 }
 
 } // namespace godot
-
-#endif // GODOT_OBJECT_HPP

--- a/include/godot_cpp/core/object_id.hpp
+++ b/include/godot_cpp/core/object_id.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_OBJECT_ID_HPP
-#define GODOT_OBJECT_ID_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -58,5 +57,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_OBJECT_ID_HPP

--- a/include/godot_cpp/core/print_string.hpp
+++ b/include/godot_cpp/core/print_string.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_PRINT_STRING_HPP
-#define GODOT_PRINT_STRING_HPP
+#pragma once
 
 #include <godot_cpp/variant/utility_functions.hpp>
 
@@ -69,5 +68,3 @@ void print_verbose(const Variant &p_variant, Args... p_args) {
 bool is_print_verbose_enabled();
 
 } // namespace godot
-
-#endif // GODOT_PRINT_STRING_HPP

--- a/include/godot_cpp/core/property_info.hpp
+++ b/include/godot_cpp/core/property_info.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_PROPERTY_INFO_HPP
-#define GODOT_PROPERTY_INFO_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -128,5 +127,3 @@ struct PropertyInfo {
 };
 
 } // namespace godot
-
-#endif // GODOT_PROPERTY_INFO_HPP

--- a/include/godot_cpp/core/type_info.hpp
+++ b/include/godot_cpp/core/type_info.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_TYPE_INFO_HPP
-#define GODOT_TYPE_INFO_HPP
+#pragma once
 
 #include <godot_cpp/core/object.hpp>
 #include <godot_cpp/variant/typed_array.hpp>
@@ -416,5 +415,3 @@ MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
 #define CLASS_INFO(m_type) (GetTypeInfo<m_type *>::get_class_info())
 
 } // namespace godot
-
-#endif // GODOT_TYPE_INFO_HPP

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_GODOT_HPP
-#define GODOT_GODOT_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 
@@ -265,5 +264,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_GODOT_HPP

--- a/include/godot_cpp/templates/cowdata.hpp
+++ b/include/godot_cpp/templates/cowdata.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_COWDATA_HPP
-#define GODOT_COWDATA_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/core/error_macros.hpp>
@@ -488,5 +487,3 @@ CowData<T>::~CowData() {
 #endif
 
 } // namespace godot
-
-#endif // GODOT_COWDATA_HPP

--- a/include/godot_cpp/templates/hash_map.hpp
+++ b/include/godot_cpp/templates/hash_map.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_HASH_MAP_HPP
-#define GODOT_HASH_MAP_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -587,5 +586,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_HASH_MAP_HPP

--- a/include/godot_cpp/templates/hash_set.hpp
+++ b/include/godot_cpp/templates/hash_set.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_HASH_SET_HPP
-#define GODOT_HASH_SET_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -473,5 +472,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_HASH_SET_HPP

--- a/include/godot_cpp/templates/hashfuncs.hpp
+++ b/include/godot_cpp/templates/hashfuncs.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_HASHFUNCS_HPP
-#define GODOT_HASHFUNCS_HPP
+#pragma once
 
 // Needed for fastmod.
 #if defined(_MSC_VER)
@@ -522,5 +521,3 @@ static _FORCE_INLINE_ uint32_t fastmod(const uint32_t n, const uint64_t c, const
 }
 
 } // namespace godot
-
-#endif // GODOT_HASHFUNCS_HPP

--- a/include/godot_cpp/templates/list.hpp
+++ b/include/godot_cpp/templates/list.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_LIST_HPP
-#define GODOT_LIST_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -783,5 +782,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_LIST_HPP

--- a/include/godot_cpp/templates/local_vector.hpp
+++ b/include/godot_cpp/templates/local_vector.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_LOCAL_VECTOR_HPP
-#define GODOT_LOCAL_VECTOR_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -339,5 +338,3 @@ template <typename T, typename U = uint32_t, bool force_trivial = false>
 using TightLocalVector = LocalVector<T, U, force_trivial, true>;
 
 } // namespace godot
-
-#endif // GODOT_LOCAL_VECTOR_HPP

--- a/include/godot_cpp/templates/pair.hpp
+++ b/include/godot_cpp/templates/pair.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_PAIR_HPP
-#define GODOT_PAIR_HPP
+#pragma once
 
 namespace godot {
 
@@ -103,5 +102,3 @@ struct KeyValueSort {
 };
 
 } // namespace godot
-
-#endif // GODOT_PAIR_HPP

--- a/include/godot_cpp/templates/rb_map.hpp
+++ b/include/godot_cpp/templates/rb_map.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_RB_MAP_HPP
-#define GODOT_RB_MAP_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/memory.hpp>
@@ -761,5 +760,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_RB_MAP_HPP

--- a/include/godot_cpp/templates/rb_set.hpp
+++ b/include/godot_cpp/templates/rb_set.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_RB_SET_HPP
-#define GODOT_RB_SET_HPP
+#pragma once
 
 #include <godot_cpp/core/memory.hpp>
 
@@ -710,5 +709,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_RB_SET_HPP

--- a/include/godot_cpp/templates/rid_owner.hpp
+++ b/include/godot_cpp/templates/rid_owner.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_RID_OWNER_HPP
-#define GODOT_RID_OWNER_HPP
+#pragma once
 
 #include <godot_cpp/core/memory.hpp>
 #include <godot_cpp/godot.hpp>
@@ -461,5 +460,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_RID_OWNER_HPP

--- a/include/godot_cpp/templates/safe_refcount.hpp
+++ b/include/godot_cpp/templates/safe_refcount.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_SAFE_REFCOUNT_HPP
-#define GODOT_SAFE_REFCOUNT_HPP
+#pragma once
 
 #if !defined(NO_THREADS)
 
@@ -331,5 +330,3 @@ public:
 #endif
 
 } // namespace godot
-
-#endif // GODOT_SAFE_REFCOUNT_HPP

--- a/include/godot_cpp/templates/search_array.hpp
+++ b/include/godot_cpp/templates/search_array.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_SEARCH_ARRAY_HPP
-#define GODOT_SEARCH_ARRAY_HPP
+#pragma once
 
 #include <godot_cpp/templates/sort_array.hpp>
 
@@ -67,5 +66,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_SEARCH_ARRAY_HPP

--- a/include/godot_cpp/templates/self_list.hpp
+++ b/include/godot_cpp/templates/self_list.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_SELF_LIST_HPP
-#define GODOT_SELF_LIST_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/core/error_macros.hpp>
@@ -139,5 +138,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_SELF_LIST_HPP

--- a/include/godot_cpp/templates/sort_array.hpp
+++ b/include/godot_cpp/templates/sort_array.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_SORT_ARRAY_HPP
-#define GODOT_SORT_ARRAY_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 
@@ -319,5 +318,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_SORT_ARRAY_HPP

--- a/include/godot_cpp/templates/spin_lock.hpp
+++ b/include/godot_cpp/templates/spin_lock.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_SPIN_LOCK_HPP
-#define GODOT_SPIN_LOCK_HPP
+#pragma once
 
 #include <atomic>
 
@@ -50,5 +49,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_SPIN_LOCK_HPP

--- a/include/godot_cpp/templates/thread_work_pool.hpp
+++ b/include/godot_cpp/templates/thread_work_pool.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_THREAD_WORK_POOL_HPP
-#define GODOT_THREAD_WORK_POOL_HPP
+#pragma once
 
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/semaphore.hpp>
@@ -201,5 +200,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_THREAD_WORK_POOL_HPP

--- a/include/godot_cpp/templates/vector.hpp
+++ b/include/godot_cpp/templates/vector.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR_HPP
-#define GODOT_VECTOR_HPP
+#pragma once
 
 /**
  * @class Vector
@@ -332,5 +331,3 @@ void Vector<T>::fill(T p_elem) {
 }
 
 } // namespace godot
-
-#endif // GODOT_VECTOR_HPP

--- a/include/godot_cpp/templates/vmap.hpp
+++ b/include/godot_cpp/templates/vmap.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VMAP_HPP
-#define GODOT_VMAP_HPP
+#pragma once
 
 #include <godot_cpp/templates/cowdata.hpp>
 
@@ -200,5 +199,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_VMAP_HPP

--- a/include/godot_cpp/templates/vset.hpp
+++ b/include/godot_cpp/templates/vset.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VSET_HPP
-#define GODOT_VSET_HPP
+#pragma once
 
 #include <godot_cpp/templates/vector.hpp>
 
@@ -141,5 +140,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_VSET_HPP

--- a/include/godot_cpp/variant/aabb.hpp
+++ b/include/godot_cpp/variant/aabb.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_AABB_HPP
-#define GODOT_AABB_HPP
+#pragma once
 
 #include <godot_cpp/variant/plane.hpp>
 #include <godot_cpp/variant/vector3.hpp>
@@ -491,5 +490,3 @@ AABB AABB::quantized(real_t p_unit) const {
 }
 
 } // namespace godot
-
-#endif // GODOT_AABB_HPP

--- a/include/godot_cpp/variant/array_helpers.hpp
+++ b/include/godot_cpp/variant/array_helpers.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_ARRAY_HELPERS_HPP
-#define GODOT_ARRAY_HELPERS_HPP
+#pragma once
 
 namespace godot {
 namespace helpers {
@@ -51,5 +50,3 @@ T append_all(T appendable) {
 }
 } // namespace helpers
 } // namespace godot
-
-#endif // GODOT_ARRAY_HELPERS_HPP

--- a/include/godot_cpp/variant/basis.hpp
+++ b/include/godot_cpp/variant/basis.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_BASIS_HPP
-#define GODOT_BASIS_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/variant/quaternion.hpp>
@@ -315,5 +314,3 @@ real_t Basis::determinant() const {
 }
 
 } // namespace godot
-
-#endif // GODOT_BASIS_HPP

--- a/include/godot_cpp/variant/callable_custom.hpp
+++ b/include/godot_cpp/variant/callable_custom.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CALLABLE_CUSTOM_HPP
-#define GODOT_CALLABLE_CUSTOM_HPP
+#pragma once
 
 #include <godot_cpp/core/object_id.hpp>
 #include <godot_cpp/variant/string_name.hpp>
@@ -61,5 +60,3 @@ public:
 };
 
 } // namespace godot
-
-#endif // GODOT_CALLABLE_CUSTOM_HPP

--- a/include/godot_cpp/variant/callable_method_pointer.hpp
+++ b/include/godot_cpp/variant/callable_method_pointer.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CALLABLE_METHOD_POINTER_HPP
-#define GODOT_CALLABLE_METHOD_POINTER_HPP
+#pragma once
 
 #include <godot_cpp/core/binder_common.hpp>
 #include <godot_cpp/variant/variant.hpp>
@@ -269,5 +268,3 @@ Callable create_custom_callable_static_function_pointer(R (*p_method)(P...)) {
 #define callable_mp_static(M) ::godot::create_custom_callable_static_function_pointer(M)
 
 } // namespace godot
-
-#endif // GODOT_CALLABLE_METHOD_POINTER_HPP

--- a/include/godot_cpp/variant/char_string.hpp
+++ b/include/godot_cpp/variant/char_string.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CHAR_STRING_HPP
-#define GODOT_CHAR_STRING_HPP
+#pragma once
 
 #include <godot_cpp/templates/cowdata.hpp>
 
@@ -138,5 +137,3 @@ typedef CharStringT<char32_t> Char32String;
 typedef CharStringT<wchar_t> CharWideString;
 
 } // namespace godot
-
-#endif // GODOT_CHAR_STRING_HPP

--- a/include/godot_cpp/variant/char_utils.hpp
+++ b/include/godot_cpp/variant/char_utils.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_CHAR_UTILS_HPP
-#define GODOT_CHAR_UTILS_HPP
+#pragma once
 
 static _FORCE_INLINE_ bool is_ascii_upper_case(char32_t c) {
 	return (c >= 'A' && c <= 'Z');
@@ -86,5 +85,3 @@ static _FORCE_INLINE_ bool is_punct(char32_t p_char) {
 static _FORCE_INLINE_ bool is_underscore(char32_t p_char) {
 	return (p_char == '_');
 }
-
-#endif // GODOT_CHAR_UTILS_HPP

--- a/include/godot_cpp/variant/color.hpp
+++ b/include/godot_cpp/variant/color.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_COLOR_HPP
-#define GODOT_COLOR_HPP
+#pragma once
 
 #include <godot_cpp/core/math.hpp>
 
@@ -285,5 +284,3 @@ _FORCE_INLINE_ Color operator*(float p_scalar, const Color &p_color) {
 }
 
 } // namespace godot
-
-#endif // GODOT_COLOR_HPP

--- a/include/godot_cpp/variant/color_names.inc.hpp
+++ b/include/godot_cpp/variant/color_names.inc.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_COLOR_NAMES_INC_HPP
-#define GODOT_COLOR_NAMES_INC_HPP
+#pragma once
 
 namespace godot {
 
@@ -192,5 +191,3 @@ static NamedColor named_colors[] = {
 };
 
 } // namespace godot
-
-#endif // GODOT_COLOR_NAMES_INC_HPP

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_PLANE_HPP
-#define GODOT_PLANE_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/variant/vector3.hpp>
@@ -137,5 +136,3 @@ bool Plane::operator!=(const Plane &p_plane) const {
 }
 
 } // namespace godot
-
-#endif // GODOT_PLANE_HPP

--- a/include/godot_cpp/variant/projection.hpp
+++ b/include/godot_cpp/variant/projection.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_PROJECTION_HPP
-#define GODOT_PROJECTION_HPP
+#pragma once
 
 #include <godot_cpp/core/math.hpp>
 #include <godot_cpp/variant/vector3.hpp>
@@ -167,5 +166,3 @@ Vector3 Projection::xform(const Vector3 &p_vec3) const {
 }
 
 } // namespace godot
-
-#endif // GODOT_PROJECTION_HPP

--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_QUATERNION_HPP
-#define GODOT_QUATERNION_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -232,5 +231,3 @@ _FORCE_INLINE_ Quaternion operator*(real_t p_real, const Quaternion &p_quaternio
 }
 
 } // namespace godot
-
-#endif // GODOT_QUATERNION_HPP

--- a/include/godot_cpp/variant/rect2.hpp
+++ b/include/godot_cpp/variant/rect2.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_RECT2_HPP
-#define GODOT_RECT2_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/variant/vector2.hpp>
@@ -369,5 +368,3 @@ struct [[nodiscard]] Rect2 {
 };
 
 } // namespace godot
-
-#endif // GODOT_RECT2_HPP

--- a/include/godot_cpp/variant/rect2i.hpp
+++ b/include/godot_cpp/variant/rect2i.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_RECT2I_HPP
-#define GODOT_RECT2I_HPP
+#pragma once
 
 #include <godot_cpp/classes/global_constants.hpp>
 #include <godot_cpp/variant/vector2i.hpp>
@@ -241,5 +240,3 @@ struct [[nodiscard]] Rect2i {
 };
 
 } // namespace godot
-
-#endif // GODOT_RECT2I_HPP

--- a/include/godot_cpp/variant/transform2d.hpp
+++ b/include/godot_cpp/variant/transform2d.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_TRANSFORM2D_HPP
-#define GODOT_TRANSFORM2D_HPP
+#pragma once
 
 #include <godot_cpp/variant/packed_vector2_array.hpp>
 #include <godot_cpp/variant/rect2.hpp>
@@ -247,5 +246,3 @@ PackedVector2Array Transform2D::xform_inv(const PackedVector2Array &p_array) con
 }
 
 } // namespace godot
-
-#endif // GODOT_TRANSFORM2D_HPP

--- a/include/godot_cpp/variant/transform3d.hpp
+++ b/include/godot_cpp/variant/transform3d.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_TRANSFORM3D_HPP
-#define GODOT_TRANSFORM3D_HPP
+#pragma once
 
 #include <godot_cpp/core/math.hpp>
 #include <godot_cpp/variant/aabb.hpp>
@@ -272,5 +271,3 @@ _FORCE_INLINE_ Plane Transform3D::xform_inv_fast(const Plane &p_plane, const Tra
 }
 
 } // namespace godot
-
-#endif // GODOT_TRANSFORM3D_HPP

--- a/include/godot_cpp/variant/typed_array.hpp
+++ b/include/godot_cpp/variant/typed_array.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_TYPED_ARRAY_HPP
-#define GODOT_TYPED_ARRAY_HPP
+#pragma once
 
 #include <godot_cpp/variant/array.hpp>
 #include <godot_cpp/variant/variant.hpp>
@@ -138,5 +137,3 @@ MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
 #undef MAKE_TYPED_ARRAY
 
 } // namespace godot
-
-#endif // GODOT_TYPED_ARRAY_HPP

--- a/include/godot_cpp/variant/typed_dictionary.hpp
+++ b/include/godot_cpp/variant/typed_dictionary.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_TYPED_DICTIONARY_HPP
-#define GODOT_TYPED_DICTIONARY_HPP
+#pragma once
 
 #include <godot_cpp/core/type_info.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
@@ -435,5 +434,3 @@ MAKE_TYPED_DICTIONARY_INFO(IPAddress, Variant::STRING)
 #undef MAKE_TYPED_DICTIONARY_INFO_WITH_OBJECT
 
 } // namespace godot
-
-#endif // GODOT_TYPED_DICTIONARY_HPP

--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VARIANT_HPP
-#define GODOT_VARIANT_HPP
+#pragma once
 
 #include <godot_cpp/core/defs.hpp>
 
@@ -367,5 +366,3 @@ using PackedRealArray = PackedFloat32Array;
 #endif // REAL_T_IS_DOUBLE
 
 } // namespace godot
-
-#endif // GODOT_VARIANT_HPP

--- a/include/godot_cpp/variant/variant_internal.hpp
+++ b/include/godot_cpp/variant/variant_internal.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VARIANT_INTERNAL_HPP
-#define GODOT_VARIANT_INTERNAL_HPP
+#pragma once
 
 #include <gdextension_interface.h>
 #include <godot_cpp/variant/variant.hpp>
@@ -505,5 +504,3 @@ struct VariantDefaultInitializer {
 };
 
 } // namespace godot
-
-#endif // GODOT_VARIANT_INTERNAL_HPP

--- a/include/godot_cpp/variant/vector2.hpp
+++ b/include/godot_cpp/variant/vector2.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR2_HPP
-#define GODOT_VECTOR2_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -330,5 +329,3 @@ typedef Vector2 Size2;
 typedef Vector2 Point2;
 
 } // namespace godot
-
-#endif // GODOT_VECTOR2_HPP

--- a/include/godot_cpp/variant/vector2i.hpp
+++ b/include/godot_cpp/variant/vector2i.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR2I_HPP
-#define GODOT_VECTOR2I_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -168,5 +167,3 @@ typedef Vector2i Size2i;
 typedef Vector2i Point2i;
 
 } // namespace godot
-
-#endif // GODOT_VECTOR2I_HPP

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR3_HPP
-#define GODOT_VECTOR3_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -537,5 +536,3 @@ Vector3 Vector3::reflect(const Vector3 &p_normal) const {
 }
 
 } // namespace godot
-
-#endif // GODOT_VECTOR3_HPP

--- a/include/godot_cpp/variant/vector3i.hpp
+++ b/include/godot_cpp/variant/vector3i.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR3I_HPP
-#define GODOT_VECTOR3I_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -339,5 +338,3 @@ void Vector3i::zero() {
 }
 
 } // namespace godot
-
-#endif // GODOT_VECTOR3I_HPP

--- a/include/godot_cpp/variant/vector4.hpp
+++ b/include/godot_cpp/variant/vector4.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR4_HPP
-#define GODOT_VECTOR4_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -319,5 +318,3 @@ _FORCE_INLINE_ Vector4 operator*(const int64_t p_scalar, const Vector4 &p_vec) {
 }
 
 } // namespace godot
-
-#endif // GODOT_VECTOR4_HPP

--- a/include/godot_cpp/variant/vector4i.hpp
+++ b/include/godot_cpp/variant/vector4i.hpp
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef GODOT_VECTOR4I_HPP
-#define GODOT_VECTOR4I_HPP
+#pragma once
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
@@ -367,5 +366,3 @@ void Vector4i::zero() {
 }
 
 } // namespace godot
-
-#endif // GODOT_VECTOR4I_HPP

--- a/misc/scripts/header_guards.py
+++ b/misc/scripts/header_guards.py
@@ -2,121 +2,82 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from pathlib import Path
 
 if len(sys.argv) < 2:
     print("Invalid usage of header_guards.py, it should be called with a path to one or multiple files.")
     sys.exit(1)
 
-HEADER_CHECK_OFFSET = 30
-HEADER_BEGIN_OFFSET = 31
-HEADER_END_OFFSET = -1
-
 changed = []
 invalid = []
 
 for file in sys.argv[1:]:
-    with open(file, "rt", encoding="utf-8", newline="\n") as f:
+    header_start = -1
+    header_end = -1
+
+    with open(file.strip(), "rt", encoding="utf-8", newline="\n") as f:
         lines = f.readlines()
 
-    if len(lines) <= HEADER_BEGIN_OFFSET:
-        continue  # Most likely a dummy file.
+    for idx, line in enumerate(lines):
+        sline = line.strip()
 
-    if lines[HEADER_CHECK_OFFSET].startswith("#import"):
-        continue  # Early catch obj-c file.
+        if header_start < 0:
+            if sline == "":  # Skip empty lines at the top.
+                continue
 
-    name = f"GODOT_{Path(file).name}".upper().replace(".", "_").replace("-", "_").replace(" ", "_")
+            if sline.startswith("/**********"):  # Godot header starts this way.
+                header_start = idx
+            else:
+                header_end = 0  # There is no Godot header.
+                break
+        else:
+            if not sline.startswith(("*", "/*")):  # Not in the Godot header anymore.
+                header_end = idx + 1  # The guard should be two lines below the Godot header.
+                break
 
-    HEADER_CHECK = f"#ifndef {name}\n"
-    HEADER_BEGIN = f"#define {name}\n"
-    HEADER_END = f"#endif // {name}\n"
-
-    if (
-        lines[HEADER_CHECK_OFFSET] == HEADER_CHECK
-        and lines[HEADER_BEGIN_OFFSET] == HEADER_BEGIN
-        and lines[HEADER_END_OFFSET] == HEADER_END
-    ):
+    if (HEADER_CHECK_OFFSET := header_end) < 0 or HEADER_CHECK_OFFSET >= len(lines):
+        invalid.append(file)
         continue
 
-    # Guards might exist but with the wrong names.
+    if lines[HEADER_CHECK_OFFSET].startswith("#pragma once"):
+        continue
+
+    # Might be using legacy header guards.
+    HEADER_BEGIN_OFFSET = HEADER_CHECK_OFFSET + 1
+    HEADER_END_OFFSET = len(lines) - 1
+
+    if HEADER_BEGIN_OFFSET >= HEADER_END_OFFSET:
+        invalid.append(file)
+        continue
+
     if (
         lines[HEADER_CHECK_OFFSET].startswith("#ifndef")
         and lines[HEADER_BEGIN_OFFSET].startswith("#define")
         and lines[HEADER_END_OFFSET].startswith("#endif")
     ):
-        lines[HEADER_CHECK_OFFSET] = HEADER_CHECK
-        lines[HEADER_BEGIN_OFFSET] = HEADER_BEGIN
-        lines[HEADER_END_OFFSET] = HEADER_END
+        lines[HEADER_CHECK_OFFSET] = "#pragma once"
+        lines[HEADER_BEGIN_OFFSET] = "\n"
+        lines.pop()
         with open(file, "wt", encoding="utf-8", newline="\n") as f:
             f.writelines(lines)
         changed.append(file)
         continue
 
-    header_check = -1
-    header_begin = -1
-    header_end = -1
-    pragma_once = -1
-    objc = False
-
-    for idx, line in enumerate(lines):
-        if not line.startswith("#"):
-            continue
-        elif line.startswith("#ifndef") and header_check == -1:
-            header_check = idx
-        elif line.startswith("#define") and header_begin == -1:
-            header_begin = idx
-        elif line.startswith("#endif") and header_end == -1:
-            header_end = idx
-        elif line.startswith("#pragma once"):
-            pragma_once = idx
-            break
-        elif line.startswith("#import"):
-            objc = True
+    # Verify `#pragma once` doesn't exist at invalid location.
+    misplaced = False
+    for line in lines:
+        if line.startswith("#pragma once"):
+            misplaced = True
             break
 
-    if objc:
+    if misplaced:
+        invalid.append(file)
         continue
 
-    if pragma_once != -1:
-        lines.pop(pragma_once)
-        lines.insert(HEADER_CHECK_OFFSET, HEADER_CHECK)
-        lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
-        lines.append("\n")
-        lines.append(HEADER_END)
-        with open(file, "wt", encoding="utf-8", newline="\n") as f:
-            f.writelines(lines)
-        changed.append(file)
-        continue
-
-    if header_check == -1 and header_begin == -1 and header_end == -1:
-        # Guards simply didn't exist
-        lines.insert(HEADER_CHECK_OFFSET, HEADER_CHECK)
-        lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
-        lines.append("\n")
-        lines.append(HEADER_END)
-        with open(file, "wt", encoding="utf-8", newline="\n") as f:
-            f.writelines(lines)
-        changed.append(file)
-        continue
-
-    if header_check != -1 and header_begin != -1 and header_end != -1:
-        # All prepends "found", see if we can salvage this.
-        if header_check == header_begin - 1 and header_begin < header_end:
-            lines.pop(header_check)
-            lines.pop(header_begin - 1)
-            lines.pop(header_end - 2)
-            if lines[header_end - 3] == "\n":
-                lines.pop(header_end - 3)
-            lines.insert(HEADER_CHECK_OFFSET, HEADER_CHECK)
-            lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
-            lines.append("\n")
-            lines.append(HEADER_END)
-            with open(file, "wt", encoding="utf-8", newline="\n") as f:
-                f.writelines(lines)
-            changed.append(file)
-            continue
-
-    invalid.append(file)
+    # Assume that we're simply missing a guard entirely.
+    lines.insert(HEADER_CHECK_OFFSET, "#pragma once\n\n")
+    with open(file, "wt", encoding="utf-8", newline="\n") as f:
+        f.writelines(lines)
+    changed.append(file)
 
 if changed:
     for file in changed:

--- a/test/src/example.h
+++ b/test/src/example.h
@@ -3,8 +3,7 @@
  * This is free and unencumbered software released into the public domain.
  */
 
-#ifndef EXAMPLE_CLASS_H
-#define EXAMPLE_CLASS_H
+#pragma once
 
 // We don't need windows.h in this example plugin but many others do, and it can
 // lead to annoying situations due to the ton of macros it defines.
@@ -289,5 +288,3 @@ protected:
 public:
 	String get_the_word() const;
 };
-
-#endif // EXAMPLE_CLASS_H

--- a/test/src/register_types.h
+++ b/test/src/register_types.h
@@ -3,8 +3,7 @@
  * This is free and unencumbered software released into the public domain.
  */
 
-#ifndef EXAMPLE_REGISTER_TYPES_H
-#define EXAMPLE_REGISTER_TYPES_H
+#pragma once
 
 #include <godot_cpp/core/class_db.hpp>
 
@@ -12,5 +11,3 @@ using namespace godot;
 
 void initialize_example_module(ModuleInitializationLevel p_level);
 void uninitialize_example_module(ModuleInitializationLevel p_level);
-
-#endif // EXAMPLE_REGISTER_TYPES_H

--- a/test/src/tests.h
+++ b/test/src/tests.h
@@ -3,8 +3,7 @@
  * This is free and unencumbered software released into the public domain.
  */
 
-#ifndef TESTS_H
-#define TESTS_H
+#pragma once
 
 #include <godot_cpp/templates/cowdata.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
@@ -25,5 +24,3 @@
 #include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/templates/vmap.hpp>
 #include <godot_cpp/templates/vset.hpp>
-
-#endif // TESTS_H


### PR DESCRIPTION
- Godot PR: godotengine/godot#102298

Integrates the new `#pragma once` style to godot-cpp and its builders