### PR TITLE
Fix `custom_api_file` with SCons 4.0.1

### DIFF
--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -258,8 +258,7 @@ def options(opts, env):
             help="Path to a custom directory containing GDExtension interface header and API JSON file",
             default=env.get("gdextension_dir", None),
             validator=validate_dir,
-        ),
-        converter=normalize_path,
+        )
     )
     opts.Add(
         PathVariable(
@@ -267,8 +266,7 @@ def options(opts, env):
             help="Path to a custom GDExtension API JSON file (takes precedence over `gdextension_dir`)",
             default=env.get("custom_api_file", None),
             validator=validate_file,
-        ),
-        converter=normalize_path,
+        )
     )
     opts.Add(
         BoolVariable(
@@ -537,8 +535,10 @@ def generate(env):
 
 
 def _godot_cpp(env):
-    extension_dir = env.get("gdextension_dir", default=env.Dir("gdextension").srcnode().abspath)
-    api_file = env.get("custom_api_file", default=os.path.join(extension_dir, "extension_api.json"))
+    extension_dir = normalize_path(env.get("gdextension_dir", default=env.Dir("gdextension").srcnode().abspath), env)
+    api_file = normalize_path(
+        env.get("custom_api_file", default=os.path.join(extension_dir, "extension_api.json")), env
+    )
 
     bindings = env.GodotCPPBindings(
         env.Dir("."),


### PR DESCRIPTION
After https://github.com/godotengine/godot-cpp/pull/1669, I'm getting an error like this with `custom_api_file`:

<details>
<summary>Python `FileNotFoundError` exception</summary>

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/dsnopek/Sync/Projects/default/godot_openxr_vendors/thirdparty/godot_cpp_gdextension_api/thirdparty/godot_cpp_gdextension_api/extension_api.json':
  File "/home/dsnopek/Sync/Projects/default/godot-cpp/test/SConstruct", line 3:
    env = SConscript("../SConstruct")
  File "/usr/lib/python3/dist-packages/SCons/Script/SConscript.py", line 661:
    return method(*args, **kw)
  File "/usr/lib/python3/dist-packages/SCons/Script/SConscript.py", line 598:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/usr/lib/python3/dist-packages/SCons/Script/SConscript.py", line 287:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/dsnopek/Sync/Projects/default/godot-cpp/SConstruct", line 54:
    library = env.GodotCPP()
  File "/usr/lib/python3/dist-packages/SCons/Environment.py", line 219:
    return self.method(*nargs, **kwargs)
  File "/home/dsnopek/Sync/Projects/default/godot-cpp/tools/godotcpp.py", line 543:
    bindings = env.GodotCPPBindings(
  File "/usr/lib/python3/dist-packages/SCons/Environment.py", line 255:
    return MethodWrapper.__call__(self, target, source, *args, **kw)
  File "/usr/lib/python3/dist-packages/SCons/Environment.py", line 219:
    return self.method(*nargs, **kwargs)
  File "/usr/lib/python3/dist-packages/SCons/Builder.py", line 653:
    return self._execute(env, target, source, OverrideWarner(kw), ekw)
  File "/usr/lib/python3/dist-packages/SCons/Builder.py", line 563:
    tlist, slist = self._create_nodes(env, target, source)
  File "/usr/lib/python3/dist-packages/SCons/Builder.py", line 525:
    target, source = self.emitter(target=tlist, source=slist, env=env)
  File "/home/dsnopek/Sync/Projects/default/godot-cpp/tools/godotcpp.py", line 141:
    env.Clean(target, [env.File(f) for f in get_file_list(str(source[0]), target[0].abspath, True, True)])
  File "/home/dsnopek/Sync/Projects/default/godot-cpp/binding_generator.py", line 205:
    with open(api_filepath, encoding="utf-8") as api_file:
```
</details>

It's looking for the file relative to the godot-cpp directory, rather than relative to the directory where the `scons` command was run.

This is with SCons 4.0.1, which is what comes with Ubuntu 22.04, however, if I update to SCons 4.9.1 via pip, then everything works as expected.

I did some testing (debug `print()` statements and all!), and it seems like the `converter=normalize_path` that https://github.com/godotengine/godot-cpp/pull/1669 added _is_ running, but it doesn't seem to actually affect the value returned by `env.get('custom_api_file')`.

This PR removes the `converter` and switches back to calling `normalize_path` directly, and everything works for me.

@Ivorforce Does your `variant_dir` stuff still work with this change?