### PR TITLE
Only check for Godot 4.0 if the pointer is aligned how it would be for the legacy interface.

### DIFF
--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -289,7 +289,7 @@ GDExtensionBool GDExtensionBinding::init(GDExtensionInterfaceGetProcAddress p_ge
 
 	// Make sure we weren't passed the legacy struct.
 	uint32_t *raw_interface = (uint32_t *)(void *)p_get_proc_address;
-	if (raw_interface[0] == 4 && raw_interface[1] == 0) {
+	if (uintptr_t(p_get_proc_address) % alignof(LegacyGDExtensionInterface) == 0 && raw_interface[0] == 4 && raw_interface[1] == 0) {
 		// Use the legacy interface only to give a nice error.
 		LegacyGDExtensionInterface *legacy_interface = (LegacyGDExtensionInterface *)p_get_proc_address;
 		internal::gdextension_interface_print_error = (GDExtensionInterfacePrintError)legacy_interface->print_error;


### PR DESCRIPTION
Not checking the function pointer before reading it like a struct causes ubsan to detect this as a problem.