### PR TITLE
Fix TypedDictionary binding generation

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1391,7 +1391,7 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
                                         fully_used_classes.add(dict_type_name)
                                     else:
                                         used_classes.add(dict_type_name)
-                                dict_type_name = dict_type_names[2]
+                                dict_type_name = dict_type_names[1]
                                 if dict_type_name.endswith("*"):
                                     dict_type_name = dict_type_name[:-1]
                                 if is_included(dict_type_name, class_name):
@@ -1446,7 +1446,7 @@ def generate_engine_classes_bindings(api, output_dir, use_template_get_node):
                                     fully_used_classes.add(dict_type_name)
                                 else:
                                     used_classes.add(dict_type_name)
-                            dict_type_name = dict_type_names[2]
+                            dict_type_name = dict_type_names[1]
                             if dict_type_name.endswith("*"):
                                 dict_type_name = dict_type_name[:-1]
                             if is_included(dict_type_name, class_name):
@@ -1955,7 +1955,7 @@ def generate_engine_class_source(class_api, used_classes, fully_used_classes, us
 
             if has_return:
                 result.append(
-                    f'\tCHECK_METHOD_BIND_RET(_gde_method_bind, {get_default_value_for_type(method["return_value"]["type"])});'
+                    f'\tCHECK_METHOD_BIND_RET(_gde_method_bind, ({get_default_value_for_type(method["return_value"]["type"])}));'
                 )
             else:
                 result.append("\tCHECK_METHOD_BIND(_gde_method_bind);")
@@ -2249,7 +2249,7 @@ def generate_utility_functions(api, output_dir):
         has_return = "return_type" in function and function["return_type"] != "void"
         if has_return:
             source.append(
-                f'\tCHECK_METHOD_BIND_RET(_gde_function, {get_default_value_for_type(function["return_type"])});'
+                f'\tCHECK_METHOD_BIND_RET(_gde_function, ({get_default_value_for_type(function["return_type"])}));'
             )
         else:
             source.append("\tCHECK_METHOD_BIND(_gde_function);")


### PR DESCRIPTION
Currently, `TypedDictionary` bindings fail to generate correctly.

This issue has not been apparent so far because Godot has not exposed any API using `TypedDictionary`, but it makes CI checks fail on PRs such as godotengine/godot#104096 which do so.

This PR fixes the bindgen with two small tweaks:
- An off-by-one index is corrected
- Parenthesis are added to prevent macros from erroneously splitting arguments on the comma in `TypedDictionary<KeyType, ValueType>`

For convenience, here is an `extension_api.json` generated from the above PR. The issue is related to the `typeddictionary::` entries.
[extension_api.json](https://github.com/user-attachments/files/19658749/extension_api.json)

Fixes https://github.com/godotengine/godot/issues/100137