### PR TITLE
Take reference in `Wrapped(const StringName &)`

### DIFF
--- a/include/godot_cpp/classes/wrapped.hpp
+++ b/include/godot_cpp/classes/wrapped.hpp
@@ -111,7 +111,7 @@ protected:
 
 	void _postinitialize();
 
-	Wrapped(const StringName p_godot_class);
+	Wrapped(const StringName &p_godot_class);
 	Wrapped(GodotObject *p_godot_object);
 	virtual ~Wrapped() {}
 

--- a/src/classes/wrapped.cpp
+++ b/src/classes/wrapped.cpp
@@ -66,7 +66,7 @@ void Wrapped::_postinitialize() {
 	}
 }
 
-Wrapped::Wrapped(const StringName p_godot_class) {
+Wrapped::Wrapped(const StringName &p_godot_class) {
 #ifdef HOT_RELOAD_ENABLED
 	if (unlikely(Wrapped::_constructing_recreate_owner)) {
 		_owner = Wrapped::_constructing_recreate_owner;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1797

This avoids a copy!

The automated tests run fine, and since this is only used internally, I don't think it should cause any issues