### PR TITLE
Always swap in generated move operator

### DIFF
--- a/binding_generator.py
+++ b/binding_generator.py
@@ -1511,12 +1511,7 @@ def generate_builtin_class_source(builtin_api, size, used_classes, fully_used_cl
 
     # Move assignment.
     result.append(f"{class_name} &{class_name}::operator=({class_name} &&p_other) {{")
-    if needs_copy_instead_of_move(class_name) and copy_constructor_index >= 0:
-        result.append(
-            f"\t::godot::internal::_call_builtin_constructor(_method_bindings.constructor_{copy_constructor_index}, &opaque, &p_other);"
-        )
-    else:
-        result.append("\tstd::swap(opaque, p_other.opaque);")
+    result.append("\tstd::swap(opaque, p_other.opaque);")
     result.append("\treturn *this;")
     result.append("}")
 


### PR DESCRIPTION
Currently, this is the code we generate for `Dictionary`'s move operator:

```c++
Dictionary &Dictionary::operator=(Dictionary &&p_other) {
	::godot::internal::_call_builtin_constructor(_method_bindings.constructor_1, &opaque, &p_other);
	return *this;
}
```

It's simply overwriting the `opaque` with data from a new `Dictionary`, without cleaning up the data from the old `Dictionary` (whereas the usual idiom is to swap the internal data with `p_other`, which will get cleaned up when `p_other` is destructed).

It looks like this comes from https://github.com/godotengine/godot-cpp/pull/656 - there was an issue where destructing `Dictionary`'s could lead to error spam, because of an `ERR_FAIL_NULL()` if a `Dictionary` is destructed with null data. (This code is still present in `Dictionary::unref()`.) This null could get set in the move constructor of `Dictionary` because it was swapping `opaque` value with a zero'd out one, so a fix was added to just copy rather than the usual swap.

However, it's only in the move constructor where a `Dictionary` could end up with null data, but the fix made the same change to move operator!

Anyway, this PR removes the fix from the move operator, while leaving it in place for the move constructor

I haven't tested yet, but I think this fixes https://github.com/godotengine/godot-cpp/issues/2048