### PR TITLE
fix: Add iOS min SDK version link flags

### DIFF
--- a/tools/ios.py
+++ b/tools/ios.py
@@ -36,9 +36,11 @@ def generate(env):
     if env["ios_simulator"]:
         sdk_name = "iphonesimulator"
         env.Append(CCFLAGS=["-mios-simulator-version-min=" + env["ios_min_version"]])
+        env.Append(LINKFLAGS=["-mios-simulator-version-min=" + env["ios_min_version"]])
     else:
         sdk_name = "iphoneos"
         env.Append(CCFLAGS=["-miphoneos-version-min=" + env["ios_min_version"]])
+        env.Append(LINKFLAGS=["-miphoneos-version-min=" + env["ios_min_version"]])
 
     if sys.platform == "darwin":
         if env["IOS_SDK_PATH"] == "":


### PR DESCRIPTION
This is required when publishing to the App Store, and consistent with what we already do for the macOS deployment target.

See godotengine/webrtc-native#169