### PR TITLE
Backport #1918: Fix multi-file dependency in generate_doc_source for 4.5 branch.

### DIFF
--- a/cmake/GodotCPPModule.cmake
+++ b/cmake/GodotCPPModule.cmake
@@ -166,7 +166,7 @@ function(target_doc_sources TARGET SOURCES)
 
     # Create the file generation target, this won't be triggered unless a target
     # that depends on DOC_SOURCE_FILE is built
-    generate_doc_source( "${DOC_SOURCE_FILE}" ${SOURCES} )
+    generate_doc_source( "${DOC_SOURCE_FILE}" "${SOURCES}" )
 
     # Add DOC_SOURCE_FILE as a dependency to TARGET
     target_sources(${TARGET} PRIVATE "${DOC_SOURCE_FILE}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(
 # conditionally add doc data to compile output
 if(GODOTCPP_TARGET MATCHES "editor|template_debug")
     file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/doc_classes/*.xml")
-    target_doc_sources( ${TARGET_NAME} ${DOC_XML} )
+    target_doc_sources( ${TARGET_NAME} "${DOC_XML}" )
 endif()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/project/bin/")


### PR DESCRIPTION
This is a backport of #1918 for the `4.5` branch.

It fixes an issue where multiple XML documentation source files were not properly handled as dependencies in `generate_doc_source` (due to quotes around `${SOURCES}` in `DEPENDS`), causing multi-file tracking and deletion detection to fail.

Linked PR: godotengine/godot-cpp#1918