### PR TITLE
Fix missing Infinity/NaN handling in bindings generator

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -696,6 +696,7 @@ def generate_builtin_class_header(builtin_api, size, used_classes, fully_used_cl
 
     result.append("")
     result.append("#include <godot_cpp/core/defs.hpp>")
+    result.append("#include <godot_cpp/core/math_defs.hpp>")
     result.append("")
 
     # Special cases.
@@ -2913,6 +2914,8 @@ def is_included(type_name, current_type):
 
 def correct_default_value(value, type_name):
     value_map = {
+        "inf": "Math::INF",
+        "nan": "Math::NaN",
         "null": "nullptr",
         '""': "String()",
         '&""': "StringName()",


### PR DESCRIPTION
The `bindings_generator.py` script in godot-cpp fails to handle default values of Infinity or NaN:

<img width="1370" height="176" alt="Screenshot 2026-07-25 143024" src="https://github.com/user-attachments/assets/9ebc504a-ad86-435c-9e1e-f9dcadf5dccd" />

Apparently Godot doesn't have either of these as default values in the normal engine, so the problem didn't occur before.

This PR adds a remapping to `Math::INF` and `Math::NaN`, which requires including the `math_defs.hpp` header: https://github.com/godotengine/godot-cpp/blob/master/include/godot_cpp/core/math_defs.hpp