### PR TITLE
Fix stack smashing when Godot methods return `char32_t`, `char16_t` or `wchar_t`

### DIFF
--- a/include/godot_cpp/core/engine_ptrcall.hpp
+++ b/include/godot_cpp/core/engine_ptrcall.hpp
@@ -55,10 +55,10 @@ O *_call_native_mb_ret_obj(const GDExtensionMethodBindPtr mb, void *instance, co
 
 template <typename R, typename... Args>
 R _call_native_mb_ret(const GDExtensionMethodBindPtr mb, void *instance, const Args &...args) {
-	R ret;
+	typename PtrToArg<R>::EncodeT ret;
 	std::array<GDExtensionConstTypePtr, sizeof...(Args)> mb_args = { { (GDExtensionConstTypePtr)args... } };
 	internal::gdextension_interface_object_method_bind_ptrcall(mb, instance, mb_args.data(), &ret);
-	return ret;
+	return static_cast<R>(ret);
 }
 
 template <typename... Args>
@@ -69,10 +69,10 @@ void _call_native_mb_no_ret(const GDExtensionMethodBindPtr mb, void *instance, c
 
 template <typename R, typename... Args>
 R _call_utility_ret(GDExtensionPtrUtilityFunction func, const Args &...args) {
-	R ret;
+	typename PtrToArg<R>::EncodeT ret;
 	std::array<GDExtensionConstTypePtr, sizeof...(Args)> mb_args = { { (GDExtensionConstTypePtr)args... } };
 	func(&ret, mb_args.data(), mb_args.size());
-	return ret;
+	return static_cast<R>(ret);
 }
 
 template <typename... Args>

--- a/include/godot_cpp/core/method_ptrcall.hpp
+++ b/include/godot_cpp/core/method_ptrcall.hpp
@@ -121,6 +121,9 @@ MAKE_PTRARGCONV(uint16_t, int64_t);
 MAKE_PTRARGCONV(int16_t, int64_t);
 MAKE_PTRARGCONV(uint32_t, int64_t);
 MAKE_PTRARGCONV(int32_t, int64_t);
+MAKE_PTRARGCONV(char16_t, int64_t);
+MAKE_PTRARGCONV(char32_t, int64_t);
+MAKE_PTRARGCONV(wchar_t, int64_t);
 MAKE_PTRARG(int64_t);
 MAKE_PTRARG(uint64_t);
 // Float types


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1741

It looks like we were incorrectly encoding return values for functions that return `char32_t`, `char16_t` and `wchar_t` as pointers to those exact types, whereas Godot is encoding them as pointers to `int64_t`

This PR fixes that!

In a follow up, we should update both SCons and cmake to use the `-fstack-protector-strong` flag with GCC and the equivalent flag for all other compilers (at least in debug builds), so that we can catch these sort of issues quicker.