### PR TITLE
Added aligned memory management methods

### DIFF
--- a/gdextension/gdextension_interface.h
+++ b/gdextension/gdextension_interface.h
@@ -839,6 +839,45 @@ typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
  */
 typedef void (*GDExtensionInterfaceMemFree)(void *p_ptr);
 
+// TODO: Uncomment if the approach is to add to the interface instead of a local implementation
+// /**
+//  * @name mem_aligned_alloc
+//  * @since 4.5
+//  * 
+//  * Allocates memory aligned to user input
+//  * 
+//  * @param p_bytes The amount of memory to allocate in bytes
+//  * @param p_align The alignment of the memory block to allocate to the nearest byte
+//  * 
+//  * @return A pointer to the allocated aligned memory, or NULL if unsucessful
+//  */
+// typedef void *(*GDExtensionInterfaceMemAlignedAlloc)(size_t p_bytes, size_t p_align);
+
+// /**
+//  * @name mem_aligned_realloc
+//  * @since 4.5
+//  *
+//  * Reallocates memory aligned to user input.
+//  *
+//  * @param p_ptr A pointer to the previously allocated aligned memory.
+//  * @param p_bytes The number of bytes to resize the memory block to.
+//  * @param p_prev_bytes The previous size of the memory block in bytes.
+//  * @param p_align The alignment of the memory block to allocate to the nearest byte.
+//  *
+//  * @return A pointer to the allocated aligned memory, or NULL if unsuccessful.
+//  */
+// typedef void *(*GDExtensionInterfaceMemAlignedRealloc)(void *p_ptr, size_t p_bytes, size_t p_prev_bytes, size_t p_align);
+
+// /**
+//  * @name mem_aligned_free
+//  * @since 4.5
+//  *
+//  * Frees memory allocated with `mem_aligned_alloc`.
+//  *
+//  * @param p_ptr A pointer to the previously allocated aligned memory.
+//  */
+// typedef void (*GDExtensionInterfaceMemAlignedFree)(void *p_ptr);
+
 /* INTERFACE: Godot Core */
 
 /**

--- a/include/godot_cpp/core/memory.hpp
+++ b/include/godot_cpp/core/memory.hpp
@@ -79,6 +79,10 @@ public:
 	static void *alloc_static(size_t p_bytes, bool p_pad_align = false);
 	static void *realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align = false);
 	static void free_static(void *p_ptr, bool p_pad_align = false);
+
+	static void *alloc_aligned_static(size_t p_bytes, size_t p_alignment);
+	static void *realloc_aligned_static(void *p_memory, size_t p_bytes, size_t p_prev_bytes, size_t p_alignment);
+	static void free_aligned_static(void *p_ptr);
 };
 
 template <typename T, std::enable_if_t<!std::is_base_of<::godot::Wrapped, T>::value, bool> = true>
@@ -95,6 +99,10 @@ _ALWAYS_INLINE_ T *_post_initialize(T *p_obj) {
 #define memalloc(m_size) ::godot::Memory::alloc_static(m_size)
 #define memrealloc(m_mem, m_size) ::godot::Memory::realloc_static(m_mem, m_size)
 #define memfree(m_mem) ::godot::Memory::free_static(m_mem)
+
+#define memalloc_aligned(m_size, m_alignment) ::godot::Memory::alloc_aligned_static(m_size, m_alignment)
+#define memrealloc_aligned(m_mem, m_size, m_prev_size, m_alignment) ::godot::Memory::realloc_aligned_static(m_mem, m_size, m_prev_size, m_alignment)
+#define memfree_aligned(m_mem) ::godot::Memory::free_aligned_static(m_mem)
 
 #define memnew(m_class) (::godot::_pre_initialize<std::remove_pointer_t<decltype(new ("", "") m_class)>>(), ::godot::_post_initialize(new ("", "") m_class))
 

--- a/include/godot_cpp/godot.hpp
+++ b/include/godot_cpp/godot.hpp
@@ -47,6 +47,10 @@ extern "C" GDExtensionInterfaceGetGodotVersion gdextension_interface_get_godot_v
 extern "C" GDExtensionInterfaceMemAlloc gdextension_interface_mem_alloc;
 extern "C" GDExtensionInterfaceMemRealloc gdextension_interface_mem_realloc;
 extern "C" GDExtensionInterfaceMemFree gdextension_interface_mem_free;
+// TODO: Uncomment if the engine is updated to use this extended interface
+// extern "C" GDExtensionInterfaceMemAlignedAlloc gdextension_interface_mem_aligned_alloc;
+// extern "C" GDExtensionInterfaceMemAlignedRealloc gdextension_interface_mem_aligned_realloc;
+// extern "C" GDExtensionInterfaceMemAlignedFree gdextension_interface_mem_aligned_free;
 extern "C" GDExtensionInterfacePrintError gdextension_interface_print_error;
 extern "C" GDExtensionInterfacePrintErrorWithMessage gdextension_interface_print_error_with_message;
 extern "C" GDExtensionInterfacePrintWarning gdextension_interface_print_warning;

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -54,6 +54,10 @@ GDExtensionInterfaceGetGodotVersion gdextension_interface_get_godot_version = nu
 GDExtensionInterfaceMemAlloc gdextension_interface_mem_alloc = nullptr;
 GDExtensionInterfaceMemRealloc gdextension_interface_mem_realloc = nullptr;
 GDExtensionInterfaceMemFree gdextension_interface_mem_free = nullptr;
+// TODO: Uncomment if the engine is updated to use this extended interface
+// GDExtensionInterfaceMemAlignedAlloc gdextension_interface_mem_aligned_alloc = nullptr;
+// GDExtensionInterfaceMemAlignedRealloc gdextension_interface_mem_aligned_realloc = nullptr;
+// GDExtensionInterfaceMemAlignedFree gdextension_interface_mem_aligned_free = nullptr;
 GDExtensionInterfacePrintError gdextension_interface_print_error = nullptr;
 GDExtensionInterfacePrintErrorWithMessage gdextension_interface_print_error_with_message = nullptr;
 GDExtensionInterfacePrintWarning gdextension_interface_print_warning = nullptr;


### PR DESCRIPTION
Implements aligned memory management on the godot-cpp side of the extension interface.  See [proposal](https://github.com/godotengine/godot-proposals/issues/12336).  

In this implementation, the interface itself is not updated and instead the godot-cpp side uses the same methodology as the engine to allocate memory in an aligned manner, using the existing alloc_static interface.  There is commented code in several files that can be used to interface with the [engine side interface implementation](https://github.com/godotengine/godot/pull/105947) if that is preferred instead.