### PR TITLE
Remove unnecessary forced -fno-exceptions for web builds

### DIFF
--- a/cmake/web.cmake
+++ b/cmake/web.cmake
@@ -23,7 +23,6 @@ function(web_generate)
         PUBLIC #
             -sSIDE_MODULE
             -sSUPPORT_LONGJMP=wasm
-            -fno-exceptions
             $<${THREADS_ENABLED}:-sUSE_PTHREADS=1>
     )
 


### PR DESCRIPTION

The SCons build doesn't do this, so neither should CMake.
Excpetions are already handled by DISABLE_EXCEPTIONS option.

[And it seems to be a mistake too.](https://github.com/godotengine/godot-cpp/pull/1598#discussion_r1917417944)