### PR TITLE
Remove `CPPEXTPATH` changes, add error macros

### DIFF
--- a/include/godot_cpp/core/defs.hpp
+++ b/include/godot_cpp/core/defs.hpp
@@ -338,4 +338,47 @@ struct is_zero_constructible<const volatile T> : is_zero_constructible<T> {};
 template <typename T>
 inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 
+// Warning suppression helper macros.
+#if defined(__clang__)
+#define GODOT_CLANG_PRAGMA(m_content) _Pragma(#m_content)
+#define GODOT_CLANG_WARNING_PUSH GODOT_CLANG_PRAGMA(clang diagnostic push)
+#define GODOT_CLANG_WARNING_IGNORE(m_warning) GODOT_CLANG_PRAGMA(clang diagnostic ignored m_warning)
+#define GODOT_CLANG_WARNING_POP GODOT_CLANG_PRAGMA(clang diagnostic pop)
+#define GODOT_CLANG_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_CLANG_WARNING_PUSH GODOT_CLANG_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_CLANG_PRAGMA(m_content)
+#define GODOT_CLANG_WARNING_PUSH
+#define GODOT_CLANG_WARNING_IGNORE(m_warning)
+#define GODOT_CLANG_WARNING_POP
+#define GODOT_CLANG_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define GODOT_GCC_PRAGMA(m_content) _Pragma(#m_content)
+#define GODOT_GCC_WARNING_PUSH GODOT_GCC_PRAGMA(GCC diagnostic push)
+#define GODOT_GCC_WARNING_IGNORE(m_warning) GODOT_GCC_PRAGMA(GCC diagnostic ignored m_warning)
+#define GODOT_GCC_WARNING_POP GODOT_GCC_PRAGMA(GCC diagnostic pop)
+#define GODOT_GCC_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_GCC_WARNING_PUSH GODOT_GCC_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_GCC_PRAGMA(m_content)
+#define GODOT_GCC_WARNING_PUSH
+#define GODOT_GCC_WARNING_IGNORE(m_warning)
+#define GODOT_GCC_WARNING_POP
+#define GODOT_GCC_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define GODOT_MSVC_PRAGMA(m_content) __pragma(m_content)
+#define GODOT_MSVC_WARNING_PUSH GODOT_MSVC_PRAGMA(warning(push))
+#define GODOT_MSVC_WARNING_IGNORE(m_warning) GODOT_MSVC_PRAGMA(warning(disable : m_warning))
+#define GODOT_MSVC_WARNING_POP GODOT_MSVC_PRAGMA(warning(pop))
+#define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning) GODOT_MSVC_WARNING_PUSH GODOT_MSVC_WARNING_IGNORE(m_warning)
+#else
+#define GODOT_MSVC_PRAGMA(m_content)
+#define GODOT_MSVC_WARNING_PUSH
+#define GODOT_MSVC_WARNING_IGNORE(m_warning)
+#define GODOT_MSVC_WARNING_POP
+#define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
+#endif
+
 } //namespace godot

--- a/tools/godotcpp.py
+++ b/tools/godotcpp.py
@@ -445,17 +445,6 @@ def generate(env):
     else:  # Release
         opt_level = "speed"
 
-    # Allow marking includes as external/system to avoid raising warnings.
-    if env.scons_version < (4, 2):
-        env["_CPPEXTINCFLAGS"] = "${_concat(EXTINCPREFIX, CPPEXTPATH, EXTINCSUFFIX, __env__, RDirs, TARGET, SOURCE)}"
-    else:
-        env["_CPPEXTINCFLAGS"] = (
-            "${_concat(EXTINCPREFIX, CPPEXTPATH, EXTINCSUFFIX, __env__, RDirs, TARGET, SOURCE, affect_signature=False)}"
-        )
-    env["CPPEXTPATH"] = []
-    env["EXTINCPREFIX"] = "-isystem "
-    env["EXTINCSUFFIX"] = ""
-
     env["optimize"] = ARGUMENTS.get("optimize", opt_level)
     env["debug_symbols"] = get_cmdline_bool("debug_symbols", env.dev_build)
 

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -130,11 +130,6 @@ def generate(env):
         if env["silence_msvc"] and not env.GetOption("clean"):
             silence_msvc(env)
 
-        if not env["use_llvm"]:
-            env.AppendUnique(CCFLAGS=["/experimental:external", "/external:anglebrackets"])
-        env.AppendUnique(CCFLAGS=["/external:W0"])
-        env["EXTINCPREFIX"] = "/external:I"
-
     elif (sys.platform == "win32" or sys.platform == "msys") and not env["mingw_prefix"]:
         env["use_mingw"] = True
         mingw.generate(env)


### PR DESCRIPTION
- Depends on godotengine/godot#111331

In practice, this changes nothing, as `CPPEXTPATH` was never utilized here. However, with this being reverted in the above repo, this necessitates use of error macro wrappers to handle suppression instead. Those were never properly ported over here, so this PR adds them as well.