### PR TITLE
Remove <string> includes in headers to improve build time

### DIFF
--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -47,7 +47,6 @@
 #include <list>
 #include <mutex>
 #include <set>
-#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -39,10 +39,7 @@
 
 #include <godot_cpp/classes/global_constants.hpp>
 
-#include <string>
 #include <vector>
-
-#include <iostream>
 
 namespace godot {
 

--- a/src/godot.cpp
+++ b/src/godot.cpp
@@ -39,6 +39,8 @@
 
 #include <godot_cpp/core/error_macros.hpp>
 
+#include <stdio.h>
+
 namespace godot {
 
 namespace internal {


### PR DESCRIPTION
The `<string>` header was in `class_db.hpp` and `method_bind.hpp` even though no parts of it are used in either of those files.  I also removed the `<iostream>` header from class_db.hpp because it was also unused. Both of these files ended up getting included in thousands of other cpp files so slowed down build time a lot.

There seem to be only 2 uses of code from `<string>` in godot-cpp as the code works now:
1. In src/godot.cpp it was used for printf and snprintf. Removing <string> from the class_db header broke this but just including stdio fixed it.
2. It was also used in templates/char_traits.cpp for std::char_traits::length. I left the <string> include in this file because I didn't want to change how it works and it's in a cpp file so it doesn't matter that much.

I did 2 test runs where I ran with ClangBuildAnalyzer and the `time` command then did `scons --clean`. These are the timings I got before and after making these changes:

## Without these changes
Executed in  108.61 secs
Executed in  107.91 secs

**** Time summary:
Compilation (1025 times):
  Parsing (frontend):         1701.6 s
  Codegen & opts (backend):    187.1 s

## With these changes
Executed in   97.04 secs
Executed in   91.19 secs

**** Time summary:
Compilation (1025 times):
  Parsing (frontend):         1393.1 s
  Codegen & opts (backend):    181.2 s
