### PR TITLE
Include missing defs.hpp header in template files

### DIFF
--- a/include/godot_cpp/templates/safe_refcount.hpp
+++ b/include/godot_cpp/templates/safe_refcount.hpp
@@ -33,6 +33,7 @@
 #if !defined(NO_THREADS)
 
 #include <atomic>
+#include <godot_cpp/core/defs.hpp>
 #include <type_traits>
 
 namespace godot {

--- a/include/godot_cpp/templates/spin_lock.hpp
+++ b/include/godot_cpp/templates/spin_lock.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <atomic>
+#include <godot_cpp/core/defs.hpp>
 
 namespace godot {
 


### PR DESCRIPTION
Just a small change, these two template files did not include `<godot_cpp/core/defs.hpp>` even though they both use macros defined in it. This led to errors being displayed in code editors when opening these files.