### PR TITLE
Disable double precisions builds in CI for now

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -40,15 +40,6 @@ jobs:
             artifact-path: cmake-build/bin/libgodot-cpp.linux.template_release.x86_64.a
             run-tests: true
 
-          - name: 🐧 Linux (GCC, Makefiles, Double Precision)
-            os: ubuntu-22.04
-            platform: linux
-            config-flags: -DCMAKE_BUILD_TYPE=Release -DGODOTCPP_PRECISION=double
-            artifact-name: godot-cpp-linux-glibc2.27-x86_64-double-release.cmake
-            artifact-path: cmake-build/bin/libgodot-cpp.linux.template_release.double.x86_64.a
-            flags: precision=double
-            run-tests: false
-
           - name: 🏁 Windows (x86_64, MSVC)
             os: windows-2019
             platform: windows

--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -33,15 +33,6 @@ jobs:
             run-tests: true
             cache-name: linux-x86_64
 
-          - name: 🐧 Linux (GCC, Double Precision)
-            os: ubuntu-22.04
-            platform: linux
-            artifact-name: godot-cpp-linux-glibc2.27-x86_64-double-release
-            artifact-path: bin/libgodot-cpp.linux.template_release.double.x86_64.a
-            flags: precision=double
-            run-tests: false
-            cache-name: linux-x86_64-f64
-
           - name: 🏁 Windows (x86_64, MSVC)
             os: windows-2019
             platform: windows


### PR DESCRIPTION
godot-cpp's CI does some double precision builds, however, it's using the `extension_api.json` in the repo which is from a single precision build, and hence shouldn't be used for this purpose.

In https://github.com/godotengine/godot-cpp/pull/1714, we added some protections to stop users from doing this, but they hadn't kicked in yet because we needed an updated `extension_api.json` that included precision information

Commit https://github.com/godotengine/godot-cpp/commit/61f52cb3280ade85000c64baadf77e159a5e11fa synchronized the `extension_api.json` with 4.5-beta1 which includes this information, and now CI is failing... And it should fail because this not a valid build!

**This PR just removes the double precision builds for now.**

I also can't ever recall these tests ever failing before, so it's not like they've been helping us catch bugs or anything. (These builds would never have actually worked, given that we were using the wrong `extension_api.json` anyway)

If we want to add double precision builds back, that's fine, but we'll need to figure out how to do them. I don't really want to add a double precision `extension_api.json` to the repo, because I want the JSON we release with to be from official builds, and there are no official builds with double precision. So, we'll need some solution to that.