### PR TITLE
Fix classes without `_to_string()` always returning `"[Wrapped:0]"`

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1723,6 +1723,16 @@ def generate_engine_class_header(class_api, used_classes, fully_used_classes, us
         result.append(f"\t~{class_name}();")
         result.append("")
 
+    if class_name == "Object":
+        result.append('\tString _to_string() const { return "<" + get_class() + "#" + itos(get_instance_id()) + ">"; }')
+        result.append("")
+
+    if class_name == "Node":
+        result.append(
+            '\tString _to_string() const { return (!get_name().is_empty() ? String(get_name()) + ":" : "") + Object::_to_string(); }'
+        )
+        result.append("")
+
     result.append("public:")
 
     # Special cases.

--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -93,7 +93,7 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const { return false; }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
 	void _validate_property(PropertyInfo &p_property) const {}
-	String _to_string() const { return "[" + String(get_class_static()) + ":" + itos(get_instance_id()) + "]"; }
+	String _to_string() const { return "<Wrapped#0>"; }
 
 	static void notification_bind(GDExtensionClassInstancePtr p_instance, int32_t p_what, GDExtensionBool p_reversed) {}
 	static GDExtensionBool set_bind(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionConstVariantPtr p_value) { return false; }
@@ -119,10 +119,6 @@ public:
 	static const StringName &get_class_static() {
 		static const StringName string_name = StringName("Wrapped");
 		return string_name;
-	}
-
-	uint64_t get_instance_id() const {
-		return 0;
 	}
 
 	// Must be public but you should not touch this.

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -18,8 +18,7 @@ func _ready():
 
 	# To string.
 	assert_equal(example.to_string(),'[ GDExtension::Example <--> Instance ID:%s ]' % example.get_instance_id())
-	# It appears there's a bug with instance ids :-(
-	#assert_equal($Example/ExampleMin.to_string(), 'ExampleMin:[Wrapped:%s]' % $Example/ExampleMin.get_instance_id())
+	assert_equal($Example/ExampleMin.to_string(), 'ExampleMin:<ExampleMin#%s>' % $Example/ExampleMin.get_instance_id())
 
 	# Call static methods.
 	assert_equal(Example.test_static(9, 100), 109);


### PR DESCRIPTION
I couldn't find an issue for this, but it seems that the default `_to_string()` for extension classes just always returns `"[Wrapped:0]"` which is not very helpful :-)

This PR fixes it by moving the default `_to_string()` implementation to `Object`, rather than `Wrapped`. And it makes the one on `Wrapped` explicitly always return `"[Wrapped:0]"` like it did before, but without all the code that made it look like it was doing something more sophisticated.