### PR TITLE
Use Math::abs to avoid ambiguity with integer abs

### DIFF
--- a/src/variant/basis.cpp
+++ b/src/variant/basis.cpp
@@ -272,7 +272,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	Vector3 dots;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
+			dots[j] += s[i] * Math::abs(m.get_column(i).normalized().dot(b.get_column(j)));
 		}
 	}
 	if (sign != std::signbit(dots.x + dots.y + dots.z)) {


### PR DESCRIPTION
That happened when compiling with Clang on Linux and `-Wall`: https://github.com/Zylann/godot_voxel/actions/runs/14474467053/job/40596573102
