### PR TITLE
SCons: Add `CPPEXTPATH` for external includes

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -130,6 +130,11 @@ def generate(env):
         if env["silence_msvc"] and not env.GetOption("clean"):
             silence_msvc(env)
 
+        if not env["use_llvm"]:
+            env.AppendUnique(CCFLAGS=["/experimental:external", "/external:anglebrackets"])
+        env.AppendUnique(CCFLAGS=["/external:W0"])
+        env["EXTINCPREFIX"] = "/external:I"
+
     elif (sys.platform == "win32" or sys.platform == "msys") and not env["mingw_prefix"]:
         env["use_mingw"] = True
         mingw.generate(env)


### PR DESCRIPTION
- Followup to https://github.com/godotengine/godot/pull/104893

Will enable SCons scripts to declare certain includes are external/system explicitly, for the sake of supressing warnings. Not too relevant in this isolated context, where we don't really care about warnings, but will prove useful for anything deriving from us (eg: the main repo's GDExtension text servers)