### PR TITLE
Files generated by SCons should depend on the `build_profile` (if given)

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -141,7 +141,12 @@ def scons_emit_files(target, source, env):
     env.Clean(target, [env.File(f) for f in get_file_list(str(source[0]), target[0].abspath, True, True)])
 
     api = generate_trimmed_api(str(source[0]), profile_filepath)
-    files = [env.File(f) for f in _get_file_list(api, target[0].abspath, True, True)]
+    files = []
+    for f in _get_file_list(api, target[0].abspath, True, True):
+        file = env.File(f)
+        if profile_filepath:
+            env.Depends(file, profile_filepath)
+        files.append(file)
     env["godot_cpp_gen_dir"] = target[0].abspath
     return files, source
 


### PR DESCRIPTION
On [godot_openxr_vendors](https://github.com/GodotVR/godot_openxr_vendors), we've been having this problem with the SCons cache on CI, where if a PR adds something to the `build_profile.json` it'll still use outdated generated files from the cache.

This change attempts to make it so that it'll rebuild the generated files if the `build_profile.json` changes

I'm still not entirely sure this fixes the issue, because it's hard to test in the context of CI, but I'll see what I can do!

And I'd also appreciate feedback from folks who are more experienced with build system stuff