### PR TITLE
Sync defs

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -32,6 +32,7 @@
 
 #include <gdextension_interface.h>
 
+#include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/core/method_ptrcall.hpp>
 #include <godot_cpp/core/type_info.hpp>
 

--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -32,7 +32,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
+#include <utility>
 
 namespace godot {
 
@@ -64,13 +64,31 @@ namespace godot {
 #endif
 #endif
 
-// Should always inline, except in debug builds because it makes debugging harder.
+// Should always inline, except in dev builds because it makes debugging harder,
+// or `size_enabled` builds where inlining is actively avoided.
 #ifndef _FORCE_INLINE_
-#ifdef DISABLE_FORCED_INLINE
+#if defined(DEV_ENABLED) || defined(SIZE_EXTRA)
 #define _FORCE_INLINE_ inline
 #else
 #define _FORCE_INLINE_ _ALWAYS_INLINE_
 #endif
+#endif
+
+// Should never inline.
+#ifndef _NO_INLINE_
+#if defined(__GNUC__)
+#define _NO_INLINE_ __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define _NO_INLINE_ __declspec(noinline)
+#else
+#define _NO_INLINE_
+#endif
+#endif
+
+// In some cases [[nodiscard]] will get false positives,
+// we can prevent the warning in specific cases by preceding the call with a cast.
+#ifndef _ALLOW_DISCARD_
+#define _ALLOW_DISCARD_ (void)
 #endif
 
 // Windows badly defines a lot of stuff we'll never use. Undefine it.
@@ -80,13 +98,181 @@ namespace godot {
 #undef ERROR // override (really stupid) wingdi.h standard definition
 #undef DELETE // override (another really stupid) winnt.h standard definition
 #undef MessageBox // override winuser.h standard definition
-#undef MIN // override standard definition
-#undef MAX // override standard definition
-#undef CLAMP // override standard definition
 #undef Error
 #undef OK
 #undef CONNECT_DEFERRED // override from Windows SDK, clashes with Object enum
+#undef MemoryBarrier
+#undef MONO_FONT
 #endif
+
+// Make room for our constexpr's below by overriding potential system-specific macros.
+#undef SIGN
+#undef MIN
+#undef MAX
+#undef CLAMP
+
+template <typename T>
+constexpr const T SIGN(const T m_v) {
+	return m_v > 0 ? +1.0f : (m_v < 0 ? -1.0f : 0.0f);
+}
+
+template <typename T, typename T2>
+constexpr auto MIN(const T m_a, const T2 m_b) {
+	return m_a < m_b ? m_a : m_b;
+}
+
+template <typename T, typename T2>
+constexpr auto MAX(const T m_a, const T2 m_b) {
+	return m_a > m_b ? m_a : m_b;
+}
+
+template <typename T, typename T2, typename T3>
+constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
+	return m_a < m_min ? m_min : (m_a > m_max ? m_max : m_a);
+}
+
+// Generic swap template.
+#ifndef SWAP
+#define SWAP(m_x, m_y) std::swap((m_x), (m_y))
+#endif // SWAP
+
+/* Functions to handle powers of 2 and shifting. */
+
+// Returns `true` if a positive integer is a power of 2, `false` otherwise.
+template <typename T>
+inline bool is_power_of_2(const T x) {
+	return x && ((x & (x - 1)) == 0);
+}
+
+// Function to find the next power of 2 to an integer.
+static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
+	if (x == 0) {
+		return 0;
+	}
+
+	--x;
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+
+	return ++x;
+}
+
+// Function to find the previous power of 2 to an integer.
+static _FORCE_INLINE_ unsigned int previous_power_of_2(unsigned int x) {
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	return x - (x >> 1);
+}
+
+// Function to find the closest power of 2 to an integer.
+static _FORCE_INLINE_ unsigned int closest_power_of_2(unsigned int x) {
+	unsigned int nx = next_power_of_2(x);
+	unsigned int px = previous_power_of_2(x);
+	return (nx - x) > (x - px) ? px : nx;
+}
+
+// Get a shift value from a power of 2.
+static inline int get_shift_from_power_of_2(unsigned int p_bits) {
+	for (unsigned int i = 0; i < 32; i++) {
+		if (p_bits == (unsigned int)(1 << i)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+template <typename T>
+static _FORCE_INLINE_ T nearest_power_of_2_templated(T x) {
+	--x;
+
+	// The number of operations on x is the base two logarithm
+	// of the number of bits in the type. Add three to account
+	// for sizeof(T) being in bytes.
+	size_t num = get_shift_from_power_of_2(sizeof(T)) + 3;
+
+	// If the compiler is smart, it unrolls this loop.
+	// If it's dumb, this is a bit slow.
+	for (size_t i = 0; i < num; i++) {
+		x |= x >> (1 << i);
+	}
+
+	return ++x;
+}
+
+// Function to find the nearest (bigger) power of 2 to an integer.
+static inline unsigned int nearest_shift(unsigned int p_number) {
+	for (int i = 30; i >= 0; i--) {
+		if (p_number & (1 << i)) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}
+
+// constexpr function to find the floored log2 of a number
+template <typename T>
+constexpr T floor_log2(T x) {
+	return x < 2 ? x : 1 + floor_log2(x >> 1);
+}
+
+// Get the number of bits needed to represent the number.
+// IE, if you pass in 8, you will get 4.
+// If you want to know how many bits are needed to store 8 values however, pass in (8 - 1).
+template <typename T>
+constexpr T get_num_bits(T x) {
+	return floor_log2(x);
+}
+
+// Swap 16, 32 and 64 bits value for endianness.
+#if defined(__GNUC__)
+#define BSWAP16(x) __builtin_bswap16(x)
+#define BSWAP32(x) __builtin_bswap32(x)
+#define BSWAP64(x) __builtin_bswap64(x)
+#elif defined(_MSC_VER)
+#define BSWAP16(x) _byteswap_ushort(x)
+#define BSWAP32(x) _byteswap_ulong(x)
+#define BSWAP64(x) _byteswap_uint64(x)
+#else
+static inline uint16_t BSWAP16(uint16_t x) {
+	return (x >> 8) | (x << 8);
+}
+
+static inline uint32_t BSWAP32(uint32_t x) {
+	return ((x << 24) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | (x >> 24));
+}
+
+static inline uint64_t BSWAP64(uint64_t x) {
+	x = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
+	x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
+	x = (x & 0x00FF00FF00FF00FF) << 8 | (x & 0xFF00FF00FF00FF00) >> 8;
+	return x;
+}
+#endif
+
+// Generic comparator used in Map, List, etc.
+template <typename T>
+struct Comparator {
+	_ALWAYS_INLINE_ bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
+};
+
+// Global lock macro, relies on the static Mutex::_global_mutex.
+void _global_lock();
+void _global_unlock();
+
+struct _GlobalLock {
+	_GlobalLock() { _global_lock(); }
+	~_GlobalLock() { _global_unlock(); }
+};
+
+#define GLOBAL_LOCK_FUNCTION _GlobalLock _global_lock_;
 
 #if defined(__GNUC__)
 #define likely(x) __builtin_expect(!!(x), 1)
@@ -96,22 +282,17 @@ namespace godot {
 #define unlikely(x) x
 #endif
 
-#ifdef REAL_T_IS_DOUBLE
-typedef double real_t;
+#if defined(__GNUC__)
+#define _PRINTF_FORMAT_ATTRIBUTE_2_0 __attribute__((format(printf, 2, 0)))
+#define _PRINTF_FORMAT_ATTRIBUTE_2_3 __attribute__((format(printf, 2, 3)))
 #else
-typedef float real_t;
+#define _PRINTF_FORMAT_ATTRIBUTE_2_0
+#define _PRINTF_FORMAT_ATTRIBUTE_2_3
 #endif
 
-// Generic swap template.
-#ifndef SWAP
-#define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
-template <typename T>
-inline void __swap_tmpl(T &x, T &y) {
-	T aux = x;
-	x = y;
-	y = aux;
-}
-#endif // SWAP
+// This is needed due to a strange OpenGL API that expects a pointer
+// type for an argument that is actually an offset.
+#define CAST_INT_TO_UCHAR_PTR(ptr) ((uint8_t *)(uintptr_t)(ptr))
 
 // Home-made index sequence trick, so it can be used everywhere without the costly include of std::tuple.
 // https://stackoverflow.com/questions/15014096/c-index-of-type-during-variadic-template-expansion
@@ -124,8 +305,36 @@ struct BuildIndexSequence : BuildIndexSequence<N - 1, N - 1, Is...> {};
 template <size_t... Is>
 struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 
-} //namespace godot
+// Limit the depth of recursive algorithms when dealing with Array/Dictionary
+#define MAX_RECURSION 100
 
-// To maintain compatibility an alias is defined outside the namespace.
-// Consider it deprecated.
-using real_t = godot::real_t;
+#ifdef DEBUG_ENABLED
+#define DEBUG_METHODS_ENABLED
+#endif
+
+// Macro GD_IS_DEFINED() allows to check if a macro is defined. It needs to be defined to anything (say 1) to work.
+#define __GDARG_PLACEHOLDER_1 false,
+#define __gd_take_second_arg(__ignored, val, ...) val
+#define ____gd_is_defined(arg1_or_junk) __gd_take_second_arg(arg1_or_junk true, false)
+#define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
+#define GD_IS_DEFINED(x) ___gd_is_defined(x)
+
+// Whether the default value of a type is just all-0 bytes.
+// This can most commonly be exploited by using memset for these types instead of loop-construct.
+// Trivially constructible types are also zero-constructible.
+template <typename T>
+struct is_zero_constructible : std::is_trivially_constructible<T> {};
+
+template <typename T>
+struct is_zero_constructible<const T> : is_zero_constructible<T> {};
+
+template <typename T>
+struct is_zero_constructible<volatile T> : is_zero_constructible<T> {};
+
+template <typename T>
+struct is_zero_constructible<const volatile T> : is_zero_constructible<T> {};
+
+template <typename T>
+inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
+
+} //namespace godot

--- a/include/godot_cpp/core/math.compat.inc
+++ b/include/godot_cpp/core/math.compat.inc
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/*  math.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+
+#ifndef DISABLE_DEPRECATED
+
+namespace godot {
+
+#undef ABS
+
+// Generic ABS function, for math uses please use Math::abs.
+template <typename T>
+[[deprecated("Use Math::abs instead")]]
+constexpr T ABS(T m_v) {
+	return m_v < 0 ? -m_v : m_v;
+}
+
+}
+
+// To maintain compatibility an alias is defined outside the namespace.
+// Consider it deprecated.
+using real_t = godot::real_t;
+
+#endif

--- a/include/godot_cpp/core/math.hpp
+++ b/include/godot_cpp/core/math.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/core/math_defs.hpp>
 
 #include <gdextension_interface.h>
 
@@ -38,184 +39,7 @@
 
 namespace godot {
 
-#define Math_SQRT12 0.7071067811865475244008443621048490
-#define Math_SQRT2 1.4142135623730950488016887242
-#define Math_LN2 0.6931471805599453094172321215
-#define Math_PI 3.1415926535897932384626433833
-#define Math_TAU 6.2831853071795864769252867666
-#define Math_E 2.7182818284590452353602874714
-#define Math_INF INFINITY
-#define Math_NAN NAN
-
-// Make room for our constexpr's below by overriding potential system-specific macros.
-#undef ABS
-#undef SIGN
-#undef MIN
-#undef MAX
-#undef CLAMP
-
-// Generic ABS function, for math uses please use Math::abs.
-template <typename T>
-constexpr T ABS(T m_v) {
-	return m_v < 0 ? -m_v : m_v;
-}
-
-template <typename T>
-constexpr const T SIGN(const T m_v) {
-	return m_v == 0 ? 0.0f : (m_v < 0 ? -1.0f : +1.0f);
-}
-
-template <typename T, typename T2>
-constexpr auto MIN(const T m_a, const T2 m_b) {
-	return m_a < m_b ? m_a : m_b;
-}
-
-template <typename T, typename T2>
-constexpr auto MAX(const T m_a, const T2 m_b) {
-	return m_a > m_b ? m_a : m_b;
-}
-
-template <typename T, typename T2, typename T3>
-constexpr auto CLAMP(const T m_a, const T2 m_min, const T3 m_max) {
-	return m_a < m_min ? m_min : (m_a > m_max ? m_max : m_a);
-}
-
-// Generic swap template.
-#ifndef SWAP
-#define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
-template <typename T>
-inline void __swap_tmpl(T &x, T &y) {
-	T aux = x;
-	x = y;
-	y = aux;
-}
-#endif // SWAP
-
-/* Functions to handle powers of 2 and shifting. */
-
-// Function to find the next power of 2 to an integer.
-static _FORCE_INLINE_ unsigned int next_power_of_2(unsigned int x) {
-	if (x == 0) {
-		return 0;
-	}
-
-	--x;
-	x |= x >> 1;
-	x |= x >> 2;
-	x |= x >> 4;
-	x |= x >> 8;
-	x |= x >> 16;
-
-	return ++x;
-}
-
-// Function to find the previous power of 2 to an integer.
-static _FORCE_INLINE_ unsigned int previous_power_of_2(unsigned int x) {
-	x |= x >> 1;
-	x |= x >> 2;
-	x |= x >> 4;
-	x |= x >> 8;
-	x |= x >> 16;
-	return x - (x >> 1);
-}
-
-// Function to find the closest power of 2 to an integer.
-static _FORCE_INLINE_ unsigned int closest_power_of_2(unsigned int x) {
-	unsigned int nx = next_power_of_2(x);
-	unsigned int px = previous_power_of_2(x);
-	return (nx - x) > (x - px) ? px : nx;
-}
-
-// Get a shift value from a power of 2.
-static inline int get_shift_from_power_of_2(unsigned int p_bits) {
-	for (unsigned int i = 0; i < 32; i++) {
-		if (p_bits == (unsigned int)(1 << i)) {
-			return i;
-		}
-	}
-
-	return -1;
-}
-
-template <typename T>
-static _FORCE_INLINE_ T nearest_power_of_2_templated(T x) {
-	--x;
-
-	// The number of operations on x is the base two logarithm
-	// of the number of bits in the type. Add three to account
-	// for sizeof(T) being in bytes.
-	size_t num = get_shift_from_power_of_2(sizeof(T)) + 3;
-
-	// If the compiler is smart, it unrolls this loop.
-	// If it's dumb, this is a bit slow.
-	for (size_t i = 0; i < num; i++) {
-		x |= x >> (1 << i);
-	}
-
-	return ++x;
-}
-
-// Function to find the nearest (bigger) power of 2 to an integer.
-static inline unsigned int nearest_shift(unsigned int p_number) {
-	for (int i = 30; i >= 0; i--) {
-		if (p_number & (1 << i)) {
-			return i + 1;
-		}
-	}
-
-	return 0;
-}
-
-// constexpr function to find the floored log2 of a number
-template <typename T>
-constexpr T floor_log2(T x) {
-	return x < 2 ? x : 1 + floor_log2(x >> 1);
-}
-
-// Get the number of bits needed to represent the number.
-// IE, if you pass in 8, you will get 4.
-// If you want to know how many bits are needed to store 8 values however, pass in (8 - 1).
-template <typename T>
-constexpr T get_num_bits(T x) {
-	return floor_log2(x);
-}
-
-// Swap 16, 32 and 64 bits value for endianness.
-#if defined(__GNUC__)
-#define BSWAP16(x) __builtin_bswap16(x)
-#define BSWAP32(x) __builtin_bswap32(x)
-#define BSWAP64(x) __builtin_bswap64(x)
-#else
-static inline uint16_t BSWAP16(uint16_t x) {
-	return (x >> 8) | (x << 8);
-}
-
-static inline uint32_t BSWAP32(uint32_t x) {
-	return ((x << 24) | ((x << 8) & 0x00FF0000) | ((x >> 8) & 0x0000FF00) | (x >> 24));
-}
-
-static inline uint64_t BSWAP64(uint64_t x) {
-	x = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
-	x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
-	x = (x & 0x00FF00FF00FF00FF) << 8 | (x & 0xFF00FF00FF00FF00) >> 8;
-	return x;
-}
-#endif
-
 namespace Math {
-
-// This epsilon should match the one used by Godot for consistency.
-// Using `f` when `real_t` is float.
-#define CMP_EPSILON 0.00001f
-#define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
-
-// This epsilon is for values related to a unit size (scalar or vector len).
-#ifdef PRECISE_MATH_CHECKS
-#define UNIT_EPSILON 0.00001
-#else
-// Tolerate some more floating point error normally.
-#define UNIT_EPSILON 0.001
-#endif
 
 // Functions reproduced as in Godot's source code `math_funcs.h`.
 // Some are overloads to automatically support changing real_t into either double or float in the way Godot does.
@@ -834,3 +658,5 @@ inline float snap_scalar_separation(float p_offset, float p_step, float p_target
 
 } // namespace Math
 } // namespace godot
+
+#include "math.compat.inc"

--- a/include/godot_cpp/core/math_defs.hpp
+++ b/include/godot_cpp/core/math_defs.hpp
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  math_defs.hpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+namespace godot {
+
+#define CMP_EPSILON 0.00001
+#define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
+
+#define CMP_NORMALIZE_TOLERANCE 0.000001
+#define CMP_POINT_IN_PLANE_EPSILON 0.00001
+
+#define Math_SQRT12 0.7071067811865475244008443621048490
+#define Math_SQRT2 1.4142135623730950488016887242
+#define Math_LN2 0.6931471805599453094172321215
+#define Math_TAU 6.2831853071795864769252867666
+#define Math_PI 3.1415926535897932384626433833
+#define Math_E 2.7182818284590452353602874714
+
+#ifdef DEBUG_ENABLED
+#define MATH_CHECKS
+#endif
+
+//this epsilon is for values related to a unit size (scalar or vector len)
+#ifdef PRECISE_MATH_CHECKS
+#define UNIT_EPSILON 0.00001
+#else
+//tolerate some more floating point error normally
+#define UNIT_EPSILON 0.001
+#endif
+
+#define USEC_TO_SEC(m_usec) ((m_usec) / 1000000.0)
+
+/**
+ * The "Real" type is an abstract type used for real numbers, such as 1.5,
+ * in contrast to integer numbers. Precision can be controlled with the
+ * presence or absence of the REAL_T_IS_DOUBLE define.
+ */
+#ifdef REAL_T_IS_DOUBLE
+typedef double real_t;
+#else
+typedef float real_t;
+#endif
+} // namespace godot

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -101,12 +101,6 @@ _ALWAYS_INLINE_ T *_post_initialize(T *p_obj) {
 #define memnew_allocator(m_class, m_allocator) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", m_allocator::alloc) m_class))
 #define memnew_placement(m_placement, m_class) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", m_placement, sizeof(m_class), "") m_class))
 
-// Generic comparator used in Map, List, etc.
-template <typename T>
-struct Comparator {
-	_ALWAYS_INLINE_ bool operator()(const T &p_a, const T &p_b) const { return (p_a < p_b); }
-};
-
 template <typename T>
 void memdelete(T *p_class, typename std::enable_if<!std::is_base_of_v<godot::Wrapped, T>>::type * = nullptr) {
 	if constexpr (!std::is_trivially_destructible_v<T>) {

--- a/include/godot_cpp/variant/plane.hpp
+++ b/include/godot_cpp/variant/plane.hpp
@@ -102,7 +102,7 @@ real_t Plane::distance_to(const Vector3 &p_point) const {
 
 bool Plane::has_point(const Vector3 &p_point, real_t p_tolerance) const {
 	real_t dist = normal.dot(p_point) - d;
-	dist = ABS(dist);
+	dist = Math::abs(dist);
 	return (dist <= p_tolerance);
 }
 

--- a/include/godot_cpp/variant/vector3.hpp
+++ b/include/godot_cpp/variant/vector3.hpp
@@ -32,10 +32,10 @@
 
 #include <godot_cpp/core/error_macros.hpp>
 #include <godot_cpp/core/math.hpp>
+#include <godot_cpp/variant/string.hpp>
 
 namespace godot {
 
-class String;
 struct Basis;
 struct Vector2;
 struct Vector3i;

--- a/src/variant/plane.cpp
+++ b/src/variant/plane.cpp
@@ -60,7 +60,7 @@ Vector3 Plane::get_any_perpendicular_normal() const {
 	static const Vector3 p2 = Vector3(0, 1, 0);
 	Vector3 p;
 
-	if (ABS(normal.dot(p1)) > 0.99f) { // if too similar to p1
+	if (Math::abs(normal.dot(p1)) > 0.99f) { // if too similar to p1
 		p = p2; // use p2
 	} else {
 		p = p1; // use p1

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -467,8 +467,6 @@ def generate(env):
         # DEBUG_ENABLED enables debugging *features* and debug-only code, which is intended
         # to give *users* extra debugging information for their game development.
         env.Append(CPPDEFINES=["DEBUG_ENABLED"])
-        # In upstream Godot this is added in typedefs.h when DEBUG_ENABLED is set.
-        env.Append(CPPDEFINES=["DEBUG_METHODS_ENABLED"])
 
     if env.dev_build:
         # DEV_ENABLED enables *engine developer* code which should only be compiled for those


### PR DESCRIPTION
Code is from the godot repo, had to remove duplicate definitions from math.hpp for some types and moved out the math defs into their own file to mirror godot's file structure more closely.

I was looking at syncing some other classes, but there were some types missing, hence this PR.

Briefly tested it on one of my gdextension projects and there doesn't seem to be any issues when running it with Godot 4.4.