### PR TITLE
Use Math::abs to avoid ambiguity with integer abs

### DIFF
--- a/include/godot_cpp/variant/quaternion.hpp
+++ b/include/godot_cpp/variant/quaternion.hpp
@@ -149,7 +149,7 @@ struct [[nodiscard]] Quaternion {
 		Vector3 n0 = p_v0.normalized();
 		Vector3 n1 = p_v1.normalized();
 		real_t d = n0.dot(n1);
-		if (abs(d) > ALMOST_ONE) {
+		if (Math::abs(d) > ALMOST_ONE) {
 			if (d >= 0) {
 				return; // Vectors are same.
 			}


### PR DESCRIPTION
That happened when compiling with Clang on Linux and `-Wall` https://github.com/Zylann/godot_voxel/actions/runs/14456040422/job/40539389673