### PR TITLE
Update CI to use `windows-2022`

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -41,7 +41,7 @@ jobs:
             run-tests: true
 
           - name: 🏁 Windows (x86_64, MSVC)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             compiler: msvc
             build-flags: --config Release
@@ -50,7 +50,7 @@ jobs:
             run-tests: false
 
           - name: 🏁 Windows (x86_64, MinGW, Ninja)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             compiler: mingw
             config-flags:

--- a/.github/workflows/ci-scons.yml
+++ b/.github/workflows/ci-scons.yml
@@ -34,7 +34,7 @@ jobs:
             cache-name: linux-x86_64
 
           - name: 🏁 Windows (x86_64, MSVC)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             artifact-name: godot-cpp-windows-msvc2019-x86_64-release
             artifact-path: bin/libgodot-cpp.windows.template_release.x86_64.lib
@@ -42,7 +42,7 @@ jobs:
             cache-name: windows-x86_64-msvc
 
           - name: 🏁 Windows (x86_64, MinGW)
-            os: windows-2019
+            os: windows-2022
             platform: windows
             artifact-name: godot-cpp-linux-mingw-x86_64-release
             artifact-path: bin/libgodot-cpp.windows.template_release.x86_64.a


### PR DESCRIPTION
We're currently using `windows-2019` for our Windows builds, and it looks like GitHub is going to retire it on 2025-06-30 (6 days from now):

https://github.com/actions/runner-images/issues/12045

This PR updates to using `windows-2022`