### PR TITLE
Stop referring to GDExtension as experimental in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 > from Godot's `master` branch.
 >
 > For users of stable branches, switch to the branch matching your target Godot version:
+> - [`4.4`](https://github.com/godotengine/godot-cpp/tree/4.4)
+> - [`4.3`](https://github.com/godotengine/godot-cpp/tree/4.3)
 > - [`4.2`](https://github.com/godotengine/godot-cpp/tree/4.2)
 > - [`4.1`](https://github.com/godotengine/godot-cpp/tree/4.1)
 > - [`4.0`](https://github.com/godotengine/godot-cpp/tree/4.0)
@@ -49,20 +51,13 @@ Godot version.**
 
 ## Compatibility
 
-> [!WARNING]
->
-> The GDExtension API is brand new in Godot 4.0, and is still
-considered in **beta** stage, despite Godot 4.0 itself being released.
->
-> This applies to both the GDExtension interface header, the API JSON, and this
-first-party `godot-cpp` extension.
->
-> Some compatibility breakage is to be expected as GDExtension and `godot-cpp`
-> get more used, documented, and critical issues get resolved. See the
-> [Godot issue tracker](https://github.com/godotengine/godot/issues?q=is%3Aissue+is%3Aopen+label%3Atopic%3Agdextension)
-> and the [godot-cpp issue tracker](https://github.com/godotengine/godot-cpp/issues)
-> for a list of known issues, and be sure to provide feedback on issues and PRs
-> which affect your use of this extension.
+GDExtensions targeting an earlier version of Godot should work in later minor versions,
+but not vice-versa. For example, a GDExtension targeting Godot 4.2 should work just fine
+in Godot 4.3, but one targeting Godot 4.3 won't work in Godot 4.2.
+
+There is one exception to this: extensions targeting Godot 4.0 will _not_ work with
+Godot 4.1 and later.
+See [Updating your GDExtension for 4.1](https://docs.godotengine.org/en/latest/tutorials/migrating/upgrading_to_godot_4.1.html#updating-your-gdextension-for-godot-4-1).
 
 ## Contributing
 


### PR DESCRIPTION
Per the discussion at the previous GDExtension meeting, we think it's time to stop saying that GDExtension is experimental :-)

While I guess we technically still reserve the right to break compatibility if there is a bug or issue serious enough, based on our track record so far, I don't think we will need to.

This PR replaces the warning about being experimental, with some of the text copied from this docs page:

https://docs.godotengine.org/en/latest/tutorials/scripting/gdextension/what_is_gdextension.html#version-compatibility

I think we should ultimately just link to that docs page, so we don't have to update this information in two places, however, I don't want to link to it with https://github.com/godotengine/godot-docs/pull/10631 still open, because that will lead to the URL changing.

Also, for this reason, I didn't integrating more of the suggestions from https://github.com/godotengine/godot-cpp/pull/1588 and instead decided to keep it minimal, because all of the notes we talked about there probably should be on the docs page rather than in the godot-cpp README