### PR TITLE
Add clang PCH build

### DIFF
--- a/test/SConstruct
+++ b/test/SConstruct
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import os
+
 env = SConscript("../SConstruct")
 
 # For the reference:
@@ -13,6 +15,9 @@ env = SConscript("../SConstruct")
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
+
+if "clang" in os.path.basename(env["CC"]) and ARGUMENTS.get("use_pch", "no") == "yes":
+    env.Append(CXXFLAGS=["-include-pch", f"{os.path.abspath('./src/pch.hpp.pch')}"])
 
 if env["target"] in ["editor", "template_debug"]:
     doc_data = env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))

--- a/test/bd.py
+++ b/test/bd.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass()
+class Opts:
+    use_llvm: str = "yes"
+    optimize: str = "none"
+    debug_symbols: str = "yes"
+    compiledb: str = "yes"
+    use_pch: str = "yes"
+
+
+def get_command() -> str:
+    cmd = "scons"
+    for key, value in opts.__dict__.items():
+        cmd += f" {key}={value}"
+    return cmd
+
+
+def run(cmd: str = get_command()):
+    return subprocess.run(cmd, shell=True)
+
+
+def get_pch_build_command(file_path: str, json_file_path: str = "compile_commands.json") -> str:
+    """
+    Extracts the "command" associated with a given "file" from compile_commands.json.
+
+    Scons and godot have no pre compiled header support for clang so have to use stupid hacks to make it work
+    Hacky steps to compile pch:
+    1. Run `bd.py build_pch` this will then:
+    2. find the pch.cpp (file_path) entry in the generated compile_commands.json file
+    3. Copy the "command" parameter string to get the full compile command.
+    4. Change "-o /path/to/pch.cpp" to -o /path/to/src/pch.hpp.pch at the front of the command
+    5. Change the command target the the end of the command to "/path/to/src/pch.hpp"
+    6. Run the compile command with the replaced output and input arguments to compile the pch file
+
+    Note: If using with ccache make a file "~/.config/ccache/ccache.conf" with "sloppiness = pch_defines,time_macros" in it or ccache will not work with PCH.
+    """
+    import json
+
+    try:
+        with open(json_file_path, "r") as file:
+            data = json.load(file)
+
+        if isinstance(data, list):
+            for entry in data:
+                if not isinstance(entry, dict):
+                    continue
+
+                command = entry.get("command")
+                cpp_file = entry.get("file")
+                if command and cpp_file and file_path in cpp_file:
+                    return str(command)
+
+        print(f"No pch command found for file: {file_path}")
+        return ""
+
+    except FileNotFoundError:
+        print(f"Error: The file '{json_file_path}' was not found.")
+    except json.JSONDecodeError:
+        print("Error: Failed to decode JSON. Please check the file format.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+
+    return ""
+
+
+def build_pch(pch_path: str):
+    command = get_pch_build_command(pch_path + ".cpp")
+    if not command:
+        return
+
+    command = command.replace(pch_path + ".os", pch_path + ".hpp.pch")
+    command = command.replace(pch_path + ".cpp", pch_path + ".hpp")
+    command = command.replace(
+        "-fno-exceptions", "-fno-exceptions -fpch-codegen -fpch-preprocess -fpch-instantiate-templates"
+    )
+    command = re.sub(r"-include-pch\s.*(hpp\.pch)", "", command)
+    command = command.replace("register_types", "pch")
+
+    print("Precompiling header: ", pch_path.replace("register_types", "pch") + ".hpp")
+    run(command)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "command",
+    choices=[
+        "build_pch",
+        "time_trace",
+    ],
+    nargs="?",
+    help="Build command to execute.",
+)
+
+args = parser.parse_args()
+
+opts = Opts()
+
+if args.command == "build_pch":
+    opts.use_pch = "no"
+    build_pch("src/register_types")
+    exit(0)
+
+run()

--- a/test/src/pch.hpp
+++ b/test/src/pch.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cmath>
+
+#include <godot_cpp/classes/canvas_item.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/node2d.hpp>
+#include <godot_cpp/classes/node3d.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/core/class_db.hpp>
+
+#include "example.h"


### PR DESCRIPTION
Adds an option to use clang PCH to build a pch and then use it.

On my computer this makes clean build times go from 230 seconds without PCH to 11 seconds with PCH, about 91% faster compile time. This 91% increase is without my 7 other recent PRs that all also make build times faster.

For me PCH isn't even really about clean build time though that is what [Unity Builds](https://github.com/godotengine/godot-cpp/pull/1844) are for. This also makes incremental builds in user code considerably faster as you can pre compile all the expensive bloated headers from godot-cpp and from your own code. I measured this by just changing a number in example.cpp, without PCH this takes about 10 seconds to recompile. With PCH that same change only takes 3 seconds.

The way this is implemented is definitely wrong though and i'll need some help/tips on how to get it to fit more idiomatically in with the godot-cpp build. I ripped this straight out of how I currently do it in my engine module build system. I'm not really sure what the best way to adapt it to fit properly into godot-cpp's build system is since PCH is very complicated but it probably has to be it's own Builder which I don't' really know how to do.

It's also very compiler specific, this only works for clang. I've tested GCC's PCH and it pretty much doesn't work at all in my experience. I guess msvc also has solid PCH that scons has a built in Builder for but I've never used it.

There are also some minor problems with my current implementation because I can't figure out a way to get godot-cpp to generate all the bindings files without actually doing a full compilation. There doesn't seem to be any option to do that and the binding gen is so tightly coupled with the build system it's hard to figure it out.