### PR TITLE
Silenced compiler warning in godot::call_with_variant_args_ret_helper

### DIFF
--- a/include/godot_cpp/core/binder_common.hpp
+++ b/include/godot_cpp/core/binder_common.hpp
@@ -262,6 +262,7 @@ void call_with_variant_args_ret_helper(T *p_instance, R (T::*p_method)(P...), co
 #else
 	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
 #endif
+	(void)p_args; // Avoid warning.
 }
 
 template <typename T, typename R, typename... P, size_t... Is>
@@ -273,7 +274,7 @@ void call_with_variant_args_retc_helper(T *p_instance, R (T::*p_method)(P...) co
 #else
 	r_ret = (p_instance->*p_method)(VariantCaster<P>::cast(*p_args[Is])...);
 #endif
-	(void)p_args;
+	(void)p_args; // Avoid warning.
 }
 
 template <typename T, typename... P>


### PR DESCRIPTION
g++ falsely flagged `p_args` as unused. This PR applies the same fix used in the surrounding functions.

g++ -v: `g++ (Debian 12.2.0-14+deb12u1) 12.2.0`

clang (using clangd) does not report this warning at all.