### PR TITLE
Fix array constructor crash

### DIFF
--- a/include/godot_cpp/variant/variant.hpp
+++ b/include/godot_cpp/variant/variant.hpp
@@ -408,7 +408,8 @@ Array::ConstIterator Array::end() const {
 	return Array::ConstIterator(ptr() + size());
 }
 
-Array::Array(std::initializer_list<Variant> p_init) {
+Array::Array(std::initializer_list<Variant> p_init) :
+		Array() {
 	ERR_FAIL_COND(resize(p_init.size()) != 0);
 
 	size_t i = 0;


### PR DESCRIPTION
This PR fixes a runtime crash when using the Array's `initializer_list` constructor