### PR TITLE
[GitHub CI] Fix source detection, added missing include .hpp and .inc to detection rules.

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -34,13 +34,14 @@ jobs:
               - '.github/workflows/*.yml'
               - '**/*.py'
               - '**/*.cpp'
+              - '**/*.hpp'
               - '**/*.h'
+              - '**/*.inc'
               - 'test/build_profile.json'
               - 'gdextension/extension_api.json'
             scons:
               - '**/SConstruct'
               - '**/SCsub'
-              - '**/*.py'
             cmake:
               - '**/CMakeLists.txt'
               - '**/*.cmake'


### PR DESCRIPTION
It was noticed in #1772 that after updating a header the CI was not triggered.
This was my fault when I made the detection rules.
This PR updates the rules to include the missing .hpp files.

I also double checked what other files may be valid to detect and found `include\godot_cpp\core\math.compat.inc`
I removed redundant .py detection in scons, as it was already in the sources section which triggers both builds.