### PR TITLE
Override for debug_features in SCons and CMake

### DIFF
--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -290,9 +290,8 @@ function(godotcpp_generate)
 
     # Transform options into generator expressions
     set(HOT_RELOAD-UNSET "$<STREQUAL:${GODOTCPP_USE_HOT_RELOAD},>")
-
+    set(DEBUG_FEATURES-UNSET "$<STREQUAL:${GODOTCPP_DEBUG_FEATURES},>")
     set(DISABLE_EXCEPTIONS "$<BOOL:${GODOTCPP_DISABLE_EXCEPTIONS}>")
-
     set(THREADS_ENABLED "$<BOOL:${GODOTCPP_THREADS}>")
 
     # GODOTCPP_DEV_BUILD
@@ -308,10 +307,10 @@ function(godotcpp_generate)
     endif()
     set(IS_DEV_BUILD "$<BOOL:${GODOTCPP_DEV_BUILD}>")
 
-    ### Define our godot-cpp library targets
     # Generator Expressions that rely on the target
-    set(DEBUG_FEATURES "$<NOT:$<STREQUAL:${GODOTCPP_TARGET},template_release>>")
-    set(HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},${DEBUG_FEATURES},$<BOOL:${GODOTCPP_USE_HOT_RELOAD}>>")
+    set(TEMPLATE_RELEASE "$<STREQUAL:${TARGET_ALIAS},template_release>")
+    set(DEBUG_FEATURES "$<IF:${DEBUG_FEATURES-UNSET},$<NOT:${TEMPLATE_RELEASE}>,$<BOOL:${GODOTCPP_DEBUG_FEATURES}>>")
+    set(HOT_RELOAD "$<IF:${HOT_RELOAD-UNSET},$<NOT:${TEMPLATE_RELEASE}>,$<BOOL:${GODOTCPP_USE_HOT_RELOAD}>>")
 
     # Suffix
     string(

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -339,6 +339,14 @@ def options(opts, env):
 
     opts.Add(
         BoolVariable(
+            key="debug_features",
+            help="Enable the DEBUG_ENABLED and DEBUG_METHODS_ENABLED pre-processor defines.",
+            default=env.get("debug_features", None),
+        )
+    )
+
+    opts.Add(
+        BoolVariable(
             "disable_exceptions", "Force disabling exception handling code", default=env.get("disable_exceptions", True)
         )
     )
@@ -426,9 +434,9 @@ def generate(env):
 
     # These defaults may be needed by platform tools
     env.use_hot_reload = env.get("use_hot_reload", env["target"] != "template_release")
+    env.debug_features = env.get("debug_features", env["target"] != "template_release")
     env.editor_build = env["target"] == "editor"
     env.dev_build = env["dev_build"]
-    env.debug_features = env["target"] in ["editor", "template_debug"]
 
     if env.dev_build:
         opt_level = "none"


### PR DESCRIPTION
@Naros raised that after the recent CMake changes his builds now have the `DEBUG_ENABLED` flag set.

This is due to using the godot-cpp build target being `editor` or `debug_template`.
The CMake scripts now match the SCons scripts, which was not previously the case.

In SCons there is an attribute `debug_features` which is dependent on the target being either `template_debug` or `editor`
this is then used to add `DEBUG_ENABLED` and `DEBUG_METHODS_ENABLED` to the `CPPDEFINES`.

This PR adds a new option to both SCons and CMake, `debug_features` and `GODOTCPP_DEBUG_FEATURES` respectively, which when unset uses the existing logic, and allows a user to explcitly enable or disable the `debug_features`.

This works exactly the same way as the `use_hot_reload` option.