### PR TITLE
Allow searching LIBRARY_PATH with build_library=no

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -564,16 +564,25 @@ def _godot_cpp(env):
     library = None
     library_name = "libgodot-cpp" + env["suffix"] + env["LIBSUFFIX"]
 
+    default_args = []
+
     if env["build_library"]:
         library = env.StaticLibrary(target=env.File("bin/%s" % library_name), source=sources)
         env.NoCache(library)
         default_args = [library]
 
-        # Add compiledb if the option is set
-        if env.get("compiledb", False):
-            default_args += ["compiledb"]
+        env.AppendUnique(LIBS=[env.File("bin/%s" % library_name)])
+    else:
+        # When not building the library, allow it to be found in other library
+        # paths on the system. It may have been built previously, so still add
+        # bin/ to the search path.
+        env.AppendUnique(LIBPATH=[env.Dir("bin/")])
+        env.AppendUnique(LIBS=[library_name])
 
-        env.Default(*default_args)
+    # Add compiledb if the option is set
+    if env.get("compiledb", False):
+        default_args += ["compiledb"]
 
-    env.AppendUnique(LIBS=[env.File("bin/%s" % library_name)])
+    env.Default(*default_args)
+
     return library


### PR DESCRIPTION
Currently when building a downstream project with `build_library=no`, the library is still assumed to be present in `godot-cpp/bin/` from a previous build. With this change, allow the linker to search the system (`LIBRARY_PATH`) for it. When `build_library=yes`, the current behavior of passing the entire path to the linker is retained, since in that case you definitely intended to use the newly-built version.

This change allows more flexibility in the build process of downstream projects: while they still need to have the godot-cpp submodule present for the `SConscript`, the library can more easily be built as part of a previous step or even preinstalled into the build environment. My specific goal is to save build time in CI with multiple GDExtensions that all use the same version of godot-cpp.

```
>> scons verbose=yes build_library=no
scons: Reading SConscript files ...
Auto-detected 16 CPU cores available for build parallelism. Using 15 cores by default. You can override it with the -j argument.
Building for architecture x86_64 on platform linux
scons: done reading SConscript files.
…
g++ -o demo/addons/mylib/bin/linux64/libmyliblinux.template_debug.x86_64.so -Wl,-R,'$ORIGIN' -m64 -march=x86-64 -fvisibility=hidden -s -shared -Wl,-rpath=\$ORIGIN src/register_types.os src/mylib.os src/gen/doc_data.gen.os -Lgodot-cpp/bin -lgodot-cpp.linux.template_debug.x86_64
scons: done building targets.
```

I'm no scons expert so there may be a more idiomatic approach to this. It does technically have a side effect: if a shared library version of godot-cpp somehow existed on the system, it would be preferred because scons [has no way to force a given library to be used statically](https://github.com/SCons/scons/issues/2743#issuecomment-1785369405). In practice, this will never happen.