### PR TITLE
Fix compatibility break for CI action 'setup-godot-cpp'

### DIFF
--- a/.github/actions/setup-godot-cpp/action.yml
+++ b/.github/actions/setup-godot-cpp/action.yml
@@ -23,6 +23,7 @@ inputs:
     default: r23c
     description: Android NDK version.
   buildtool:
+    default: scons
     description: scons or cmake
   scons-version:
     default: 4.4.0


### PR DESCRIPTION
As noted here:
https://github.com/godotengine/godot-cpp/commit/b6c0251296377fcb449752f64ec4e2eceaae40c4#r154926270

Other people rely on the functionality of the action, and so changes to its default logic break the build.
My introduction of cmake, change the behaviour to require a buildtool input variable.
This PR adds a default of scons so that input is noo longer required and things behave as they used to.