### PR TITLE
CI: bump of mozilla-sccache action to 0.0.9

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -119,7 +119,7 @@ jobs:
           submodules: recursive
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Setup godot-cpp
         uses: ./.github/actions/setup-godot-cpp


### PR DESCRIPTION
Github recenty decomissioned some cache servers:
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

> GitHub has migrated customers to a [new cache service](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) and will now be shutting down the old service. This process will include brownouts of the old service before turning it off completely on April 15th, 2025. If your Actions workflows are still hitting the old cache service, your workflows may fail during these brownouts.
The brownout dates and times are as follows:
> * April 1, 2025, 3 p.m. – 7 p.m. UTC
> * April 8, 2025, 2 p.m. – 10 p.m. UTC
> 
> You may still be using the old service if you’re interacting with the cache in one of the following ways:
> 1. Using a third party action (i.e. not actions/cache) or product that uses an actions cache service to perform caching. In this case, you may need to upgrade to the latest version. Examples: [mozilla/sccache](https://github.com/mozilla/sccache), [Mozilla-Actions/sccache-action](https://github.com/Mozilla-Actions/sccache-action), [Docker with GitHub Actions as a caching backend](https://docs.docker.com/build/cache/backends/gha/)
> 1. Using a runner version older than 2.320.1
> 1. Have manually changed (edited or removed) any of the environment variables below:
        ACTIONS_CACHE_URL
        ACTIONS_RESULTS_URL
        ACTIONS_RUNTIME_TOKEN
        ACTIONS_CACHE_SERVICE_V2

Updating the mozilla-sccache action from v0.0.7, to latest 0.0.9 resolves the failures.
