### PR TITLE
Add Link Time Optimization Parallelization Support

### DIFF
--- a/tools/common_compiler_flags.py
+++ b/tools/common_compiler_flags.py
@@ -84,8 +84,8 @@ def generate(env):
             env.Append(LINKFLAGS=["-flto=thin"])
         elif env["lto"] == "full":
             if env["use_llvm"]:
-                env.Append(CCFLAGS=["-flto"])
-                env.Append(LINKFLAGS=["-flto"])
+                env.Append(CCFLAGS=["-flto=auto"])
+                env.Append(LINKFLAGS=["-flto=auto"])
             else:
                 env.AppendUnique(CCFLAGS=["/GL"])
                 env.AppendUnique(ARFLAGS=["/LTCG"])
@@ -131,5 +131,5 @@ def generate(env):
             env.Append(CCFLAGS=["-flto=thin"])
             env.Append(LINKFLAGS=["-flto=thin"])
         elif env["lto"] == "full":
-            env.Append(CCFLAGS=["-flto"])
-            env.Append(LINKFLAGS=["-flto"])
+            env.Append(CCFLAGS=["-flto=auto"])
+            env.Append(LINKFLAGS=["-flto=auto"])


### PR DESCRIPTION
closes: #2002
This commit simply changes ```-flto``` flag to ```-flto=auto``` from GCC documentation.

"Use -flto=auto to use GNU make’s job server, if available, or otherwise fall back to autodetection of the number of CPU threads present in your system. "

Which speed ups builds by taking advantage of multiple threads. The option looks like it's backwards compatible with older compiler versions. As the change in the compiler mentioned in #2002 seems to have only  added a warning about serial compilation when ```-flto``` was used instead of changing what the ```-flto``` option did. So this shouldn't break any workflows
