### PR TITLE
Allow non-Object types in callable_mp

### DIFF
--- a/include/godot_cpp/variant/callable_method_pointer.hpp
+++ b/include/godot_cpp/variant/callable_method_pointer.hpp
@@ -69,7 +69,10 @@ class CallableCustomMethodPointer : public CallableCustomMethodPointerBase {
 
 public:
 	virtual ObjectID get_object() const override {
-		return ObjectID(data.instance->get_instance_id());
+		if constexpr (std::is_base_of_v<Object, T>) {
+			return ObjectID(data.instance->get_instance_id());
+		}
+		return {};
 	}
 
 	virtual int get_argument_count(bool &r_is_valid) const override {
@@ -111,7 +114,10 @@ class CallableCustomMethodPointerRet : public CallableCustomMethodPointerBase {
 
 public:
 	virtual ObjectID get_object() const override {
-		return ObjectID(data.instance->get_instance_id());
+		if constexpr (std::is_base_of_v<Object, T>) {
+			return ObjectID(data.instance->get_instance_id());
+		}
+		return {};
 	}
 
 	virtual int get_argument_count(bool &r_is_valid) const override {
@@ -153,7 +159,10 @@ class CallableCustomMethodPointerRetC : public CallableCustomMethodPointerBase {
 
 public:
 	virtual ObjectID get_object() const override {
-		return ObjectID(data.instance->get_instance_id());
+		if constexpr (std::is_base_of_v<Object, T>) {
+			return ObjectID(data.instance->get_instance_id());
+		}
+		return {};
 	}
 
 	virtual int get_argument_count(bool &r_is_valid) const override {


### PR DESCRIPTION
Adds a compile time check to see if the type of the Object passed into callable_mp is derived from the Godot Object type. Without this change using callable_mp on a non-Object type would fail with a compiler error unless you defined a get_instance_id function on the type, even though creating a Callable on non-Object types is valid and does work. callable_mp_static already doesn't make use of the instance id so I just made it work the same as the static version. I already use this in my code all over and have tested and there don't seem to be any side effects.

The upstream file here https://github.com/godotengine/godot/blob/master/core/object/callable_method_pointer.h already does this it looks like (it's not compile time upstream though, might want to change that too).