### PR TITLE
Add hook file to generator dependency list

### DIFF
--- a/cmake/GodotCPPModule.cmake
+++ b/cmake/GodotCPPModule.cmake
@@ -117,7 +117,7 @@ function(
         VERBATIM
         WORKING_DIRECTORY ${godot-cpp_SOURCE_DIR}
         MAIN_DEPENDENCY ${GODOTCPP_GDEXTENSION_API_FILE}
-        DEPENDS ${godot-cpp_SOURCE_DIR}/binding_generator.py
+        DEPENDS ${godot-cpp_SOURCE_DIR}/binding_generator.py ${BINDING_HOOK_FILE}
         COMMENT "Generating bindings"
     )
     add_custom_target(generate_bindings DEPENDS ${GENERATED_FILES_LIST})


### PR DESCRIPTION
This should guarantee that when the hook file contents change, the files are regenerated on CMake and don't become stale across rebuilds.

FYI @Togira123

In addition to this, I do have one question. In our implementation what we opted to do was to have the hooks file act as a delegator/reader. In other words our project looks like this:

```
cmake/bindings/resource_loader.cpp
cmake/bindings/resource_loader.hpp
cmake/bindings/bindings_hook.py
src/<our plugin>
```

**resource_loader.hpp**
```cpp
#include <godot_cpp/core/version.hpp>

//~ Begin CustomBindings Interface
#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR < 8
String get_resource_type(const String &p_path);
#endif
//~ End CustomBindings Interface
```

**resource_loader.cpp**
```cpp
#include <godot_cpp/classes/resource.hpp>
#include <godot_cpp/core/version.hpp>

//~ Begin CustomBindings Implementation
#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR < 8
String ResourceLoader::get_resource_type(const String &p_path) {
	const Ref<Resource> resource = load(p_path, "", CACHE_MODE_IGNORE);
	if (resource.is_valid()) {
		return resource->get_class();
	}

	return String();
}
#endif
//~ End CustomBindings Implementation
```

The script knows how to parse these fragments and place the contents where it belongs.

Our CMAKE module watches for any changes to the contents in cmake/bindings/** and if a file changes, this enforces a similar situation to what you see here by adding the hook file as a dependency.

I do wonder whether it would make sense for there to be something like a `GODOTCPP_BINDING_HOOK_DIR` and here is where a user would place their python script and any other content, which would be treated as a _DEPENDS_ input here, and any content that changes in this directory enforces a regeneration pass. The other option is just a generic `GODOTCPP_BINDING_DEPENDS` where the extension supplies a list of files, which could include the python script and any other dependencies.

For now, we have to generate a SHA256 fingerprint on each file in the directory, and if there are changes, we remove the godot-cpp hpp/cpp files so they get regenerated, which seems like it would be naturally expected to work that way out of the box.