### PR TITLE
Implement `use_static_cpp` flag for Linux

### DIFF
--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -14,11 +14,23 @@ function(linux_options)
         Not implemented as compiler selection is managed by CMake. Look to
         doc/cmake.rst for examples.
     ]]
+    option(GODOTCPP_USE_STATIC_CPP "Link libgcc and libstdc++ statically for better portability" ON)
 endfunction()
 
 #[===========================[ Target Generation ]===========================]
 function(linux_generate)
+	set(STATIC_CPP "$<BOOL:${GODOTCPP_USE_STATIC_CPP}>")
+
     target_compile_definitions(godot-cpp PUBLIC LINUX_ENABLED UNIX_ENABLED)
+
+	target_link_options(
+		godot-cpp
+		PUBLIC
+			$<${STATIC_CPP}:
+				-static-libgcc
+				-static-libstdc++
+			>
+	)
 
     common_compiler_flags()
 endfunction()

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -5,6 +5,7 @@ from SCons.Variables import BoolVariable
 
 def options(opts):
     opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler - only effective when targeting Linux", False))
+    opts.Add(BoolVariable("use_static_cpp", "Link libgcc and libstdc++ statically for better portability", True))
 
 
 def exists(env):
@@ -36,6 +37,10 @@ def generate(env):
     elif env["arch"] == "rv64":
         env.Append(CCFLAGS=["-march=rv64gc"])
         env.Append(LINKFLAGS=["-march=rv64gc"])
+
+    # Link statically for portability
+    if env["use_static_cpp"]:
+        env.Append(LINKFLAGS=["-static-libgcc", "-static-libstdc++"])
 
     env.Append(CPPDEFINES=["LINUX_ENABLED", "UNIX_ENABLED"])
 


### PR DESCRIPTION
Without statically linking libstdc++ you run into backward-compatibility issues when trying to run a GDExtension linked against a newer version of libstdc++, on a machine that runs an older version. This will also let us upgrade CI runner images to the latest version on godot-cpp-template.

Godot's buildsystem already does this. https://github.com/godotengine/godot/blob/fc827bbe256e47e1d7ec6945deb9c1e79724dac9/platform/linuxbsd/detect.py#L499-L506

I'm fumbling in the dark with CMake. Open to letting someone else handle that part.