### PR TITLE
Fix ClassDB iterators making unintended copies

### DIFF
--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -392,7 +392,7 @@ void ClassDB::_editor_get_classes_used_callback(GDExtensionTypePtr p_packed_stri
 	PackedStringArray *arr = reinterpret_cast<PackedStringArray *>(p_packed_string_array);
 	arr->resize(instance_binding_callbacks.size());
 	int index = 0;
-	for (const std::pair<StringName, const GDExtensionInstanceBindingCallbacks *> &pair : instance_binding_callbacks) {
+	for (const std::pair<const StringName, const GDExtensionInstanceBindingCallbacks *> &pair : instance_binding_callbacks) {
 		(*arr)[index++] = pair.first;
 	}
 }
@@ -401,7 +401,7 @@ void ClassDB::initialize_class(const ClassInfo &p_cl) {
 }
 
 void ClassDB::initialize(GDExtensionInitializationLevel p_level) {
-	for (const std::pair<StringName, ClassInfo> pair : classes) {
+	for (const std::pair<const StringName, ClassInfo> &pair : classes) {
 		const ClassInfo &cl = pair.second;
 		if (cl.level != p_level) {
 			continue;


### PR DESCRIPTION
```
godot-cpp/src/core/class_db.cpp: In static member function 'static void godot::ClassDB::_editor_get_classes_used_callback(GDExtensionTypePtr)':
godot-cpp/src/core/class_db.cpp:395:88: error: loop variable 'pair' of type 'const std::pair<godot::StringName, const GDExtensionInstanceBindingCallbacks*>&' binds to a temporary constructed from type 'std::pair<const godot::StringName, const GDExtensionInstanceBindingCallbacks*>' [-Werror=range-loop-construct]
  395 | ame, const GDExtensionInstanceBindingCallbacks *> &pair : instance_binding_callbacks) {
      |                                                    ^~~~

godot-cpp/src/core/class_db.cpp:395:88: note: use non-reference type 'const std::pair<godot::StringName, const GDExtensionInstanceBindingCallbacks*>' to make the copy explicit or 'const std::pair<const godot::StringName, const GDExtensionInstanceBindingCallbacks*>&' to prevent copying
```