### PR TITLE
Use a temp file for ARCOM to fix command line too long errors

### DIFF
--- a/tools/android.py
+++ b/tools/android.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import ar_tempfile
 import common_compiler_flags
 import my_spawn
 
@@ -111,6 +112,9 @@ def generate(env):
     env["STRIP"] = toolchain + "/bin/llvm-strip"
     env["RANLIB"] = toolchain + "/bin/llvm-ranlib"
     env["SHLIBSUFFIX"] = ".so"
+
+    # Configure ARCOM response file in case the command line call to AR is too long.
+    ar_tempfile.configure(env)
 
     env.Append(
         CCFLAGS=["--target=" + arch_info["target"] + env["android_api_level"], "-march=" + arch_info["march"], "-fPIC"]

--- a/tools/ar_tempfile.py
+++ b/tools/ar_tempfile.py
@@ -1,0 +1,29 @@
+import os
+import re
+
+# Backslashes that aren't escaping a quote or another backslash.
+WINPATHSEP_RE = re.compile(r"\\([^\"'\\]|$)")
+
+
+def tempfile_arg_esc_func(arg):
+    from SCons.Subst import quote_spaces
+
+    arg = quote_spaces(arg)
+    # GCC requires double Windows slashes, let's use UNIX separator
+    return WINPATHSEP_RE.sub(r"/\1", arg)
+
+
+# The generated bindings can produce enough object files to exceed the command
+# line length limit when creating the static library. This works around that by
+# writing the command to a response file. Refer to the engine equivalent in
+# https://github.com/godotengine/godot/blob/master/platform/windows/detect.py
+def configure(env):
+    if "ARCOM_ORIG" in env:
+        return  # Already configured, don't wrap ARCOM in TEMPFILE twice.
+
+    env["ARCOM_ORIG"] = env["ARCOM"]
+    # This is SCons lazy evaluation syntax, only switching to a file when the command is actually too long.
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
+    env["TEMPFILESUFFIX"] = ".rsp"
+    if os.name == "nt":
+        env["TEMPFILEARGESCFUNC"] = tempfile_arg_esc_func

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -52,4 +52,11 @@ def generate(env):
     if env["lto"] == "auto":
         env["lto"] = "full"
 
+    # The generated bindings can produce enough object files to exceed the
+    # Linux command-line length limit when linking the static library.
+    # This ARCOM stuff works around that by writing the command to a temporary file.
+    env["ARCOM_ORIG"] = env["ARCOM"]
+    # This is SCons lazy evaluation syntax, only switching to a file when the command is actually too long.
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
+
     common_compiler_flags.generate(env)

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -1,3 +1,4 @@
+import ar_tempfile
 import common_compiler_flags
 from SCons.Tool import clang, clangxx
 from SCons.Variables import BoolVariable
@@ -51,5 +52,8 @@ def generate(env):
     # Refer to https://github.com/godotengine/godot/blob/master/platform/linuxbsd/detect.py
     if env["lto"] == "auto":
         env["lto"] = "full"
+
+    # Configure ARCOM response file in case the command line call to AR is too long.
+    ar_tempfile.configure(env)
 
     common_compiler_flags.generate(env)

--- a/tools/my_spawn.py
+++ b/tools/my_spawn.py
@@ -33,20 +33,15 @@ def configure(env):
         return rv
 
     def mySpawn(sh, escape, cmd, args, env):
+        # Used by TEMPFILE, which spawns a "del" command to clean up the response file.
+        # See the equivalent code in the engine in `methods.py`.
+        if cmd == "del":
+            os.remove(args[1])
+            return 0
+
         newargs = " ".join(args[1:])
         cmdline = cmd + " " + newargs
 
-        rv = 0
-        if len(cmdline) > 32000 and cmd.endswith("ar"):
-            cmdline = cmd + " " + args[1] + " " + args[2] + " "
-            for i in range(3, len(args)):
-                rv = mySubProcess(cmdline + args[i], env)
-                if rv:
-                    break
-        else:
-            rv = mySubProcess(cmdline, env)
-
-        return rv
+        return mySubProcess(cmdline, env)
 
     env["SPAWN"] = mySpawn
-    env.Replace(ARFLAGS=["q"])

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import ar_tempfile
 import common_compiler_flags
 import my_spawn
 from SCons.Tool import mingw, msvc
@@ -150,8 +151,11 @@ def generate(env):
                 ]
             )
 
-        # Long line hack. Use custom spawn, quick AR append (to avoid files with the same names to override each other).
+        # Long line hack. Use custom spawn to work around the command line length limit.
         my_spawn.configure(env)
+
+        # Configure ARCOM response file in case the command line call to AR is too long.
+        ar_tempfile.configure(env)
 
     else:
         env["use_mingw"] = True
@@ -200,6 +204,9 @@ def generate(env):
 
         if sys.platform == "win32" or sys.platform == "msys":
             my_spawn.configure(env)
+
+        # Configure ARCOM response file in case the command line call to AR is too long.
+        ar_tempfile.configure(env)
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED"])
 


### PR DESCRIPTION
With [my Godot fork](https://github.com/godot-dimensions/godot), the added C++ modules are enough to push godot-cpp over the limit. The total length of all C++ files concatenated into the argument list is over 133 thousand bytes, which exceeds the 128 KiB limit of Linux argument lists:

<img width="1884" height="148" alt="Screenshot 2026-07-25 221339" src="https://github.com/user-attachments/assets/aeb16699-21d5-45eb-9d35-16a48a46f975" />

This PR fixes the problem on godot-cpp's side by adding `ARCOM`, which allows SCons to write the arguments to a file, and then pass that file to `ar`, rather than trying to put everything into command line arguments.

I have verified that this works, because I pointed the failing `dimensions-4.8` branch at `aaronfranke/godot-cpp` with branch `4.5-arcom-command-length`, and now the "Linux / Editor w/ Mono (target=editor)" CI job that includes godot-cpp succeeds: https://github.com/godot-dimensions/godot/actions/runs/30248252906/job/89922634667

Note that this isn't a godot-dimensions specific issue: the same problem would've occurred with Godot itself in a matter of years as the engine size grows over time. My godot-dimensions fork merely encountered the problem sooner.

This should be cherry-picked to past branches. The cherry-picking is beneficial to forks. ~~I have branches ready for this, here is the 4.5 branch:~~ https://github.com/aaronfranke/godot-cpp/tree/4.5-arcom-command-length EDIT: I will update this branch with this PR's updated contents soon.

Corresponding engine PR: https://github.com/godotengine/godot/pull/96407/changes

Supersedes https://github.com/godotengine/godot-cpp/pull/1731