### PR TITLE
Fix: Add STATUS to CMake message commands missing them

### DIFF
--- a/cmake/common_compiler_flags.cmake
+++ b/cmake/common_compiler_flags.cmake
@@ -47,7 +47,7 @@ by default, we need to test for it. ]]
 function(compiler_detection)
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
         if(${CMAKE_CXX_COMPILER_FRONTEND_VARIANT} STREQUAL MSVC)
-            message("Using clang-cl")
+            message(STATUS "Using clang-cl")
             set(IS_CLANG "0" PARENT_SCOPE)
             set(IS_MSVC "1" PARENT_SCOPE)
             set(NOT_MSVC "0" PARENT_SCOPE)

--- a/cmake/godotcpp.cmake
+++ b/cmake/godotcpp.cmake
@@ -29,7 +29,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/windows.cmake)
 # Detect number of processors
 include(ProcessorCount)
 ProcessorCount(PROC_MAX)
-message("Auto-detected ${PROC_MAX} CPU cores available for build parallelism.")
+message(STATUS "Auto-detected ${PROC_MAX} CPU cores available for build parallelism.")
 
 # List of known platforms
 set(PLATFORM_LIST
@@ -197,15 +197,16 @@ function(godotcpp_generate)
     another compiler simulating the Visual C++ cl command-line syntax. ]]
     if(MSVC)
         math(EXPR PROC_N "(${PROC_MAX}-1) | (${X}-2)>>31 & 1")
-        message("Using ${PROC_N} cores for multi-threaded compilation.")
+        message(STATUS "Using ${PROC_N} cores for multi-threaded compilation.")
         # TODO You can override it at configure time with ...." )
     else()
         message(
+            STATUS
             "Using ${CMAKE_BUILD_PARALLEL_LEVEL} cores, You can override"
             " it at configure time by using -j <n> or --parallel <n> on the build"
             " command."
         )
-        message("  eg. cmake --build . -j 7  ...")
+        message(STATUS "  eg. cmake --build . -j 7  ...")
     endif()
 
     #[[ GODOTCPP_SYMBOL_VISIBLITY
@@ -245,8 +246,8 @@ function(godotcpp_generate)
     # Build Profile
     if(GODOTCPP_BUILD_PROFILE)
         message(STATUS "Using build profile to trim api file")
-        message("\tBUILD_PROFILE = '${GODOTCPP_BUILD_PROFILE}'")
-        message("\tAPI_SOURCE = '${GODOTCPP_GDEXTENSION_API_FILE}'")
+        message(STATUS "\tBUILD_PROFILE = '${GODOTCPP_BUILD_PROFILE}'")
+        message(STATUS "\tAPI_SOURCE = '${GODOTCPP_GDEXTENSION_API_FILE}'")
         build_profile_generate_trimmed_api(
                 "${GODOTCPP_BUILD_PROFILE}"
                 "${GODOTCPP_GDEXTENSION_API_FILE}"


### PR DESCRIPTION
Set message mode to STATUS for those missing a mode, to avoid direction to `stderr`