### PR TITLE
Use LocalVector instead of std::vector

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -37,7 +37,6 @@
 #include <godot_cpp/core/type_info.hpp>
 
 #include <array>
-#include <vector>
 
 namespace godot {
 
@@ -331,7 +330,7 @@ void call_with_variant_args_retc(T *p_instance, R (T::*p_method)(P...) const, co
 }
 
 template <typename T, typename... P>
-void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -366,7 +365,7 @@ void call_with_variant_args_dv(T *p_instance, void (T::*p_method)(P...), const G
 }
 
 template <typename T, typename... P>
-void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -401,7 +400,7 @@ void call_with_variant_argsc_dv(T *p_instance, void (T::*p_method)(P...) const, 
 }
 
 template <typename T, typename R, typename... P>
-void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -436,7 +435,7 @@ void call_with_variant_args_ret_dv(T *p_instance, R (T::*p_method)(P...), const 
 }
 
 template <typename T, typename R, typename... P>
-void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const, const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_args_retc_dv(T *p_instance, R (T::*p_method)(P...) const, const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -548,7 +547,7 @@ void call_with_variant_args_static(void (*p_method)(P...), const Variant **p_arg
 }
 
 template <typename... P>
-void call_with_variant_args_static_dv(void (*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_args_static_dv(void (*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;
@@ -640,7 +639,7 @@ void call_with_variant_args_static_ret(R (*p_method)(P...), const Variant **p_ar
 }
 
 template <typename R, typename... P>
-void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const std::vector<Variant> &default_values) {
+void call_with_variant_args_static_ret_dv(R (*p_method)(P...), const GDExtensionConstVariantPtr *p_args, int p_argcount, Variant &r_ret, GDExtensionCallError &r_error, const LocalVector<Variant> &default_values) {
 #ifdef DEBUG_ENABLED
 	if ((size_t)p_argcount > sizeof...(P)) {
 		r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;

--- a/include/godot_cpp/core/class_db.hpp
+++ b/include/godot_cpp/core/class_db.hpp
@@ -44,11 +44,12 @@
 // Needs to come after method_bind and object have been included.
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 
+#include <godot_cpp/templates/local_vector.hpp>
+
 #include <list>
 #include <mutex>
 #include <set>
 #include <unordered_map>
-#include <vector>
 
 // Needed to use StringName as key in `std::unordered_map`
 template <>
@@ -108,7 +109,7 @@ private:
 	static std::unordered_map<StringName, ClassInfo> classes;
 	static std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *> instance_binding_callbacks;
 	// Used to remember the custom class registration order.
-	static std::vector<StringName> class_register_order;
+	static LocalVector<StringName> class_register_order;
 	static std::unordered_map<StringName, Object *> engine_singletons;
 	static std::mutex engine_singletons_mutex;
 
@@ -190,7 +191,7 @@ public:
 	static MethodBind *bind_static_method(StringName p_class, N p_method_name, M p_method, VarArgs... p_args);
 
 	template <typename M>
-	static MethodBind *bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const std::vector<Variant> &p_default_args = std::vector<Variant>{}, bool p_return_nil_is_variant = true);
+	static MethodBind *bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info = MethodInfo(), const LocalVector<Variant> &p_default_args = LocalVector<Variant>{}, bool p_return_nil_is_variant = true);
 
 	static void add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix);
 	static void add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix);
@@ -330,7 +331,7 @@ MethodBind *ClassDB::bind_static_method(StringName p_class, N p_method_name, M p
 }
 
 template <typename M>
-MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info, const std::vector<Variant> &p_default_args, bool p_return_nil_is_variant) {
+MethodBind *ClassDB::bind_vararg_method(uint32_t p_flags, StringName p_name, M p_method, const MethodInfo &p_info, const LocalVector<Variant> &p_default_args, bool p_return_nil_is_variant) {
 	MethodBind *bind = create_vararg_method_bind(p_method, p_info, p_return_nil_is_variant);
 	ERR_FAIL_NULL_V(bind, nullptr);
 

--- a/include/godot_cpp/core/method_bind.hpp
+++ b/include/godot_cpp/core/method_bind.hpp
@@ -38,8 +38,7 @@
 #include <gdextension_interface.h>
 
 #include <godot_cpp/classes/global_constants.hpp>
-
-#include <vector>
+#include <godot_cpp/templates/local_vector.hpp>
 
 namespace godot {
 
@@ -54,9 +53,9 @@ class MethodBind {
 	bool _returns = false;
 	bool _vararg = false;
 
-	std::vector<StringName> argument_names;
+	LocalVector<StringName> argument_names;
 	GDExtensionVariantType *argument_types = nullptr;
-	std::vector<Variant> default_arguments;
+	LocalVector<Variant> default_arguments;
 
 protected:
 	void _set_const(bool p_const);
@@ -70,7 +69,7 @@ protected:
 	void set_argument_count(int p_count) { argument_count = p_count; }
 
 public:
-	_FORCE_INLINE_ const std::vector<Variant> &get_default_arguments() const { return default_arguments; }
+	_FORCE_INLINE_ const LocalVector<Variant> &get_default_arguments() const { return default_arguments; }
 	_FORCE_INLINE_ int get_default_argument_count() const { return (int)default_arguments.size(); }
 
 	_FORCE_INLINE_ Variant has_default_argument(int p_arg) const {
@@ -101,8 +100,8 @@ public:
 
 	PropertyInfo get_argument_info(int p_argument) const;
 
-	std::vector<PropertyInfo> get_arguments_info_list() const {
-		std::vector<PropertyInfo> vec;
+	LocalVector<PropertyInfo> get_arguments_info_list() const {
+		LocalVector<PropertyInfo> vec;
 		// First element is return value
 		vec.reserve(argument_count + 1);
 		for (int i = 0; i < argument_count + 1; i++) {
@@ -111,8 +110,8 @@ public:
 		return vec;
 	}
 
-	void set_argument_names(const std::vector<StringName> &p_names);
-	std::vector<StringName> get_argument_names() const;
+	void set_argument_names(const LocalVector<StringName> &p_names);
+	LocalVector<StringName> get_argument_names() const;
 
 	virtual GDExtensionClassMethodArgumentMetadata get_argument_metadata(int p_argument) const = 0;
 
@@ -133,10 +132,10 @@ public:
 	_FORCE_INLINE_ bool is_vararg() const { return _vararg; }
 	_FORCE_INLINE_ bool has_return() const { return _returns; }
 
-	void set_default_arguments(const std::vector<Variant> &p_default_arguments) { default_arguments = p_default_arguments; }
+	void set_default_arguments(const LocalVector<Variant> &p_default_arguments) { default_arguments = p_default_arguments; }
 
-	std::vector<GDExtensionClassMethodArgumentMetadata> get_arguments_metadata_list() const {
-		std::vector<GDExtensionClassMethodArgumentMetadata> vec;
+	LocalVector<GDExtensionClassMethodArgumentMetadata> get_arguments_metadata_list() const {
+		LocalVector<GDExtensionClassMethodArgumentMetadata> vec;
 		// First element is return value
 		vec.reserve(argument_count + 1);
 		for (int i = 0; i < argument_count + 1; i++) {
@@ -155,7 +154,7 @@ template <typename Derived, typename T, typename R, bool should_returns>
 class MethodBindVarArgBase : public MethodBind {
 protected:
 	R (T::*method)(const Variant **, GDExtensionInt, GDExtensionCallError &);
-	std::vector<PropertyInfo> arguments;
+	LocalVector<PropertyInfo> arguments;
 
 public:
 	virtual PropertyInfo gen_argument_type_info(int p_arg) const {
@@ -191,7 +190,7 @@ public:
 		if (p_method_info.arguments.size()) {
 			arguments = p_method_info.arguments;
 
-			std::vector<StringName> names;
+			LocalVector<StringName> names;
 			names.reserve(p_method_info.arguments.size());
 			for (size_t i = 0; i < p_method_info.arguments.size(); i++) {
 				names.push_back(p_method_info.arguments[i].name);

--- a/include/godot_cpp/core/object.hpp
+++ b/include/godot_cpp/core/object.hpp
@@ -38,13 +38,13 @@
 
 #include <godot_cpp/variant/variant.hpp>
 
+#include <godot_cpp/templates/local_vector.hpp>
+
 #include <godot_cpp/classes/object.hpp>
 
 #include <godot_cpp/godot.hpp>
 
 #include <gdextension_interface.h>
-
-#include <vector>
 
 #define ADD_SIGNAL(m_signal) ::godot::ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_GROUP(m_name, m_prefix) ::godot::ClassDB::add_property_group(get_class_static(), m_name, m_prefix)
@@ -65,10 +65,10 @@ struct MethodInfo {
 	PropertyInfo return_val;
 	uint32_t flags;
 	int id = 0;
-	std::vector<PropertyInfo> arguments;
-	std::vector<Variant> default_arguments;
+	LocalVector<PropertyInfo> arguments;
+	LocalVector<Variant> default_arguments;
 	GDExtensionClassMethodArgumentMetadata return_val_metadata;
-	std::vector<GDExtensionClassMethodArgumentMetadata> arguments_metadata;
+	LocalVector<GDExtensionClassMethodArgumentMetadata> arguments_metadata;
 
 	inline bool operator==(const MethodInfo &p_method) const { return id == p_method.id; }
 	inline bool operator<(const MethodInfo &p_method) const { return id == p_method.id ? (name < p_method.name) : (id < p_method.id); }
@@ -92,21 +92,17 @@ struct MethodInfo {
 
 template <typename... Args>
 MethodInfo::MethodInfo(StringName p_name, const Args &...args) :
-		name(p_name), flags(GDEXTENSION_METHOD_FLAG_NORMAL) {
-	arguments = { args... };
-}
+		name(p_name), flags(GDEXTENSION_METHOD_FLAG_NORMAL), arguments({ args... }) {}
 
 template <typename... Args>
 MethodInfo::MethodInfo(Variant::Type ret, StringName p_name, const Args &...args) :
-		name(p_name), flags(GDEXTENSION_METHOD_FLAG_NORMAL) {
+		name(p_name), flags(GDEXTENSION_METHOD_FLAG_NORMAL), arguments({ args... }) {
 	return_val.type = ret;
-	arguments = { args... };
 }
 
 template <typename... Args>
 MethodInfo::MethodInfo(const PropertyInfo &p_ret, StringName p_name, const Args &...args) :
-		name(p_name), return_val(p_ret), flags(GDEXTENSION_METHOD_FLAG_NORMAL) {
-	arguments = { args... };
+		name(p_name), return_val(p_ret), flags(GDEXTENSION_METHOD_FLAG_NORMAL), arguments({ args... }) {
 }
 
 class ObjectDB {

--- a/src/core/class_db.cpp
+++ b/src/core/class_db.cpp
@@ -36,13 +36,11 @@
 
 #include <godot_cpp/core/memory.hpp>
 
-#include <algorithm>
-
 namespace godot {
 
 std::unordered_map<StringName, ClassDB::ClassInfo> ClassDB::classes;
 std::unordered_map<StringName, const GDExtensionInstanceBindingCallbacks *> ClassDB::instance_binding_callbacks;
-std::vector<StringName> ClassDB::class_register_order;
+LocalVector<StringName> ClassDB::class_register_order;
 std::unordered_map<StringName, Object *> ClassDB::engine_singletons;
 std::mutex ClassDB::engine_singletons_mutex;
 GDExtensionInitializationLevel ClassDB::current_level = GDEXTENSION_INITIALIZATION_CORE;
@@ -157,7 +155,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const M
 
 	p_bind->set_hint_flags(p_flags);
 
-	std::vector<StringName> args;
+	LocalVector<StringName> args;
 	args.resize(method_name.args.size());
 	size_t arg_index = 0;
 	for (StringName arg : method_name.args) {
@@ -166,7 +164,7 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const M
 
 	p_bind->set_argument_names(args);
 
-	std::vector<Variant> defvals;
+	LocalVector<Variant> defvals;
 
 	defvals.resize(p_defcount);
 	for (int i = 0; i < p_defcount; i++) {
@@ -186,34 +184,34 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const M
 }
 
 void ClassDB::bind_method_godot(const StringName &p_class_name, MethodBind *p_method) {
-	std::vector<GDExtensionVariantPtr> def_args;
-	const std::vector<Variant> &def_args_val = p_method->get_default_arguments();
+	LocalVector<GDExtensionVariantPtr> def_args;
+	const LocalVector<Variant> &def_args_val = p_method->get_default_arguments();
 	def_args.resize(def_args_val.size());
 	for (size_t i = 0; i < def_args_val.size(); i++) {
 		def_args[i] = (GDExtensionVariantPtr)&def_args_val[i];
 	}
 
-	std::vector<PropertyInfo> return_value_and_arguments_info = p_method->get_arguments_info_list();
-	std::vector<GDExtensionClassMethodArgumentMetadata> return_value_and_arguments_metadata = p_method->get_arguments_metadata_list();
+	LocalVector<PropertyInfo> return_value_and_arguments_info = p_method->get_arguments_info_list();
+	LocalVector<GDExtensionClassMethodArgumentMetadata> return_value_and_arguments_metadata = p_method->get_arguments_metadata_list();
 
-	std::vector<GDExtensionPropertyInfo> return_value_and_arguments_gdextension_info;
+	LocalVector<GDExtensionPropertyInfo> return_value_and_arguments_gdextension_info;
 	return_value_and_arguments_gdextension_info.reserve(return_value_and_arguments_info.size());
-	for (std::vector<PropertyInfo>::iterator it = return_value_and_arguments_info.begin(); it != return_value_and_arguments_info.end(); it++) {
+	for (const PropertyInfo &info : return_value_and_arguments_info) {
 		return_value_and_arguments_gdextension_info.push_back(
 				GDExtensionPropertyInfo{
-						static_cast<GDExtensionVariantType>(it->type), // GDExtensionVariantType type;
-						it->name._native_ptr(), // GDExtensionStringNamePtr name;
-						it->class_name._native_ptr(), // GDExtensionStringNamePtr class_name;
-						it->hint, // uint32_t hint;
-						it->hint_string._native_ptr(), // GDExtensionStringPtr hint_string;
-						it->usage, // uint32_t usage;
+						static_cast<GDExtensionVariantType>(info.type), // GDExtensionVariantType type;
+						info.name._native_ptr(), // GDExtensionStringNamePtr name;
+						info.class_name._native_ptr(), // GDExtensionStringNamePtr class_name;
+						info.hint, // uint32_t hint;
+						info.hint_string._native_ptr(), // GDExtensionStringPtr hint_string;
+						info.usage, // uint32_t usage;
 				});
 	}
 
-	GDExtensionPropertyInfo *return_value_info = return_value_and_arguments_gdextension_info.data();
-	GDExtensionClassMethodArgumentMetadata *return_value_metadata = return_value_and_arguments_metadata.data();
-	GDExtensionPropertyInfo *arguments_info = return_value_and_arguments_gdextension_info.data() + 1;
-	GDExtensionClassMethodArgumentMetadata *arguments_metadata = return_value_and_arguments_metadata.data() + 1;
+	GDExtensionPropertyInfo *return_value_info = return_value_and_arguments_gdextension_info.ptr();
+	GDExtensionClassMethodArgumentMetadata *return_value_metadata = return_value_and_arguments_metadata.ptr();
+	GDExtensionPropertyInfo *arguments_info = return_value_and_arguments_gdextension_info.ptr() + 1;
+	GDExtensionClassMethodArgumentMetadata *arguments_metadata = return_value_and_arguments_metadata.ptr() + 1;
 
 	StringName name = p_method->get_name();
 	GDExtensionClassMethodInfo method_info = {
@@ -229,7 +227,7 @@ void ClassDB::bind_method_godot(const StringName &p_class_name, MethodBind *p_me
 		arguments_info, // GDExtensionPropertyInfo *
 		arguments_metadata, // GDExtensionClassMethodArgumentMetadata *
 		(uint32_t)p_method->get_default_argument_count(), // uint32_t default_argument_count;
-		def_args.data(), // GDExtensionVariantPtr *default_arguments;
+		def_args.ptr(), // GDExtensionVariantPtr *default_arguments;
 	};
 	internal::gdextension_interface_classdb_register_extension_class_method(internal::library, p_class_name._native_ptr(), &method_info);
 }
@@ -252,7 +250,7 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 	cl.signal_names.insert(p_signal.name);
 
 	// register our signal in godot
-	std::vector<GDExtensionPropertyInfo> parameters;
+	LocalVector<GDExtensionPropertyInfo> parameters;
 	parameters.reserve(p_signal.arguments.size());
 
 	for (const PropertyInfo &par : p_signal.arguments) {
@@ -266,7 +264,7 @@ void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) 
 		});
 	}
 
-	internal::gdextension_interface_classdb_register_extension_class_signal(internal::library, cl.name._native_ptr(), p_signal.name._native_ptr(), parameters.data(), parameters.size());
+	internal::gdextension_interface_classdb_register_extension_class_signal(internal::library, cl.name._native_ptr(), p_signal.name._native_ptr(), parameters.ptr(), parameters.size());
 }
 
 void ClassDB::bind_integer_constant(const StringName &p_class_name, const StringName &p_enum_name, const StringName &p_constant_name, GDExtensionInt p_constant_value, bool p_is_bitfield) {
@@ -413,8 +411,8 @@ void ClassDB::initialize(GDExtensionInitializationLevel p_level) {
 
 void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
 	std::set<StringName> to_erase;
-	for (std::vector<StringName>::reverse_iterator i = class_register_order.rbegin(); i != class_register_order.rend(); ++i) {
-		const StringName &name = *i;
+	for (int i = class_register_order.size() - 1; i >= 0; --i) {
+		const StringName &name = class_register_order[i];
 		const ClassInfo &cl = classes[name];
 
 		if (cl.level != p_level) {
@@ -432,17 +430,15 @@ void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
 	}
 
 	{
-		// The following is equivalent to c++20 `std::erase_if(class_register_order, [&](const StringName& name){ return to_erase.contains(name); });`
-		std::vector<StringName>::iterator it = std::remove_if(class_register_order.begin(), class_register_order.end(), [&](const StringName &p_name) {
-			return to_erase.count(p_name) > 0;
-		});
-		class_register_order.erase(it, class_register_order.end());
+		for (const StringName &x : to_erase) {
+			class_register_order.erase(x);
+		}
 	}
 
 	if (p_level == GDEXTENSION_INITIALIZATION_CORE) {
 		// Make a new list of the singleton objects, since freeing the instance bindings will lead to
 		// elements getting removed from engine_singletons.
-		std::vector<Object *> singleton_objects;
+		LocalVector<Object *> singleton_objects;
 		{
 			std::lock_guard<std::mutex> lock(engine_singletons_mutex);
 			singleton_objects.reserve(engine_singletons.size());
@@ -450,8 +446,8 @@ void ClassDB::deinitialize(GDExtensionInitializationLevel p_level) {
 				singleton_objects.push_back(pair.second);
 			}
 		}
-		for (std::vector<Object *>::iterator i = singleton_objects.begin(); i != singleton_objects.end(); i++) {
-			internal::gdextension_interface_object_free_instance_binding((*i)->_owner, internal::token);
+		for (const Object *i : singleton_objects) {
+			internal::gdextension_interface_object_free_instance_binding((*i)._owner, internal::token);
 		}
 	}
 }

--- a/src/core/method_bind.cpp
+++ b/src/core/method_bind.cpp
@@ -56,11 +56,11 @@ void MethodBind::set_name(const StringName &p_name) {
 	name = p_name;
 }
 
-void MethodBind::set_argument_names(const std::vector<StringName> &p_names) {
+void MethodBind::set_argument_names(const LocalVector<StringName> &p_names) {
 	argument_names = p_names;
 }
 
-std::vector<StringName> MethodBind::get_argument_names() const {
+LocalVector<StringName> MethodBind::get_argument_names() const {
 	return argument_names;
 }
 

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -60,7 +60,7 @@ Object *get_object_instance_binding(GodotObject *p_engine_object) {
 	return reinterpret_cast<Object *>(gdextension_interface_object_get_instance_binding(p_engine_object, token, binding_callbacks));
 }
 
-TypedArray<Dictionary> convert_property_list(const std::vector<PropertyInfo> &p_list) {
+TypedArray<Dictionary> convert_property_list(const LocalVector<PropertyInfo> &p_list) {
 	TypedArray<Dictionary> va;
 	for (const PropertyInfo &pi : p_list) {
 		va.push_back(Dictionary(pi));


### PR DESCRIPTION
This removes (almost) all of the std::vector usage and replaces it with Godot's LocalVector.

There is still one place in `classes/wrapped.cpp` where std::vector is still used that I didn't want to mess with because it calls push_back during static initialization and the allocation function that LocalVector::push_back uses from the GDExtension API isn't registered yet. Reworking this to figure out a better time to call push_back didn't look too fun so I'm just going to leave it as is.

I tested the build time difference with ClangBuildAnalyzer and got these results:

## With these changes:
Executed in  103.10 secs

**** Time summary:
Compilation (1025 times):
  Parsing (frontend):         1640.2 s
  Codegen & opts (backend):    190.6 s

 ## Without these changes

Executed in  106.30 secs

 **** Time summary:
Compilation (1025 times):
  Parsing (frontend):         1682.0 s
  Codegen & opts (backend):    184.8 s