### PR TITLE
Add missing Projection constructor with 16 `real_t` values

### DIFF
--- a/include/godot_cpp/variant/projection.hpp
+++ b/include/godot_cpp/variant/projection.hpp
@@ -152,6 +152,7 @@ struct [[nodiscard]] Projection {
 
 	Projection();
 	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
+	Projection(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_xw, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_yw, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_zw, real_t p_wx, real_t p_wy, real_t p_wz, real_t p_ww);
 	Projection(const Transform3D &p_transform);
 	~Projection();
 };

--- a/src/variant/projection.cpp
+++ b/src/variant/projection.cpp
@@ -913,6 +913,13 @@ Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_
 	columns[3] = p_w;
 }
 
+Projection::Projection(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_xw, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_yw, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_zw, real_t p_wx, real_t p_wy, real_t p_wz, real_t p_ww) {
+	columns[0] = Vector4(p_xx, p_xy, p_xz, p_xw);
+	columns[1] = Vector4(p_yx, p_yy, p_yz, p_yw);
+	columns[2] = Vector4(p_zx, p_zy, p_zz, p_zw);
+	columns[3] = Vector4(p_wx, p_wy, p_wz, p_ww);
+}
+
 Projection::Projection(const Transform3D &p_transform) {
 	const Transform3D &tr = p_transform;
 	real_t *m = &columns[0][0];


### PR DESCRIPTION
When GDExtension generates bindings, it creates C++ code based on the API JSON. Values are serialized into literals constructed with numbers matching the value, for example, `Vector3(0, 1, 0)`. This includes default values for function parameters. Projection default values are serialized like `Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)`. However, Godot is missing a constructor for Projection, so the generated C++ code doesn't compile:

<img width="800" alt="Screenshot 2025-03-14 at 2 41 03 AM" src="https://github.com/user-attachments/assets/8ce0ceab-04ab-4f97-a724-15e01494e3cd" />

I encountered this problem when the CI checks for godot-cpp failed to compile with my 4D module, because one of the bound methods includes a Projection default value, which cannot be constructed, as seen in the above image. This wasn't a problem in the engine before because the engine doesn't have any Projection default values in parameters.

See also PR which adds this to the engine: https://github.com/godotengine/godot/pull/104113