### PR TITLE
Fix CMake double precision builds

### DIFF
--- a/cmake/GodotCPPModule.cmake
+++ b/cmake/GodotCPPModule.cmake
@@ -86,9 +86,9 @@ missing. ]]
 function(
     binding_generator_generate_bindings
     API_FILE
-    USE_TEMPLATE_GET_NODE,
-    BITS,
-    PRECISION,
+    USE_TEMPLATE_GET_NODE
+    BITS
+    PRECISION
     OUTPUT_DIR
 )
     # This code snippet will be squashed into a single line


### PR DESCRIPTION
Double precision builds with CMake are currently broken. Since I'm contributing the fix directly I did not bother to make an issue first, but please let me know if that is required.

The `binding_generator_generate_bindings` function has erroneous commas after some of its arguments (i.e., `PRECISION,`), but this is not correct CMake syntax; the arguments should be separated by whitespace. This causes the `USE_TEMPLATE_GET_NODE`, `BITS`, and `PRECISION` arguments to not be properly received when this function is invoked. This is partially masked for the `BITS` argument as there is a `BITS` variable at a higher CMake scope that is used.

The end result is that the `PYTHON_SCRIPT` always ends up getting populated with  `precision=''` and `use_template_get_node=''`, which makes it impossible to get a working double precision build via CMake.