### PR TITLE
Typed dictionary initializer support

### DIFF
--- a/include/godot_cpp/classes/ref.hpp
+++ b/include/godot_cpp/classes/ref.hpp
@@ -70,6 +70,10 @@ class Ref {
 	}
 
 public:
+	static _FORCE_INLINE_ String get_class_static() {
+		return T::get_class_static();
+	}
+
 	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
 		return reference == p_ptr;
 	}

--- a/include/godot_cpp/templates/pair.hpp
+++ b/include/godot_cpp/templates/pair.hpp
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <godot_cpp/templates/hashfuncs.hpp>
+
 namespace godot {
 
 template <typename F, typename S>

--- a/include/godot_cpp/variant/typed_dictionary.hpp
+++ b/include/godot_cpp/variant/typed_dictionary.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <godot_cpp/core/type_info.hpp>
+#include <godot_cpp/templates/pair.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
@@ -57,54 +58,75 @@ public:
 	_FORCE_INLINE_ TypedDictionary() {
 		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
 	}
+	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<K, V>> p_init) :
+			Dictionary() {
+		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
+		for (const KeyValue<K, V> &E : p_init) {
+			operator[](E.key) = E.value;
+		}
+	}
 };
 
 //specialization for the rest of variant types
 
-#define MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                          \
-	template <typename T>                                                                                                  \
-	class TypedDictionary<T, m_type> : public Dictionary {                                                                 \
-	public:                                                                                                                \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type."); \
-			Dictionary::operator=(p_dictionary);                                                                           \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                         \
-				TypedDictionary(Dictionary(p_variant)) {                                                                   \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                   \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());         \
-			if (is_same_typed(p_dictionary)) {                                                                             \
-				Dictionary::operator=(p_dictionary);                                                                       \
-			} else {                                                                                                       \
-				assign(p_dictionary);                                                                                      \
-			}                                                                                                              \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                 \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());         \
-		}                                                                                                                  \
-	};                                                                                                                     \
-	template <typename T>                                                                                                  \
-	class TypedDictionary<m_type, T> : public Dictionary {                                                                 \
-	public:                                                                                                                \
-		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type."); \
-			Dictionary::operator=(p_dictionary);                                                                           \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                         \
-				TypedDictionary(Dictionary(p_variant)) {                                                                   \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                   \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());         \
-			if (is_same_typed(p_dictionary)) {                                                                             \
-				Dictionary::operator=(p_dictionary);                                                                       \
-			} else {                                                                                                       \
-				assign(p_dictionary);                                                                                      \
-			}                                                                                                              \
-		}                                                                                                                  \
-		_FORCE_INLINE_ TypedDictionary() {                                                                                 \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());         \
-		}                                                                                                                  \
+#define MAKE_TYPED_DICTIONARY_WITH_OBJECT(m_type, m_variant_type)                                                                             \
+	template <typename T>                                                                                                                     \
+	class TypedDictionary<T, m_type> : public Dictionary {                                                                                    \
+	public:                                                                                                                                   \
+		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                       \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                    \
+			Dictionary::operator=(p_dictionary);                                                                                              \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                            \
+				TypedDictionary(Dictionary(p_variant)) {                                                                                      \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                      \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
+			if (is_same_typed(p_dictionary)) {                                                                                                \
+				Dictionary::operator=(p_dictionary);                                                                                          \
+			} else {                                                                                                                          \
+				assign(p_dictionary);                                                                                                         \
+			}                                                                                                                                 \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary() {                                                                                                    \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T, m_type>> p_init) :                                                   \
+				Dictionary() {                                                                                                                \
+			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                            \
+			for (const KeyValue<T, m_type> &E : p_init) {                                                                                     \
+				operator[](E.key) = E.value;                                                                                                  \
+			}                                                                                                                                 \
+		}                                                                                                                                     \
+	};                                                                                                                                        \
+	template <typename T>                                                                                                                     \
+	class TypedDictionary<m_type, T> : public Dictionary {                                                                                    \
+	public:                                                                                                                                   \
+		_FORCE_INLINE_ void operator=(const Dictionary &p_dictionary) {                                                                       \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                    \
+			Dictionary::operator=(p_dictionary);                                                                                              \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                            \
+				TypedDictionary(Dictionary(p_variant)) {                                                                                      \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                      \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                            \
+			if (is_same_typed(p_dictionary)) {                                                                                                \
+				Dictionary::operator=(p_dictionary);                                                                                          \
+			} else {                                                                                                                          \
+				assign(p_dictionary);                                                                                                         \
+			}                                                                                                                                 \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary() {                                                                                                    \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                            \
+		}                                                                                                                                     \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T>> p_init) :                                                   \
+				Dictionary() {                                                                                                                \
+			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, std::remove_pointer<T>::type::get_class_static(), Variant()); \
+			for (const KeyValue<m_type, T> &E : p_init) {                                                                                     \
+				operator[](E.key) = E.value;                                                                                                  \
+			}                                                                                                                                 \
+		}                                                                                                                                     \
 	};
 
 #define MAKE_TYPED_DICTIONARY_EXPANDED(m_type_key, m_variant_type_key, m_type_value, m_variant_type_value)                 \
@@ -128,6 +150,13 @@ public:
 		}                                                                                                                  \
 		_FORCE_INLINE_ TypedDictionary() {                                                                                 \
 			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());         \
+		}                                                                                                                  \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) :                 \
+				Dictionary() {                                                                                             \
+			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());         \
+			for (const KeyValue<m_type_key, m_type_value> &E : p_init) {                                                   \
+				operator[](E.key) = E.value;                                                                               \
+			}                                                                                                              \
 		}                                                                                                                  \
 	};
 


### PR DESCRIPTION
Allows for the following syntax:
```
TypedDictionary<int, String> colors = {
	{1, "Red"},
	{2, "Green"}
};
```