### PR TITLE
Fix passing multiple XML doc sources to generate_doc_source

### DIFF
--- a/cmake/GodotCPPModule.cmake
+++ b/cmake/GodotCPPModule.cmake
@@ -168,7 +168,7 @@ function(target_doc_sources TARGET SOURCES)
 
     # Create the file generation target, this won't be triggered unless a target
     # that depends on DOC_SOURCE_FILE is built
-    generate_doc_source( "${DOC_SOURCE_FILE}" ${SOURCES} )
+    generate_doc_source( "${DOC_SOURCE_FILE}" "${SOURCES}" )
 
     # Add DOC_SOURCE_FILE as a dependency to TARGET
     target_sources(${TARGET} PRIVATE "${DOC_SOURCE_FILE}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(
 # conditionally add doc data to compile output
 if(GODOTCPP_TARGET MATCHES "editor|template_debug")
     file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
-    target_doc_sources( ${TARGET_NAME} ${DOC_XML} )
+    target_doc_sources( ${TARGET_NAME} "${DOC_XML}" )
 endif()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/")


### PR DESCRIPTION
CMake functions only received the first XML file due to argument expansion.
Quoting the SOURCES argument ensures multiple XML doc sources are passed correctly.